### PR TITLE
Add prediction feedback

### DIFF
--- a/cypress/integration/multiple-choice.test.js
+++ b/cypress/integration/multiple-choice.test.js
@@ -62,6 +62,71 @@ context("Test multiple-choice interactive", () => {
     });
   });
 
+  context("Submit button", () => {
+
+    it("renders a submit button if required: true", () => {
+      phonePost("initInteractive", {
+        mode: "runtime",
+        authoredState: {
+          prompt: "Test prompt",
+          multipleAnswers: false,
+          choices: [
+            {id: "id1", content: "choice A"},
+            {id: "id2", content: "choice B"},
+          ],
+          required: true,
+        }
+      });
+
+      cy.getIframeBody().find("[data-cy=lock-answer-button]").should("be.visible");
+      cy.getIframeBody().find("[data-cy=lock-answer-button]").should("include.text", "Submit");
+      cy.getIframeBody().find("[data-cy=lock-answer-button]").should("have.attr", "disabled");
+    });
+
+    it("locks the answer when Submit is clicked", () => {
+      phonePost("initInteractive", {
+        mode: "runtime",
+        authoredState: {
+          prompt: "Test prompt",
+          multipleAnswers: false,
+          choices: [
+            {id: "id1", content: "choice A"},
+            {id: "id2", content: "choice B"},
+          ],
+          required: true,
+        }
+      });
+
+      cy.getIframeBody().find("input[value='id1']").click();
+      cy.getIframeBody().find("[data-cy=lock-answer-button]").should("not.have.attr", "disabled");
+      cy.getIframeBody().find("[data-cy=lock-answer-button]").click();
+      cy.getIframeBody().find("input[value='id1']").should("have.attr", "disabled");
+      cy.getIframeBody().find("[data-cy=locked-info]").should("be.visible");
+      cy.getIframeBody().find("[data-cy=locked-info]").should("include.text", "locked");
+    });
+
+    it("shows feedback when Submit is clicked", () => {
+      phonePost("initInteractive", {
+        mode: "runtime",
+        authoredState: {
+          prompt: "Test prompt",
+          multipleAnswers: false,
+          choices: [
+            {id: "id1", content: "choice A"},
+            {id: "id2", content: "choice B"},
+          ],
+          required: true,
+          predictionFeedback: "Good guess"
+        }
+      });
+
+      cy.getIframeBody().find("input[value='id1']").click();
+      cy.getIframeBody().find("[data-cy=lock-answer-button]").click();
+      cy.getIframeBody().find("[data-cy=locked-info]").should("include.text", "Good guess");
+    });
+
+  });
+
   context("Dropdown layout", () => {
     it("renders prompt, dropdown, and handles pre-existing interactive state", () => {
       phonePost("initInteractive", {

--- a/cypress/integration/open-response.test.js
+++ b/cypress/integration/open-response.test.js
@@ -51,6 +51,39 @@ context("Test open response interactive", () => {
     });
   });
 
+  context("Submit button", () => {
+
+    it("renders a Submit button and shows feedback when Submit is clicked", () => {
+      phonePost("initInteractive", {
+        mode: "runtime",
+        authoredState: {
+          version: 1,
+          prompt: "Test prompt",
+          hint: "Hint",
+          defaultAnswer: "Default answer",
+          required: true,
+          predictionFeedback: "Good guess"
+        }
+      });
+
+      cy.getIframeBody().find("[data-cy=lock-answer-button]").should("be.visible");
+      cy.getIframeBody().find("[data-cy=lock-answer-button]").should("include.text", "Submit");
+      cy.getIframeBody().find("[data-cy=lock-answer-button]").should("have.attr", "disabled");
+
+      cy.getIframeBody().find("textarea").type("test answer");
+
+      cy.getIframeBody().find("[data-cy=lock-answer-button]").should("not.have.attr", "disabled");
+
+      cy.getIframeBody().find("[data-cy=lock-answer-button]").click();
+
+      cy.getIframeBody().find("textarea").should("have.attr", "disabled");
+      cy.getIframeBody().find("[data-cy=locked-info]").should("be.visible");
+      cy.getIframeBody().find("[data-cy=locked-info]").should("include.text", "locked");
+      cy.getIframeBody().find("[data-cy=locked-info]").should("include.text", "Good guess");
+    });
+
+  });
+
   context("Authoring view", () => {
     it("handles pre-existing authored state", () => {
       phonePost("initInteractive", {

--- a/src/multiple-choice/components/app.tsx
+++ b/src/multiple-choice/components/app.tsx
@@ -41,12 +41,8 @@ export const baseAuthoringProps = {
         type: "string"
       },
       required: {
-        title: "Required",
+        title: "Required (Show submit and lock button)",
         type: "boolean"
-      },
-      predictionFeedback: {
-        title: "Prediction feedback (optional)",
-        type: "string"
       },
       hint: {
         title: "Hint",
@@ -113,10 +109,44 @@ export const baseAuthoringProps = {
           }
         ]
       }
+    },
+    dependencies: {
+      required: {
+        oneOf: [
+          {
+            properties: {
+              required: {
+                enum: [
+                  false
+                ]
+              }
+            }
+          },
+          {
+            properties: {
+              required: {
+                enum: [
+                  true
+                ]
+              },
+              predictionFeedback: {
+                title: "Post-submission feedback (optional)",
+                type: "string"
+              }
+            }
+          }
+        ]
+      }
     }
   } as JSONSchema6,
 
   uiSchema: {
+    "ui:order": [
+      "prompt",
+      "required",
+      "predictionFeedback",
+      "*"
+    ],
     version: {
       "ui:widget": "hidden"
     },

--- a/src/multiple-choice/components/app.tsx
+++ b/src/multiple-choice/components/app.tsx
@@ -44,6 +44,10 @@ export const baseAuthoringProps = {
         title: "Required",
         type: "boolean"
       },
+      predictionFeedback: {
+        title: "Prediction feedback (optional)",
+        type: "string"
+      },
       hint: {
         title: "Hint",
         type: "string"

--- a/src/open-response/components/app.tsx
+++ b/src/open-response/components/app.tsx
@@ -35,6 +35,10 @@ const baseAuthoringProps = {
         title: "Required",
         type: "boolean"
       },
+      predictionFeedback: {
+        title: "Prediction feedback (optional)",
+        type: "string"
+      },
       hint: {
         title: "Hint",
         type: "string"

--- a/src/open-response/components/app.tsx
+++ b/src/open-response/components/app.tsx
@@ -32,12 +32,8 @@ const baseAuthoringProps = {
         type: "string"
       },
       required: {
-        title: "Required",
+        title: "Required (Show submit and lock button)",
         type: "boolean"
-      },
-      predictionFeedback: {
-        title: "Prediction feedback (optional)",
-        type: "string"
       },
       hint: {
         title: "Hint",
@@ -47,10 +43,44 @@ const baseAuthoringProps = {
         type: "string",
         title: "Default answer"
       }
+    },
+    dependencies: {
+      required: {
+        oneOf: [
+          {
+            properties: {
+              required: {
+                enum: [
+                  false
+                ]
+              }
+            }
+          },
+          {
+            properties: {
+              required: {
+                enum: [
+                  true
+                ]
+              },
+              predictionFeedback: {
+                title: "Post-submission feedback (optional)",
+                type: "string"
+              }
+            }
+          }
+        ]
+      }
     }
   } as JSONSchema6,
 
   uiSchema: {
+    "ui:order": [
+      "prompt",
+      "required",
+      "predictionFeedback",
+      "*"
+    ],
     version: {
       "ui:widget": "hidden"
     },

--- a/src/shared/components/base-question-app.tsx
+++ b/src/shared/components/base-question-app.tsx
@@ -15,6 +15,7 @@ import css from "./base-app.scss";
 interface IBaseQuestionAuthoredState extends IBaseAuthoredState {
   hint?: string;
   required?: boolean;
+  predictionFeedback?: string;
 }
 
 interface IBaseQuestionInteractiveState {

--- a/src/shared/components/locked-info.scss
+++ b/src/shared/components/locked-info.scss
@@ -1,17 +1,28 @@
 @import "../styles/helpers";
 
 .locked {
-  // Based on LARA styles.
-  color: #525252;
-  font-weight: lighter;
-  background-color: #ededed;
-  width: 100%;
-  padding: 4px;
-  font-size: 14pt;
-  margin-top: 10px;
 
-  // Icon.
-  svg {
-    fill: #525252;
+  .header {
+    color: #525252;
+    font-weight: lighter;
+    background-color: #ededed;
+    width: 100%;
+    padding: 4px;
+    font-size: 14pt;
+    margin-top: 10px;
+
+    // Icon.
+    svg {
+      fill: #525252;
+    }
+  }
+
+  .feedback {
+    display: block;
+    width: 100%;
+    margin: 0px;
+    border: 1px solid #ededed;
+    border-radius: 0 0 13px 13px;
+    padding: 1em;
   }
 }

--- a/src/shared/components/locked-info.tsx
+++ b/src/shared/components/locked-info.tsx
@@ -1,16 +1,26 @@
 import React from "react";
 import LockIcon from "../icons/lock.svg";
-import { useInteractiveState } from "@concord-consortium/lara-interactive-api";
+import { useInteractiveState, useAuthoredState } from "@concord-consortium/lara-interactive-api";
 import css from "./locked-info.scss";
 
 // This hook can be used by any interactive that defines `required` property in its authored state and
 // `submitted` property in its interactive state (student state).
 export const LockedInfo: React.FC = () => {
+  const { authoredState } = useAuthoredState<{ predictionFeedback?: boolean }>();
   const { interactiveState } = useInteractiveState<{ submitted?: boolean }>();
 
   if (!interactiveState?.submitted) {
     // Question is not submitted, nothing to show.
     return null;
   }
-  return <div className={css.locked}>Your answer is now locked. <LockIcon className={css.mediumIcon} /></div>;
+
+  return (
+    <div className={css.locked} data-cy="locked-info">
+      <div className={css.header}>Your answer is now locked. <LockIcon className={css.mediumIcon} /></div>
+      {
+      authoredState?.predictionFeedback &&
+      <div className={css.feedback}>{ authoredState.predictionFeedback }</div>
+      }
+    </div>
+  );
 };

--- a/src/shared/components/submit-button.tsx
+++ b/src/shared/components/submit-button.tsx
@@ -23,7 +23,7 @@ export const SubmitButton: React.FC<IProps> = ({ isAnswered }) => {
   };
 
   return (
-    <button className={css.laraButton} onClick={handleSubmit} disabled={!isAnswered}>
+    <button className={css.laraButton} onClick={handleSubmit} disabled={!isAnswered} data-cy="lock-answer-button">
       Submit <LockIcon className={css.smallIcon} />
     </button>
   );


### PR DESCRIPTION
This adds `predictionFeedback?` to the base question, and displays it in the Lock component if it exists.

<img width="1056" alt="Screen Shot 2020-06-12 at 1 03 09 PM" src="https://user-images.githubusercontent.com/35721/84528176-2e0ac980-acad-11ea-9973-e7c1ae52af69.png">

Note that the old LARA models had both `give_prediction_feedback: boolean` and `prediction_feedback: string`, both of which had to be set to see any feedback. It seemed simpler to condense into just `predictionFeedback: string`. We'll have to remember this when creating the migration, however.