### PR TITLE
172104057 fill in the blank

### DIFF
--- a/cypress/integration/fill-in-the-blank.test.js
+++ b/cypress/integration/fill-in-the-blank.test.js
@@ -1,0 +1,146 @@
+import { phonePost, phoneListen, getAndClearLastPhoneMessage } from "../support";
+
+context("Test fill in the blank interactive", () => {
+  beforeEach(() => {
+    cy.visit("/wrapper.html?iframe=/fill-in-the-blank");
+  });
+
+  context("Runtime view", () => {
+    it("renders prompt and handles pre-existing interactive state", () => {
+      phonePost("initInteractive", {
+        mode: "runtime",
+        authoredState: {
+          version: 1,
+          prompt: "Test prompt with [blank-1] and [blank-2]",
+          extraInstructions: "Hints",
+          blanks: [
+            {id: "[blank-1]", size: 10},
+            {id: "[blank-2]", size: 20},
+          ]
+        },
+        interactiveState: {
+          blanks: [
+            {id: "[blank-1]", response: "Test response"}
+          ]
+        }
+      });
+
+      cy.getIframeBody().find("#app").should("include.text", "Test prompt with ");
+      cy.getIframeBody().find("#app").should("include.text", "Hints");
+
+      cy.getIframeBody().find("input").eq(0).should("have.value", "Test response");
+      cy.getIframeBody().find("input").eq(1).should("have.value", "");
+    });
+
+    // This is separate from previous test to check dealing with initial, empty state.
+    it("sends back interactive state to parent", () => {
+      phonePost("initInteractive", {
+        mode: "runtime",
+        authoredState: {
+          version: 1,
+          prompt: "Test prompt with [blank-1] and [blank-2]",
+          extraInstructions: "Hints",
+          blanks: [
+            {id: "[blank-1]", size: 10},
+            {id: "[blank-2]", size: 20},
+          ]
+        }
+      });
+      phoneListen("interactiveState");
+
+      cy.getIframeBody().find("input").eq(0).type("Test response");
+      getAndClearLastPhoneMessage((state) => {
+        expect(state).eql({
+          blanks: [
+            {id: "[blank-1]", response: "Test response"}
+          ]
+        });
+      });
+    });
+  });
+
+  context("Authoring view", () => {
+    it("handles pre-existing authored state", () => {
+      phonePost("initInteractive", {
+        mode: "authoring",
+        authoredState: {
+          version: 1,
+          prompt: "Test prompt with [blank-1] and [blank-2]",
+          extraInstructions: "Hints",
+          blanks: [
+            {id: "[blank-1]", size: 10},
+            {id: "[blank-2]", size: 20, matchTerm: "test match term"},
+          ]
+        },
+      });
+
+      cy.getIframeBody().find("#app").should("include.text", "Prompt");
+      cy.getIframeBody().find("#app").should("include.text", "Extra instructions");
+      cy.getIframeBody().find("#app").should("include.text", "Blank field options");
+
+      cy.getIframeBody().find("#root_prompt").should("have.value", "Test prompt with [blank-1] and [blank-2]");
+      cy.getIframeBody().find("#root_extraInstructions").should("have.value", "Hints");
+
+      cy.getIframeBody().find("#root_blanks_0_id").should("have.value", "[blank-1]");
+      cy.getIframeBody().find("#root_blanks_0_id").should("have.attr", "readonly");
+      cy.getIframeBody().find("#root_blanks_0_size").should("have.value", "10");
+      cy.getIframeBody().find("#root_blanks_1_id").should("have.value", "[blank-2]");
+      cy.getIframeBody().find("#root_blanks_1_id").should("have.attr", "readonly");
+      cy.getIframeBody().find("#root_blanks_1_size").should("have.value", "20");
+      cy.getIframeBody().find("#root_blanks_1_matchTerm").should("have.value", "test match term");
+    });
+
+    it("renders authoring form and sends back authored state", () => {
+      phonePost("initInteractive", {
+        mode: "authoring"
+      });
+      phoneListen("authoredState");
+
+      cy.getIframeBody().find("#root_prompt").type("Test prompt with [blank-1]");
+      getAndClearLastPhoneMessage(state => {
+        expect(state.version).eql(1);
+        expect(state.prompt).eql("Test prompt with [blank-1]");
+        expect(state.blanks.length).eql(1);
+      });
+
+      cy.getIframeBody().find("#root_extraInstructions").type("Hints");
+      getAndClearLastPhoneMessage(state => {
+        expect(state.extraInstructions).eql("Hints");
+      });
+
+      cy.getIframeBody().find("#root_blanks_0_size").clear().type("15");
+      getAndClearLastPhoneMessage(state => {
+        expect(state.blanks[0].size).eql(15);
+      });
+    });
+  });
+
+  context("Report view", () => {
+    it("renders prompt and response and handles pre-existing interactive state, but doesn't let user change it", () => {
+      phonePost("initInteractive", {
+        mode: "report",
+        authoredState: {
+          version: 1,
+          prompt: "Test prompt with [blank-1] and [blank-2]",
+          extraInstructions: "Hints",
+          blanks: [
+            {id: "[blank-1]", size: 10},
+            {id: "[blank-2]", size: 20},
+          ]
+        },
+        interactiveState: {
+          blanks: [
+            {id: "[blank-1]", response: "Test response"}
+          ]
+        }
+      });
+
+      cy.getIframeBody().find("#app").should("include.text", "Test prompt with ");
+      cy.getIframeBody().find("#app").should("include.text", "Hints");
+
+      cy.getIframeBody().find("input").eq(0).should("have.value", "Test response");
+      cy.getIframeBody().find("input").eq(0).type("New answer", { force: true });
+      cy.getIframeBody().find("input").eq(0).should("have.value", "Test response");
+    });
+  });
+});

--- a/src/fill-in-the-blank/components/app.test.tsx
+++ b/src/fill-in-the-blank/components/app.test.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { mount, shallow } from "enzyme";
+import { App } from "./app";
+import { Runtime } from "./runtime";
+import { Authoring } from "./authoring";
+
+let mode: any;
+jest.mock("../../shared/hooks/use-lara-interactive-api", () => ({
+    useLARAInteractiveAPI: () => ({ mode })
+  })
+);
+
+describe("App", () => {
+  beforeEach(() => {
+    mode = undefined;
+  });
+
+  it("should render Runtime or Authoring component depending on the mode", () => {
+    mode = "runtime";
+    let wrapper = shallow(<App />);
+    expect(wrapper.find(Authoring).length).toEqual(0);
+    expect(wrapper.find(Runtime).length).toEqual(1);
+
+    mode = "authoring";
+    wrapper = shallow(<App />);
+    expect(wrapper.find(Authoring).length).toEqual(1);
+    expect(wrapper.find(Runtime).length).toEqual(0);
+
+    mode = "report";
+    wrapper = shallow(<App />);
+    expect(wrapper.find(Authoring).length).toEqual(0);
+    expect(wrapper.find(Runtime).length).toEqual(1);
+    expect(wrapper.find(Runtime).props().report).toEqual(true);
+  });
+
+  it("should listen to window resize event", () => {
+    const addSpy = jest.spyOn(window, "addEventListener");
+    const removeSpy = jest.spyOn(window, "removeEventListener");
+    const wrapper = mount(<App />);
+    expect(addSpy).toHaveBeenCalledWith("resize", expect.anything());
+    wrapper.unmount();
+    expect(removeSpy).toHaveBeenCalledWith("resize", expect.anything());
+  });
+});

--- a/src/fill-in-the-blank/components/app.tsx
+++ b/src/fill-in-the-blank/components/app.tsx
@@ -1,0 +1,23 @@
+import React, { useRef } from "react";
+import { useLARAInteractiveAPI } from "../../shared/hooks/use-lara-interactive-api";
+import { useAutoHeight } from "../../shared/hooks/use-auto-height";
+import { Authoring } from "./authoring";
+import { Runtime } from "./runtime";
+
+export const App = () => {
+  const container = useRef<HTMLDivElement>(null);
+  const { mode, authoredState, interactiveState, setInteractiveState, setAuthoredState, setHeight } = useLARAInteractiveAPI({
+    interactiveState: true,
+    authoredState: true,
+  });
+  useAutoHeight({ container, setHeight });
+
+  const report = mode === "report";
+  return (
+    <div ref={container}>
+      { mode === "authoring" && <Authoring authoredState={authoredState} setAuthoredState={setAuthoredState} /> }
+      { (mode === "runtime" || report) && <Runtime authoredState={authoredState} interactiveState={interactiveState} setInteractiveState={setInteractiveState} report={report}/> }
+      { mode === undefined && "Loading..." }
+    </div>
+  );
+};

--- a/src/fill-in-the-blank/components/authoring.test.tsx
+++ b/src/fill-in-the-blank/components/authoring.test.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { mount, shallow } from "enzyme";
+import { Authoring, IAuthoredState, defaultBlankSize, validate } from "./authoring";
+import Form, { FormValidation } from "react-jsonschema-form";
+
+const authoredState = {
+  version: 1,
+  prompt: "Test prompt with [blank-1] and [blank-2]",
+  extraInstructions: "Test extra instructions",
+  defaultAnswer: ""
+};
+
+describe("Authoring", () => {
+  it("renders react-jsonschema-form and passes there authoredState", () => {
+    const wrapper = shallow(<Authoring authoredState={authoredState} />);
+    const formEl = wrapper.find(Form);
+    expect(formEl.length).toEqual(1);
+    expect(formEl.props().formData).toEqual(authoredState);
+  });
+
+  it("calls setAuthoredState on form change and generates missing blank options", () => {
+    const setState = jest.fn();
+    const wrapper = mount(<Authoring authoredState={authoredState} setAuthoredState={setState} />);
+    const form = wrapper.find(Form).instance();
+    const newState: IAuthoredState = {
+      version: 1,
+      prompt: "New prompt with [blank-1] and [blank-2]",
+      extraInstructions: "Test instructions",
+      blanks: [
+        {id: "[blank-1]", size: 10}
+      ]
+    };
+    // Mocked form, see __mocks__ dir.
+    (form as any).triggerChange(newState);
+
+    expect(setState).toHaveBeenCalledWith({
+      version: 1,
+      prompt: "New prompt with [blank-1] and [blank-2]",
+      extraInstructions: "Test instructions",
+      blanks: [
+        {id: "[blank-1]", size: 10},
+        {id: "[blank-2]", size: defaultBlankSize}
+      ]
+    });
+  });
+});
+
+describe("validation helper", () => {
+  it("adds error when there are two blanks with the same ID", () => {
+    const errors = {
+      prompt: {
+        addError: jest.fn()
+      }
+    } as unknown as FormValidation;
+    validate({ version: 1, prompt: "test [blank-1], [blank-2], and [blank-3]"}, errors);
+    expect(errors.prompt.addError).not.toHaveBeenCalled();
+
+    validate({ version: 1, prompt: "test [blank-1], [blank-2], and [blank-1]"}, errors);
+    expect(errors.prompt.addError).toHaveBeenCalledWith("The same blank ID used multiple times: [blank-1]");
+  })
+});

--- a/src/fill-in-the-blank/components/authoring.tsx
+++ b/src/fill-in-the-blank/components/authoring.tsx
@@ -1,0 +1,166 @@
+import React, { useEffect, useRef } from "react";
+import Form, { IChangeEvent, FormValidation } from "react-jsonschema-form";
+import { JSONSchema6, JSONSchema7 } from "json-schema";
+
+import "../../shared/styles/boostrap-3.3.7.css"; // necessary to style react-jsonschema-form
+import css from "../../shared/styles/authoring.scss";
+import { useDelayedValidation } from "../../shared/hooks/use-delayed-validation";
+
+// Note that TS interfaces should match JSON schema. Currently there's no way to generate one from the other.
+// TS interfaces are not available in runtime in contrast to JSON schema.
+
+export const defaultBlankSize = 20; // characters
+const blankRegexp = /\[blank-\w+\]/g; // will match [blank-1], [blank-test], [blank-second_option] etc.
+
+export interface IBlankDef {
+  id: string;
+  size: number;
+  matchTerm?: string;
+}
+
+export interface IAuthoredState {
+  version: number;
+  prompt?: string;
+  extraInstructions?: string;
+  blanks?: IBlankDef[]
+}
+
+const schemaVersion = 1;
+const schema: JSONSchema7 = {
+  type: "object",
+  properties: {
+    version: {
+      type: "number",
+      default: schemaVersion
+    },
+    prompt: {
+      title: "Prompt. Provide sentence with one or more blanks specified with [blank-<ID>], for example [blank-1], [blank-test].",
+      type: "string"
+    },
+    extraInstructions: {
+      title: "Extra instructions",
+      type: "string"
+    },
+    blanks: {
+      type: "array",
+      title: "Blank field options",
+      items: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            title: "Blank ID",
+            readOnly: true
+          },
+          size: {
+            type: "number",
+            title: "Size (number of characters)"
+          },
+          matchTerm: {
+            type: "string",
+            title: "Match term"
+          }
+        }
+      }
+    }
+  }
+};
+
+const uiSchema = {
+  version: {
+    "ui:widget": "hidden"
+  },
+  prompt: {
+    "ui:widget": "textarea"
+  },
+  extraInstructions: {
+    "ui:widget": "textarea"
+  },
+  blanks: {
+    "ui:options":  {
+      orderable: false,
+      removable: false,
+      addable: false
+    }
+  }
+};
+
+interface IProps {
+  authoredState: IAuthoredState;
+  setAuthoredState?: (state: IAuthoredState) => void;
+}
+
+const noop = () => { /* noop */ };
+
+export const validate = (formData: IAuthoredState, errors: FormValidation) => {
+  if (formData.prompt) {
+    const sortedBlanks = (formData?.prompt?.match(blankRegexp) || []).sort();
+    for (let i = 0; i < sortedBlanks.length - 1; i++) {
+      if (sortedBlanks[i] === sortedBlanks[i + 1]) {
+        errors.prompt.addError(`The same blank ID used multiple times: ${sortedBlanks[i]}`);
+        return errors;
+      }
+    }
+  }
+  return errors;
+};
+
+const generateBlankOptions = (authoredState: IAuthoredState) => {
+  const blanks = authoredState?.prompt?.match(blankRegexp) || [];
+  const newAuthoredState = Object.assign({}, authoredState, { blanks: authoredState?.blanks?.slice() || [] });
+  // Check existing blank options and remove ones that are not necessary anymore.
+  authoredState.blanks?.forEach(blankOptions => {
+    if (!blanks.find(blankId => blankId === blankOptions.id)) {
+      // Existing blank options are not matching any keyword in the current prompt. Remove it.
+      const idx = newAuthoredState.blanks?.indexOf(blankOptions);
+      if (idx !== undefined && idx !== -1) {
+        newAuthoredState.blanks.splice(idx, 1);
+      }
+    }
+  });
+  // Add new blank options if necessary.
+  blanks.forEach(blankId => {
+    if (!newAuthoredState.blanks.find(blankOptions => blankOptions.id === blankId)) {
+      // New blank keyword found in the prompt. Add a new blank options object.
+      newAuthoredState.blanks.push({ id: blankId, size: defaultBlankSize });
+    }
+  });
+  return newAuthoredState;
+}
+
+export const Authoring: React.FC<IProps> = ({ authoredState, setAuthoredState }) => {
+  const formRef = useRef<Form<IAuthoredState>>(null);
+  const triggerDelayedValidation = useDelayedValidation({ formRef });
+
+  const onChange = (event: IChangeEvent<IAuthoredState>) => {
+    const newState = generateBlankOptions(event.formData);
+    // Immediately save the data.
+    if (setAuthoredState) {
+      setAuthoredState(newState);
+    }
+    triggerDelayedValidation();
+  };
+
+  useEffect(() => {
+    // Initial validation.
+    triggerDelayedValidation();
+  }, []);
+
+  return (
+    <div className={css.authoring}>
+      <Form
+        ref={formRef}
+        schema={schema as JSONSchema6}
+        uiSchema={uiSchema}
+        formData={authoredState}
+        onChange={onChange}
+        validate={validate}
+        onError={noop} // avoid console.error messages (default react-jsonschema-form error handler)
+      >
+        {/* Children are used to render custom action buttons. We don't want any, */}
+        {/* as form is saving and validating data live. */}
+        <span />
+      </Form>
+    </div>
+  );
+};

--- a/src/fill-in-the-blank/components/runtime.scss
+++ b/src/fill-in-the-blank/components/runtime.scss
@@ -1,0 +1,13 @@
+@import "../../shared/styles/helpers";
+
+.runtime {
+  @include lara-styles;
+}
+
+.correctAnswer {
+  color: $correctColor;
+}
+
+.incorrectAnswer {
+  color: $incorrectColor;
+}

--- a/src/fill-in-the-blank/components/runtime.test.tsx
+++ b/src/fill-in-the-blank/components/runtime.test.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { insertInputs, Runtime } from "./runtime";
+
+const authoredState = {
+  version: 1,
+  prompt: "Test prompt with [blank-1] and [blank-2].",
+  extraInstructions: "Test extra instructions",
+  blanks: [
+    {id: "[blank-1]", size: 10},
+    {id: "[blank-2]", size: 20, matchTerm: "Expected answer"}
+  ]
+};
+
+const interactiveState = {
+  blanks: [
+    {id: "[blank-1]", response: "Test response"}
+  ]
+};
+
+describe("Runtime", () => {
+  it("renders prompt, extra instructions and inputs", () => {
+    const wrapper = shallow(<Runtime authoredState={authoredState} />);
+    expect(wrapper.text()).toEqual(expect.stringContaining("Test prompt with "));
+    expect(wrapper.text()).toEqual(expect.stringContaining(authoredState.extraInstructions));
+    expect(wrapper.find("input").length).toEqual(2);
+    expect(wrapper.find("input").at(0).props().size).toEqual(10);
+    expect(wrapper.find("input").at(1).props().size).toEqual(20);
+  });
+
+  it("handles passed interactiveState", () => {
+    const wrapper = shallow(<Runtime authoredState={authoredState} interactiveState={interactiveState} />);
+    expect(wrapper.find("input").at(0).props().value).toEqual(interactiveState.blanks[0].response);
+    expect(wrapper.find("input").at(1).props().value).toEqual(undefined);
+  });
+
+  it("calls setInteractiveState when user provides an answer", () => {
+    const setState = jest.fn();
+    const wrapper = shallow(<Runtime authoredState={authoredState} interactiveState={interactiveState} setInteractiveState={setState} />);
+    wrapper.find("input").at(1).simulate("change", { target: { value: "New response" } });
+    expect(setState).toHaveBeenCalledWith({
+      blanks: [
+        {id: "[blank-1]", response: "Test response"},
+        {id: "[blank-2]", response: "New response"}
+      ]
+    });
+  });
+
+  describe("report mode", () => {
+    it("renders prompt, extra instructions and *disabled* inputs", () => {
+      const wrapper = shallow(<Runtime authoredState={authoredState} report={true} />);
+      expect(wrapper.text()).toEqual(expect.stringContaining("Test prompt with "));
+      expect(wrapper.text()).toEqual(expect.stringContaining(authoredState.extraInstructions));
+      expect(wrapper.find("input").length).toEqual(2);
+      expect(wrapper.find("input").at(0).props().disabled).toEqual(true);
+      expect(wrapper.find("input").at(1).props().disabled).toEqual(true);
+    });
+
+    it("handles passed interactiveState", () => {
+      const wrapper = shallow(<Runtime authoredState={authoredState} interactiveState={interactiveState} report={true} />);
+      expect(wrapper.find("input").at(0).props().value).toEqual(interactiveState.blanks[0].response);
+      expect(wrapper.find("input").at(1).props().value).toEqual(undefined);
+    });
+
+    it("never calls setInteractiveState when user selects an answer", () => {
+      const setState = jest.fn();
+      const wrapper = shallow(<Runtime authoredState={authoredState} interactiveState={interactiveState} setInteractiveState={setState} report={true} />);
+      wrapper.find("input").at(0).simulate("change", { target: { value: "diff answer" } });
+      wrapper.find("input").at(1).simulate("change", { target: { value: "diff answer" } });
+      expect(setState).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("insertInputs helper", () => {
+  it("returns array of strings and input field descriptions", () => {
+    const result = insertInputs(authoredState.prompt, authoredState.blanks, interactiveState.blanks);
+    expect(result).toEqual([
+      "Test prompt with ",
+      {id: "[blank-1]", size: 10, matchTerm: undefined, value: "Test response"},
+      " and ",
+      {id: "[blank-2]", size: 20, matchTerm: "Expected answer", value: undefined},
+      "."
+    ])
+  });
+});

--- a/src/fill-in-the-blank/components/runtime.tsx
+++ b/src/fill-in-the-blank/components/runtime.tsx
@@ -46,13 +46,6 @@ export const insertInputs = (prompt: string, blanks: IBlankDef[], userResponses:
   return result;
 };
 
-const getInputClass = (value?: string, matchTerm?: string) => {
-  if (!matchTerm) {
-    return undefined;
-  }
-  return value === matchTerm ? css.correctAnswer : css.incorrectAnswer;
-}
-
 export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, report }) => {
   const handleChange = (blankId: string, event: React.ChangeEvent<HTMLInputElement>) => {
     const newState = Object.assign({}, interactiveState, { blanks: interactiveState?.blanks?.slice() || [] });
@@ -69,6 +62,13 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     }
   };
 
+  const getInputClass = (value?: string, matchTerm?: string) => {
+    if (!report || !matchTerm) {
+      return undefined;
+    }
+    return value === matchTerm ? css.correctAnswer : css.incorrectAnswer;
+  }
+
   let content = [];
   try {
     content = insertInputs(authoredState.prompt || "", authoredState.blanks || [], interactiveState?.blanks || []);
@@ -84,7 +84,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
             return element;
           } else {
             return <input
-              className={report ? getInputClass(element.value, element.matchTerm) : undefined}
+              className={getInputClass(element.value, element.matchTerm)}
               type="text"
               key={element.id}
               value={element.value}

--- a/src/fill-in-the-blank/components/runtime.tsx
+++ b/src/fill-in-the-blank/components/runtime.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { IAuthoredState, IBlankDef } from "./authoring";
+import css from "./runtime.scss";
+
+interface IFilledBlank {
+  id: string;
+  response: string;
+}
+
+interface IInteractiveState {
+  blanks: IFilledBlank[];
+}
+
+interface IProps {
+  authoredState: IAuthoredState;
+  interactiveState?: IInteractiveState;
+  setInteractiveState?: (state: IInteractiveState) => void;
+  report?: boolean;
+}
+
+export const insertInputs = (prompt: string, blanks: IBlankDef[], userResponses: IFilledBlank[]) => {
+  if (blanks.length === 0) {
+    // Stop condition. No more blanks to test, return the current prompt.
+    return [ prompt ];
+  }
+  const blank = blanks[0];
+  const remainingBlanks = blanks.slice(1);
+
+  const result: (string | {id: string, value?: string, size?: number, matchTerm?: string})[] = [];
+  const dividedPrompt = prompt.split(blank.id);
+  if (dividedPrompt.length === 1) {
+    // Blank not found in this prompt part. Try other blanks.
+    result.push(...insertInputs(prompt, remainingBlanks, userResponses));
+  }
+  if (dividedPrompt.length === 2) {
+    // Blank found in this prompt part.
+    result.push(...insertInputs(dividedPrompt[0], remainingBlanks, userResponses));
+    const response = userResponses.find(ur => ur.id === blank.id)?.response;
+    result.push({id: blank.id, value: response, size: blank.size, matchTerm: blank.matchTerm });
+    result.push(...insertInputs(dividedPrompt[1], remainingBlanks, userResponses));
+  }
+  if (dividedPrompt.length > 2) {
+    // Multiple blanks with the same ID found, incorrect state.
+    throw new Error("Invalid authored state: multiple blanks with the same ID.");
+  }
+  return result;
+};
+
+const getInputClass = (value?: string, matchTerm?: string) => {
+  if (!matchTerm) {
+    return undefined;
+  }
+  return value === matchTerm ? css.correctAnswer : css.incorrectAnswer;
+}
+
+export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, report }) => {
+  const handleChange = (blankId: string, event: React.ChangeEvent<HTMLInputElement>) => {
+    const newState = Object.assign({}, interactiveState, { blanks: interactiveState?.blanks?.slice() || [] });
+    const newResponse = {id: blankId, response: event.target.value };
+    const existingResponse = newState.blanks.find(b => b.id === blankId);
+    if (existingResponse) {
+      const idx = newState.blanks.indexOf(existingResponse);
+      newState.blanks.splice(idx, 1, newResponse);
+    } else {
+      newState.blanks.push(newResponse);
+    }
+    if (setInteractiveState) {
+      setInteractiveState(newState);
+    }
+  };
+
+  let content = [];
+  try {
+    content = insertInputs(authoredState.prompt || "", authoredState.blanks || [], interactiveState?.blanks || []);
+  } catch (e) {
+    return e.message;
+  }
+
+  return (
+    <div className={css.runtime}>
+      {
+        content.map(element => {
+          if (typeof element === "string") {
+            return element;
+          } else {
+            return <input
+              className={report ? getInputClass(element.value, element.matchTerm) : undefined}
+              type="text"
+              key={element.id}
+              value={element.value}
+              size={element.size}
+              onChange={report ? undefined : handleChange.bind(null, element.id)}
+              readOnly={report}
+              disabled={report}
+            />
+          }
+        })
+      }
+      {
+        authoredState.extraInstructions &&
+        <div className={css.extraInstructions}>{ authoredState.extraInstructions }</div>
+      }
+    </div>
+  );
+};

--- a/src/fill-in-the-blank/index.tsx
+++ b/src/fill-in-the-blank/index.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { App } from "./components/app";
+
+ReactDOM.render(
+  <App />,
+  document.getElementById("app")
+);

--- a/src/multiple-choice/components/runtime.scss
+++ b/src/multiple-choice/components/runtime.scss
@@ -4,17 +4,10 @@
   @include lara-styles;
 }
 
-.extraInstructions {
-  margin-top: 10px;
-  background: #f5f5f5;
-  padding: 5px;
-  font-size: 0.9em;
-}
-
 .correctChoice {
-  color: #055c05;
+  color: $correctColor;
 }
 
 .incorrectChoice {
-  color: #930606;
+  color: $incorrectColor;
 }

--- a/src/multiple-choice/components/runtime.tsx
+++ b/src/multiple-choice/components/runtime.tsx
@@ -69,7 +69,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
           authoredState.choices && authoredState.choices.map(choice => {
             const checked = selectedChoiceIds.indexOf(choice.id) !== -1;
             return (
-              <div key={choice.id} className={report && getChoiceClass(choice, questionScored, checked)}>
+              <div key={choice.id} className={report ? getChoiceClass(choice, questionScored, checked) : undefined}>
                 <input
                   type={type}
                   value={choice.id}

--- a/src/multiple-choice/components/runtime.tsx
+++ b/src/multiple-choice/components/runtime.tsx
@@ -13,19 +13,6 @@ interface IProps {
   report?: boolean;
 }
 
-const getChoiceClass = (choice: IChoice, questionScored: boolean, checked: boolean) => {
-  if (!questionScored) {
-    return undefined;
-  }
-  if (checked && choice.correct) {
-    return css.correctChoice;
-  }
-  if (!checked && choice.correct) {
-    // User didn't check correct answer. Mark it.
-    return css.incorrectChoice;
-  }
-};
-
 export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, report }) => {
   const type = authoredState.multipleAnswers ? "checkbox" : "radio";
   let selectedChoiceIds = interactiveState?.selectedChoiceIds || [];
@@ -58,8 +45,23 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     }
   };
 
-  // Question is scored if it has at least one correct answer defined.
-  const questionScored = !!authoredState.choices && authoredState.choices.filter(c => c.correct).length > 0;
+  const getChoiceClass = (choice: IChoice, checked: boolean) => {
+    if (!report) {
+      return undefined;
+    }
+    // Question is scored if it has at least one correct answer defined.
+    const questionScored = !!authoredState.choices && authoredState.choices.filter(c => c.correct).length > 0;
+    if (!questionScored) {
+      return undefined;
+    }
+    if (checked && choice.correct) {
+      return css.correctChoice;
+    }
+    if (!checked && choice.correct) {
+      // User didn't check correct answer. Mark it.
+      return css.incorrectChoice;
+    }
+  };
 
   return (
     <div className={css.runtime}>
@@ -69,7 +71,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
           authoredState.choices && authoredState.choices.map(choice => {
             const checked = selectedChoiceIds.indexOf(choice.id) !== -1;
             return (
-              <div key={choice.id} className={report ? getChoiceClass(choice, questionScored, checked) : undefined}>
+              <div key={choice.id} className={getChoiceClass(choice, checked)}>
                 <input
                   type={type}
                   value={choice.id}

--- a/src/open-response/components/runtime.scss
+++ b/src/open-response/components/runtime.scss
@@ -10,10 +10,3 @@
     padding: 16px;
   }
 }
-
-.extraInstructions {
-  margin-top: 10px;
-  background: #f5f5f5;
-  padding: 5px;
-  font-size: 0.9em;
-}

--- a/src/shared/hooks/use-delayed-validation.test.ts
+++ b/src/shared/hooks/use-delayed-validation.test.ts
@@ -3,7 +3,7 @@ import { renderHook, act } from "@testing-library/react-hooks";
 import { useDelayedValidation } from "./use-delayed-validation";
 import Form from "react-jsonschema-form";
 
-describe("useAutoHeight", () => {
+describe("useDelayedValidation", () => {
   it("should call clearTimeout and setTimeout when trigger is called", () => {
     const clearSpy = jest.spyOn(window, "clearTimeout");
     const setSpy = jest.spyOn(window, "setTimeout");

--- a/src/shared/hooks/use-delayed-validation.test.ts
+++ b/src/shared/hooks/use-delayed-validation.test.ts
@@ -1,0 +1,21 @@
+import React, { useRef } from "react";
+import { renderHook, act } from "@testing-library/react-hooks";
+import { useDelayedValidation } from "./use-delayed-validation";
+import Form from "react-jsonschema-form";
+
+describe("useAutoHeight", () => {
+  it("should call clearTimeout and setTimeout when trigger is called", () => {
+    const clearSpy = jest.spyOn(window, "clearTimeout");
+    const setSpy = jest.spyOn(window, "setTimeout");
+    const HookWrapper = () => {
+      const formRef = useRef<Form<any>>(null);
+      return useDelayedValidation({ formRef, delay: 123 });
+    }
+    const { result } = renderHook(HookWrapper);
+    act(() => {
+      result.current();
+    });
+    expect(clearSpy).toHaveBeenCalled();
+    expect(setSpy).toHaveBeenCalledWith(expect.anything(), 123);
+  });
+});

--- a/src/shared/hooks/use-delayed-validation.ts
+++ b/src/shared/hooks/use-delayed-validation.ts
@@ -1,0 +1,20 @@
+import { RefObject, useRef } from "react";
+import Form from "react-jsonschema-form";
+
+interface IConfig {
+  formRef: RefObject<Form<any>>;
+  delay?: number; // ms
+}
+
+const defaultDelay = 500; // ms
+
+// Note that this will actually trigger submit(), as that's the way to trigger validation.
+// Our form don't have submit buttons and don't set onSubmit handlers, so it should be fine.
+export const useDelayedValidation = (config: IConfig) => {
+  const timer = useRef<number>();
+
+  return () => {
+    window.clearTimeout(timer.current);
+    timer.current = window.setTimeout(() => config.formRef.current?.submit(), config.delay || defaultDelay);
+  };
+}

--- a/src/shared/styles/helpers.scss
+++ b/src/shared/styles/helpers.scss
@@ -9,3 +9,13 @@
     margin-right: 10px;
   }
 }
+
+$correctColor: #055c05;
+$incorrectColor: #930606;
+
+.extraInstructions {
+  margin-top: 10px;
+  background: #f5f5f5;
+  padding: 5px;
+  font-size: 0.9em;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = (env, argv) => {
     entry: {
       'multiple-choice': './src/multiple-choice/index.tsx',
       'open-response': './src/open-response/index.tsx',
+      'fill-in-the-blank': './src/fill-in-the-blank/index.tsx',
       'wrapper': './src/shared/wrapper.tsx'
     },
     mode: 'development',
@@ -91,6 +92,11 @@ module.exports = (env, argv) => {
       new HtmlWebpackPlugin({
         chunks: ['open-response'],
         filename: 'open-response/index.html',
+        template: 'src/shared/index.html'
+      }),
+      new HtmlWebpackPlugin({
+        chunks: ['fill-in-the-blank'],
+        filename: 'fill-in-the-blank/index.html',
         template: 'src/shared/index.html'
       }),
       // Wrapper page, useful for testing and Cypress.


### PR DESCRIPTION
This PR adds fill in the blank. Authoring isn't based only on keywords parsing, we're adding dynamically new input fields when needed. 

Once the question is authored, the runtime doesn't depend on the current keyword regexp. So, we can later change [blank-<ID>] to whatever string we want and it shouldn't break old questions.

I might extract authoring component to something like BaseAuthoring later, as it seems all the questions so far are fine with default React-JSONSchema-Form + optional state processing (to generate choice IDs or blank fields options).

Authoring demo:
https://authoring.staging.concord.org/activities/20643/pages/307426/edit
Runtime demo:
https://authoring.staging.concord.org/activities/20643/pages/307426
LARA student reporting (summary) seems to be broken when there's managed interactive that saves state, so can't show report for now.