### PR TITLE
Add useRequiredQuestion hook and use it in all the question types

### DIFF
--- a/src/fill-in-the-blank/components/app.test.tsx
+++ b/src/fill-in-the-blank/components/app.test.tsx
@@ -6,7 +6,7 @@ import { Authoring } from "./authoring";
 
 let mode: any;
 jest.mock("../../shared/hooks/use-lara-interactive-api", () => ({
-    useLARAInteractiveAPI: () => ({ mode })
+    useLARAInteractiveAPI: () => ({ mode, authoredState: {} })
   })
 );
 

--- a/src/fill-in-the-blank/components/app.tsx
+++ b/src/fill-in-the-blank/components/app.tsx
@@ -1,22 +1,24 @@
 import React, { useRef } from "react";
 import { useLARAInteractiveAPI } from "../../shared/hooks/use-lara-interactive-api";
 import { useAutoHeight } from "../../shared/hooks/use-auto-height";
-import { Authoring } from "./authoring";
-import { Runtime } from "./runtime";
+import { Authoring, IAuthoredState } from "./authoring";
+import { IInteractiveState, Runtime } from "./runtime";
 
 export const App = () => {
   const container = useRef<HTMLDivElement>(null);
-  const { mode, authoredState, interactiveState, setInteractiveState, setAuthoredState, setHeight } = useLARAInteractiveAPI({
+  const { mode, authoredState, interactiveState, setInteractiveState, setAuthoredState, setHeight, setNavigation } = useLARAInteractiveAPI<IAuthoredState, IInteractiveState>({
     interactiveState: true,
     authoredState: true,
   });
   useAutoHeight({ container, setHeight });
 
   const report = mode === "report";
+  const authoring = mode === "authoring";
+  const runtime = mode === "runtime";
   return (
     <div ref={container}>
-      { mode === "authoring" && <Authoring authoredState={authoredState} setAuthoredState={setAuthoredState} /> }
-      { (mode === "runtime" || report) && <Runtime authoredState={authoredState} interactiveState={interactiveState} setInteractiveState={setInteractiveState} report={report}/> }
+      { authoring && <Authoring authoredState={authoredState} setAuthoredState={setAuthoredState} /> }
+      { (runtime || report) && authoredState && <Runtime authoredState={authoredState} interactiveState={interactiveState} setInteractiveState={setInteractiveState} report={report} setNavigation={setNavigation} /> }
       { mode === undefined && "Loading..." }
     </div>
   );

--- a/src/fill-in-the-blank/components/authoring.tsx
+++ b/src/fill-in-the-blank/components/authoring.tsx
@@ -22,7 +22,8 @@ export interface IAuthoredState {
   version: number;
   prompt?: string;
   extraInstructions?: string;
-  blanks?: IBlankDef[]
+  blanks?: IBlankDef[];
+  required?: boolean;
 }
 
 const schemaVersion = 1;
@@ -36,6 +37,10 @@ const schema: JSONSchema7 = {
     prompt: {
       title: "Prompt. Provide sentence with one or more blanks specified with [blank-<ID>], for example [blank-1], [blank-test].",
       type: "string"
+    },
+    required: {
+      title: "Required",
+      type: "boolean"
     },
     extraInstructions: {
       title: "Extra instructions",
@@ -86,7 +91,7 @@ const uiSchema = {
 };
 
 interface IProps {
-  authoredState: IAuthoredState;
+  authoredState: IAuthoredState | undefined;
   setAuthoredState?: (state: IAuthoredState) => void;
 }
 

--- a/src/fill-in-the-blank/components/runtime.tsx
+++ b/src/fill-in-the-blank/components/runtime.tsx
@@ -82,7 +82,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     return e.message;
   }
 
-  const readOnly = report || interactiveState?.submitted;
+  const readOnly = report || (authoredState.required && interactiveState?.submitted);
 
   return (
     <div className={css.runtime}>

--- a/src/fill-in-the-blank/components/runtime.tsx
+++ b/src/fill-in-the-blank/components/runtime.tsx
@@ -50,8 +50,8 @@ export const insertInputs = (prompt: string, blanks: IBlankDef[], userResponses:
 };
 
 export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, setNavigation, report }) => {
-  const submitEnabled = (interactiveState?.blanks || []).length > 0;
-  const { submitButton, lockedInfo } = useRequiredQuestion({ authoredState, interactiveState, setInteractiveState, setNavigation, submitEnabled });
+  const isAnswered = (interactiveState?.blanks || []).length > 0;
+  const { submitButton, lockedInfo } = useRequiredQuestion({ authoredState, interactiveState, setInteractiveState, setNavigation, isAnswered });
 
   const handleChange = (blankId: string, event: React.ChangeEvent<HTMLInputElement>) => {
     const newState = Object.assign({}, interactiveState, { blanks: interactiveState?.blanks?.slice() || [] });

--- a/src/multiple-choice/components/app.test.tsx
+++ b/src/multiple-choice/components/app.test.tsx
@@ -6,7 +6,7 @@ import { Authoring } from "./authoring";
 
 let mode: any;
 jest.mock("../../shared/hooks/use-lara-interactive-api", () => ({
-    useLARAInteractiveAPI: () => ({ mode })
+    useLARAInteractiveAPI: () => ({ mode, authoredState: {} })
   })
 );
 

--- a/src/multiple-choice/components/app.tsx
+++ b/src/multiple-choice/components/app.tsx
@@ -1,22 +1,24 @@
 import React, { useRef } from "react";
 import { useLARAInteractiveAPI } from "../../shared/hooks/use-lara-interactive-api";
 import { useAutoHeight } from "../../shared/hooks/use-auto-height";
-import { Authoring } from "./authoring";
-import { Runtime } from "./runtime";
+import { Authoring, IAuthoredState } from "./authoring";
+import { IInteractiveState, Runtime } from "./runtime";
 
 export const App = () => {
   const container = useRef<HTMLDivElement>(null);
-  const { mode, authoredState, interactiveState, setInteractiveState, setAuthoredState, setHeight } = useLARAInteractiveAPI({
+  const { mode, authoredState, interactiveState, setInteractiveState, setAuthoredState, setHeight, setNavigation } = useLARAInteractiveAPI<IAuthoredState, IInteractiveState>({
     interactiveState: true,
     authoredState: true,
   });
   useAutoHeight({ container, setHeight });
 
   const report = mode === "report";
+  const authoring = mode === "authoring";
+  const runtime = mode === "runtime";
   return (
     <div ref={container}>
-      { mode === "authoring" && <Authoring authoredState={authoredState} setAuthoredState={setAuthoredState} /> }
-      { (mode === "runtime" || report) && <Runtime authoredState={authoredState} interactiveState={interactiveState} setInteractiveState={setInteractiveState} report={report}/> }
+      { authoring && <Authoring authoredState={authoredState} setAuthoredState={setAuthoredState} /> }
+      { (runtime || report) && authoredState && <Runtime authoredState={authoredState} interactiveState={interactiveState} setInteractiveState={setInteractiveState} report={report} setNavigation={setNavigation} /> }
       { mode === undefined && "Loading..." }
     </div>
   );

--- a/src/multiple-choice/components/authoring.tsx
+++ b/src/multiple-choice/components/authoring.tsx
@@ -18,6 +18,7 @@ export interface IChoice {
 export interface IAuthoredState {
   version: number;
   prompt?: string;
+  required?: boolean;
   extraInstructions?: string;
   multipleAnswers?: boolean;
   choices?: IChoice[];
@@ -34,6 +35,10 @@ const schema: JSONSchema6 = {
     prompt: {
       title: "Prompt",
       type: "string"
+    },
+    required: {
+      title: "Required",
+      type: "boolean"
     },
     extraInstructions: {
       title: "Extra instructions",

--- a/src/multiple-choice/components/runtime.tsx
+++ b/src/multiple-choice/components/runtime.tsx
@@ -69,7 +69,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     }
   };
 
-  const readOnly = report || interactiveState?.submitted;
+  const readOnly = report || (authoredState.required && interactiveState?.submitted);
 
   return (
     <div className={css.runtime}>

--- a/src/multiple-choice/components/runtime.tsx
+++ b/src/multiple-choice/components/runtime.tsx
@@ -26,8 +26,8 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     selectedChoiceIds = [];
   }
 
-  const submitEnabled = selectedChoiceIds.length > 0;
-  const { submitButton, lockedInfo } = useRequiredQuestion({ authoredState, interactiveState, setInteractiveState, setNavigation, submitEnabled });
+  const isAnswered = selectedChoiceIds.length > 0;
+  const { submitButton, lockedInfo } = useRequiredQuestion({ authoredState, interactiveState, setInteractiveState, setNavigation, isAnswered });
 
   const handleChange = (choiceId: string, event: React.ChangeEvent<HTMLInputElement>) => {
     const checked = event.target.checked;

--- a/src/open-response/components/app.test.tsx
+++ b/src/open-response/components/app.test.tsx
@@ -6,7 +6,7 @@ import { Authoring } from "./authoring";
 
 let mode: any;
 jest.mock("../../shared/hooks/use-lara-interactive-api", () => ({
-    useLARAInteractiveAPI: () => ({ mode })
+    useLARAInteractiveAPI: () => ({ mode, authoredState: {} })
   })
 );
 

--- a/src/open-response/components/app.tsx
+++ b/src/open-response/components/app.tsx
@@ -1,22 +1,24 @@
 import React, { useRef } from "react";
 import { useLARAInteractiveAPI } from "../../shared/hooks/use-lara-interactive-api";
 import { useAutoHeight } from "../../shared/hooks/use-auto-height";
-import { Authoring } from "./authoring";
-import { Runtime } from "./runtime";
+import { Authoring, IAuthoredState } from "./authoring";
+import { IInteractiveState, Runtime } from "./runtime";
 
 export const App = () => {
   const container = useRef<HTMLDivElement>(null);
-  const { mode, authoredState, interactiveState, setInteractiveState, setAuthoredState, setHeight } = useLARAInteractiveAPI({
+  const { mode, authoredState, interactiveState, setInteractiveState, setAuthoredState, setHeight, setNavigation } = useLARAInteractiveAPI<IAuthoredState, IInteractiveState>({
     interactiveState: true,
     authoredState: true,
   });
   useAutoHeight({ container, setHeight });
 
   const report = mode === "report";
+  const authoring = mode === "authoring";
+  const runtime = mode === "runtime";
   return (
     <div ref={container}>
-      { mode === "authoring" && <Authoring authoredState={authoredState} setAuthoredState={setAuthoredState} /> }
-      { (mode === "runtime" || report) && <Runtime authoredState={authoredState} interactiveState={interactiveState} setInteractiveState={setInteractiveState} report={report}/> }
+      { authoring && <Authoring authoredState={authoredState} setAuthoredState={setAuthoredState} /> }
+      { (runtime || report) && authoredState && <Runtime authoredState={authoredState} interactiveState={interactiveState} setInteractiveState={setInteractiveState} report={report} setNavigation={setNavigation}/> }
       { mode === undefined && "Loading..." }
     </div>
   );

--- a/src/open-response/components/authoring.tsx
+++ b/src/open-response/components/authoring.tsx
@@ -13,6 +13,7 @@ export interface IAuthoredState {
   prompt?: string;
   extraInstructions?: string;
   defaultAnswer?: string;
+  required?: boolean;
 }
 
 const schemaVersion = 1;
@@ -26,6 +27,10 @@ const schema: JSONSchema6 = {
     prompt: {
       title: "Prompt",
       type: "string"
+    },
+    required: {
+      title: "Required",
+      type: "boolean"
     },
     extraInstructions: {
       title: "Extra instructions",
@@ -54,7 +59,7 @@ const uiSchema = {
 };
 
 interface IProps {
-  authoredState: IAuthoredState;
+  authoredState: IAuthoredState | undefined;
   setAuthoredState?: (state: IAuthoredState) => void;
 }
 

--- a/src/open-response/components/runtime.tsx
+++ b/src/open-response/components/runtime.tsx
@@ -20,7 +20,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   const submitEnabled = !!interactiveState?.response;
   const { submitButton, lockedInfo } = useRequiredQuestion({ authoredState, interactiveState, setInteractiveState, setNavigation, submitEnabled });
 
-  const readOnly = report || interactiveState?.submitted;
+  const readOnly = report || (authoredState.required && interactiveState?.submitted);
 
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     if (setInteractiveState) {

--- a/src/open-response/components/runtime.tsx
+++ b/src/open-response/components/runtime.tsx
@@ -17,8 +17,8 @@ interface IProps {
 }
 
 export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, setNavigation, report }) => {
-  const submitEnabled = !!interactiveState?.response;
-  const { submitButton, lockedInfo } = useRequiredQuestion({ authoredState, interactiveState, setInteractiveState, setNavigation, submitEnabled });
+  const isAnswered = !!interactiveState?.response;
+  const { submitButton, lockedInfo } = useRequiredQuestion({ authoredState, interactiveState, setInteractiveState, setNavigation, isAnswered });
 
   const readOnly = report || (authoredState.required && interactiveState?.submitted);
 

--- a/src/open-response/components/runtime.tsx
+++ b/src/open-response/components/runtime.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { IAuthoredState } from "./authoring";
 import css from "./runtime.scss";
+import { useRequiredQuestion } from "../../shared/hooks/use-required-question";
 
-interface IInteractiveState {
+export interface IInteractiveState {
   response: string;
+  submitted?: boolean;
 }
 
 interface IProps {
@@ -11,9 +13,15 @@ interface IProps {
   interactiveState?: IInteractiveState;
   setInteractiveState?: (state: IInteractiveState) => void;
   report?: boolean;
+  setNavigation?: (enableForwardNav: boolean, message: string) => void;
 }
 
-export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, report }) => {
+export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, setNavigation, report }) => {
+  const submitEnabled = !!interactiveState?.response;
+  const { submitButton, lockedInfo } = useRequiredQuestion({ authoredState, interactiveState, setInteractiveState, setNavigation, submitEnabled });
+
+  const readOnly = report || interactiveState?.submitted;
+
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     if (setInteractiveState) {
       setInteractiveState(Object.assign({}, interactiveState, { response: event.target.value }));
@@ -26,9 +34,9 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
       <div>
         <textarea
           value={interactiveState?.response}
-          onChange={report ? undefined : handleChange}
-          readOnly={report}
-          disabled={report}
+          onChange={readOnly ? undefined : handleChange}
+          readOnly={readOnly}
+          disabled={readOnly}
           rows={8}
           placeholder={authoredState.defaultAnswer || "Type answer here"}
         />
@@ -36,6 +44,13 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
       {
         authoredState.extraInstructions &&
         <div className={css.extraInstructions}>{ authoredState.extraInstructions }</div>
+      }
+      {
+        !report &&
+        <div>
+          { submitButton }
+          { lockedInfo }
+        </div>
       }
     </div>
   );

--- a/src/scaffolded-question/components/app.test.tsx
+++ b/src/scaffolded-question/components/app.test.tsx
@@ -6,7 +6,7 @@ import { Authoring } from "./authoring";
 
 let mode: any;
 jest.mock("../../shared/hooks/use-lara-interactive-api", () => ({
-    useLARAInteractiveAPI: () => ({ mode })
+    useLARAInteractiveAPI: () => ({ mode, authoredState: {} })
   })
 );
 

--- a/src/scaffolded-question/components/app.tsx
+++ b/src/scaffolded-question/components/app.tsx
@@ -1,22 +1,24 @@
 import React, { useRef } from "react";
 import { useLARAInteractiveAPI } from "../../shared/hooks/use-lara-interactive-api";
 import { useAutoHeight } from "../../shared/hooks/use-auto-height";
-import { Authoring } from "./authoring";
-import { Runtime } from "./runtime";
+import { Authoring, IAuthoredState } from "./authoring";
+import { IInteractiveState, Runtime } from "./runtime";
 
 export const App = () => {
   const container = useRef<HTMLDivElement>(null);
-  const { mode, authoredState, interactiveState, setInteractiveState, setAuthoredState, setHeight } = useLARAInteractiveAPI({
+  const { mode, authoredState, interactiveState, setInteractiveState, setAuthoredState, setHeight, setNavigation } = useLARAInteractiveAPI<IAuthoredState, IInteractiveState>({
     interactiveState: true,
     authoredState: true,
   });
   useAutoHeight({ container, setHeight });
 
   const report = mode === "report";
+  const authoring = mode === "authoring";
+  const runtime = mode === "runtime";
   return (
     <div ref={container}>
-      { mode === "authoring" && <Authoring authoredState={authoredState} setAuthoredState={setAuthoredState} /> }
-      { (mode === "runtime" || report) && <Runtime authoredState={authoredState} interactiveState={interactiveState} setInteractiveState={setInteractiveState} report={report}/> }
+      { authoring && <Authoring authoredState={authoredState} setAuthoredState={setAuthoredState} /> }
+      { (runtime || report) && authoredState && <Runtime authoredState={authoredState} interactiveState={interactiveState} setInteractiveState={setInteractiveState} report={report} setNavigation={setNavigation}/> }
       { mode === undefined && "Loading..." }
     </div>
   );

--- a/src/scaffolded-question/components/authoring.tsx
+++ b/src/scaffolded-question/components/authoring.tsx
@@ -13,6 +13,7 @@ import { v4 as uuidv4 } from "uuid";
 export interface IAuthoredState {
   version: number;
   prompt?: string;
+  required?: boolean;
   extraInstructions?: string;
   subinteractives: {
     id: string;
@@ -32,6 +33,10 @@ const schema: JSONSchema6 = {
     prompt: {
       title: "Prompt",
       type: "string"
+    },
+    required: {
+      title: "Required",
+      type: "boolean"
     },
     extraInstructions: {
       title: "Extra instructions",
@@ -76,7 +81,7 @@ const uiSchema = {
 };
 
 interface IProps {
-  authoredState: IAuthoredState;
+  authoredState?: IAuthoredState;
   setAuthoredState?: (state: IAuthoredState) => void;
 }
 
@@ -85,7 +90,7 @@ export const Authoring: React.FC<IProps> = ({ authoredState, setAuthoredState })
     const formData = event.formData as IAuthoredState;
     // Generate interactive ID if necessary.
     formData.subinteractives?.forEach(int => {
-      if (int.id === undefined) {
+      if (!int.id) {
         int.id = uuidv4();
       }
     });

--- a/src/scaffolded-question/components/runtime.tsx
+++ b/src/scaffolded-question/components/runtime.tsx
@@ -1,11 +1,10 @@
 import React from "react";
 import { IAuthoredState } from "./authoring";
 import { IframeRuntime } from "./iframe-runtime";
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faLock } from '@fortawesome/free-solid-svg-icons'
 import css from "./runtime.scss";
+import { useRequiredQuestion } from "../../shared/hooks/use-required-question";
 
-interface IInteractiveState {
+export interface IInteractiveState {
   subinteractiveStates: {
     [id: string]: any;
   },
@@ -18,9 +17,10 @@ interface IProps {
   interactiveState?: IInteractiveState;
   setInteractiveState?: (state: IInteractiveState) => void;
   report?: boolean;
+  setNavigation?: (enableForwardNav: boolean, message: string) => void;
 }
 
-export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, report }) => {
+export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, setNavigation, report }) => {
   const currentSubintId = interactiveState?.currentSubinteractiveId;
   let currentInteractive = authoredState.subinteractives.find(si => si.id === currentSubintId);
   if (!currentInteractive) {
@@ -36,9 +36,11 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   const hintAvailable = !submitted && (currentSubintIndex < authoredState.subinteractives.length - 1);
 
   // User can submit answer only if any answer has been provided before.
-  const submitAvailable = !submitted && !!subState;
+  const submitEnabled = !!subState;
 
   const reportOrSubmitted = report || interactiveState?.submitted;
+
+  const { submitButton, lockedInfo } = useRequiredQuestion({ authoredState, interactiveState, setInteractiveState, setNavigation, submitEnabled });
 
   const handleNewInteractiveState = (interactiveId: string, newInteractiveState: any) => {
     if (setInteractiveState) {
@@ -51,12 +53,6 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     if (setInteractiveState && currentSubintIndex < authoredState.subinteractives.length - 1) {
       const newInteractive = authoredState.subinteractives[currentSubintIndex + 1];
       setInteractiveState(Object.assign({}, interactiveState, { currentSubinteractiveId: newInteractive.id }));
-    }
-  };
-
-  const handleSubmit = () => {
-    if (setInteractiveState) {
-      setInteractiveState(Object.assign({}, interactiveState, { submitted: true }));
     }
   };
 
@@ -83,15 +79,15 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
         !report &&
         <div className={css.buttons}>
           { hintAvailable && <button onClick={handleHint}>Hint</button> }
-          { !submitted && <button onClick={handleSubmit} disabled={!submitAvailable}>Submit <FontAwesomeIcon icon={faLock} size="sm" /></button> }
+          { submitButton }
         </div>
       }
-      { !report && submitted && <div className={css.locked}>Your answer is now locked. <FontAwesomeIcon icon={faLock} size="sm" /></div> }
+      { !report && lockedInfo }
       {
         report &&
         <div>
           <div>Hint has been used { currentSubintIndex } times.</div>
-          <div>Question has been { submitted ? "" : "not" } submitted.</div>
+          { authoredState.required && <div>Question has been { submitted ? "" : "not" } submitted.</div> }
         </div>
       }
     </div>

--- a/src/scaffolded-question/components/runtime.tsx
+++ b/src/scaffolded-question/components/runtime.tsx
@@ -38,7 +38,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   // User can submit answer only if any answer has been provided before.
   const submitEnabled = !!subState;
 
-  const reportOrSubmitted = report || interactiveState?.submitted;
+  const readOnly = report || (authoredState.required && interactiveState?.submitted);
 
   const { submitButton, lockedInfo } = useRequiredQuestion({ authoredState, interactiveState, setInteractiveState, setNavigation, submitEnabled });
 
@@ -68,8 +68,8 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
         url={currentInteractive.url}
         authoredState={currentInteractive.authoredState}
         interactiveState={subState}
-        setInteractiveState={reportOrSubmitted ? undefined : handleNewInteractiveState.bind(null, currentInteractive.id)}
-        report={reportOrSubmitted}
+        setInteractiveState={readOnly ? undefined : handleNewInteractiveState.bind(null, currentInteractive.id)}
+        report={readOnly}
       />
       {
         authoredState.extraInstructions &&

--- a/src/scaffolded-question/components/runtime.tsx
+++ b/src/scaffolded-question/components/runtime.tsx
@@ -35,12 +35,11 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   const submitted = interactiveState?.submitted;
   const hintAvailable = !submitted && (currentSubintIndex < authoredState.subinteractives.length - 1);
 
-  // User can submit answer only if any answer has been provided before.
-  const submitEnabled = !!subState;
-
   const readOnly = report || (authoredState.required && interactiveState?.submitted);
 
-  const { submitButton, lockedInfo } = useRequiredQuestion({ authoredState, interactiveState, setInteractiveState, setNavigation, submitEnabled });
+  // User can submit answer only if any answer has been provided before.
+  const isAnswered = !!subState;
+  const { submitButton, lockedInfo } = useRequiredQuestion({ authoredState, interactiveState, setInteractiveState, setNavigation, isAnswered });
 
   const handleNewInteractiveState = (interactiveId: string, newInteractiveState: any) => {
     if (setInteractiveState) {

--- a/src/shared/hooks/use-lara-interactive-api.ts
+++ b/src/shared/hooks/use-lara-interactive-api.ts
@@ -8,11 +8,11 @@ interface IConfig {
   aspectRatio?: number;
 }
 
-export const useLARAInteractiveAPI = (config: IConfig) => {
+export const useLARAInteractiveAPI = <AS, IS>(config: IConfig) => {
   const phone = useRef<IframePhone>();
   const [ mode, setMode ] = useState<Mode>();
-  const [ authoredState, setAuthoredState ] = useState<any>();
-  const [ interactiveState, setInteractiveState ] = useState<any>();
+  const [ authoredState, setAuthoredState ] = useState<AS>();
+  const [ interactiveState, setInteractiveState ] = useState<IS>();
 
   const initInteractive = (data: any) => {
     // LARA sometimes sends string (report page), sometimes already parsed JSON (authoring, runtime).
@@ -39,6 +39,10 @@ export const useLARAInteractiveAPI = (config: IConfig) => {
 
   const handleSetHeight = (height: number) => {
     phone.current?.post("height", height);
+  }
+
+  const handleSetNavigation = (enableForwardNav: boolean, message: string) => {
+    phone.current?.post("navigation", { enableForwardNav, message });
   }
 
   useEffect(() => {
@@ -80,6 +84,7 @@ export const useLARAInteractiveAPI = (config: IConfig) => {
     interactiveState,
     setAuthoredState: handleAuthoredStateChange,
     setInteractiveState: handleInteractiveStateChange,
-    setHeight: handleSetHeight
+    setHeight: handleSetHeight,
+    setNavigation: handleSetNavigation,
   };
 }

--- a/src/shared/hooks/use-required-question.tsx
+++ b/src/shared/hooks/use-required-question.tsx
@@ -8,12 +8,12 @@ interface IConfig {
   interactiveState: { submitted?: boolean } | undefined;
   setInteractiveState: ((interactiveState: {submitted?: boolean}) => void) | undefined;
   setNavigation: ((enableForwardNav: boolean, message: string) => void) | undefined;
-  submitEnabled: boolean;
+  isAnswered: boolean;
 }
 
 // This hook can be used by any interactive that defines `required` property in its authored state and
 // `submitted` property in its interactive state (student state).
-export const useRequiredQuestion = ({ authoredState, interactiveState, setInteractiveState, setNavigation, submitEnabled }: IConfig) => {
+export const useRequiredQuestion = ({ authoredState, interactiveState, setInteractiveState, setNavigation, isAnswered }: IConfig) => {
   const handleSubmit = () => {
     if (setInteractiveState) {
       setInteractiveState(Object.assign({}, interactiveState, { submitted: true }));
@@ -25,10 +25,10 @@ export const useRequiredQuestion = ({ authoredState, interactiveState, setIntera
       const forwardNavEnabled = !!interactiveState?.submitted;
       setNavigation(forwardNavEnabled, forwardNavEnabled ? "" : "Please submit an answer first.");
     }
-  }, [authoredState, interactiveState, authoredState]);
+  }, [authoredState, interactiveState]);
 
   const submitButton = authoredState?.required && !interactiveState?.submitted ? (
-    <button className={css.laraButton} onClick={handleSubmit} disabled={!submitEnabled}>
+    <button className={css.laraButton} onClick={handleSubmit} disabled={!isAnswered}>
       Submit <FontAwesomeIcon icon={faLock} size="sm" />
     </button>
   ) : null;

--- a/src/shared/hooks/use-required-question.tsx
+++ b/src/shared/hooks/use-required-question.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faLock } from "@fortawesome/free-solid-svg-icons";
+import css from "../styles/helpers.scss";
+
+interface IConfig {
+  authoredState: { required?: boolean };
+  interactiveState: { submitted?: boolean } | undefined;
+  setInteractiveState: ((interactiveState: {submitted?: boolean}) => void) | undefined;
+  setNavigation: ((enableForwardNav: boolean, message: string) => void) | undefined;
+  submitEnabled: boolean;
+}
+
+// This hook can be used by any interactive that defines `required` property in its authored state and
+// `submitted` property in its interactive state (student state).
+export const useRequiredQuestion = ({ authoredState, interactiveState, setInteractiveState, setNavigation, submitEnabled }: IConfig) => {
+  const handleSubmit = () => {
+    if (setInteractiveState) {
+      setInteractiveState(Object.assign({}, interactiveState, { submitted: true }));
+    }
+  };
+
+  useEffect(() => {
+    if (authoredState.required && setNavigation) {
+      const forwardNavEnabled = !!interactiveState?.submitted;
+      setNavigation(forwardNavEnabled, forwardNavEnabled ? "" : "Please submit an answer first.");
+    }
+  }, [authoredState, interactiveState, authoredState]);
+
+  const submitButton = authoredState?.required && !interactiveState?.submitted ? (
+    <button className={css.laraButton} onClick={handleSubmit} disabled={!submitEnabled}>
+      Submit <FontAwesomeIcon icon={faLock} size="sm" />
+    </button>
+  ) : null;
+
+  const lockedInfo = authoredState?.required && interactiveState?.submitted ? (
+    <div className={css.locked}>Your answer is now locked. <FontAwesomeIcon icon={faLock} size="sm" /></div>
+  ) : null;
+
+  return {
+    submitButton,
+    lockedInfo
+  };
+};

--- a/src/shared/styles/helpers.scss
+++ b/src/shared/styles/helpers.scss
@@ -53,6 +53,10 @@ $themeColor2: #34a5be;
   }
 }
 
+.laraButton {
+  @include lara-button;
+}
+
 .locked {
   // Based on LARA styles.
   color: #525252;
@@ -61,6 +65,7 @@ $themeColor2: #34a5be;
   width: 100%;
   padding: 4px;
   font-size: 14pt;
+  margin-top: 10px;
 }
 
 .extraInstructions {


### PR DESCRIPTION
This hook should ensure that behavior is consistent across all the interactives. Also, if interactive ties to use it, but it doesn't implement `submitted` and `required` properties in its states, TypeScript will detect that and won't compile the code.

Theoretically, I could try to provide some wrapper even higher, but this implementation gives interactives flexibility on where to put a button and locked info. For example, Leslie wanted to have submit button on the right side of the question, while typical LARA questions have it on the left - so it's possible here pretty easily.