### PR TITLE
Add multiple-choice-alerts interactive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1192,9 +1192,9 @@
       }
     },
     "@concord-consortium/lara-interactive-api": {
-      "version": "0.4.0-pre.10",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-0.4.0-pre.10.tgz",
-      "integrity": "sha512-zzwFchKIR2CFY1T9/m0Ifj5Q3VJ0zp9QWd2G8ZEOBjg4jSjVMe2/FtP0OkXOQqMM0MjjYx93BCTqTXdh8i9ocQ==",
+      "version": "0.5.0-pre.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-0.5.0-pre.1.tgz",
+      "integrity": "sha512-FT9W2O+3h43EeuSVv+aXIow78oJu/vEqP8a4f5iuJjOCGc2JyzTAid0RPzDO8Cp4lNQBPSQjN2R5J6ppGe+cKg==",
       "requires": {
         "iframe-phone": "^1.3.1"
       },

--- a/package.json
+++ b/package.json
@@ -114,9 +114,9 @@
     "webpack-dev-server": "^3.10.3"
   },
   "dependencies": {
+    "@concord-consortium/lara-interactive-api": "^0.5.0-pre.1",
     "deep-equal": "^2.0.3",
     "iframe-phone": "^1.2.1",
-    "@concord-consortium/lara-interactive-api": "0.4.0-pre.10",
     "jquery": "^3.5.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/src/multiple-choice-alerts/components/app.test.tsx
+++ b/src/multiple-choice-alerts/components/app.test.tsx
@@ -1,0 +1,52 @@
+/*
+  This is a modified version of the standard multiple choice question which uses the LARA interactive
+  API showModal() function to show feedback via modal alert rather than inline feedback. At this point
+  its sole purpose is to allow manual testing of the modal alert functionality.
+ */
+
+import { baseAuthoringProps, IChoice } from "./app";
+
+describe("preprocessFormData helper", () => {
+  it("generates unique IDs for choices when they're missing", () => {
+    const newData = baseAuthoringProps.preprocessFormData({
+      version: 1,
+      questionType: "multiple_choice",
+      prompt: "Test prompt",
+      hint: "Test instructions",
+      choices: [
+        {content: "A", correct: true} as IChoice,
+        {content: "B", correct: true} as IChoice
+      ],
+      layout: "vertical",
+    });
+    const choices = newData.choices!;
+
+    expect(choices[0].id).toBeDefined();
+    expect(choices[1].id).toBeDefined();
+    expect(choices[0].id).not.toEqual(choices[1].id);
+  });
+
+  it("doesn't overwrite existing choice IDs", () => {
+    expect(baseAuthoringProps.preprocessFormData({
+      version: 1,
+      questionType: "multiple_choice",
+      prompt: "Test prompt",
+      hint: "Test instructions",
+      choices: [
+        {id: "1", content: "A", correct: true},
+        {id: "2", content: "B", correct: true}
+      ],
+      layout: "vertical",
+    })).toEqual({
+      version: 1,
+      questionType: "multiple_choice",
+      prompt: "Test prompt",
+      hint: "Test instructions",
+      choices: [
+        {id: "1", content: "A", correct: true},
+        {id: "2", content: "B", correct: true}
+      ],
+      layout: "vertical",
+    });
+  });
+});

--- a/src/multiple-choice-alerts/components/app.tsx
+++ b/src/multiple-choice-alerts/components/app.tsx
@@ -1,0 +1,264 @@
+/*
+  This is a modified version of the standard multiple choice question which uses the LARA interactive
+  API showModal() function to show feedback via modal alert rather than inline feedback. At this point
+  its sole purpose is to allow manual testing of the modal alert functionality.
+ */
+
+import React from "react";
+import { JSONSchema6 } from "json-schema";
+import { BaseQuestionApp } from "../../shared/components/base-question-app";
+import { Runtime } from "./runtime";
+import { v4 as uuidv4 } from "uuid";
+import {
+  IAuthoringMultipleChoiceChoiceMetadata, IAuthoringMultipleChoiceMetadata, IRuntimeMultipleChoiceMetadata,
+} from "@concord-consortium/lara-interactive-api";
+
+// Note that TS interfaces should match JSON schema. Currently there's no way to generate one from the other.
+// TS interfaces are not available in runtime in contrast to JSON schema.
+
+export interface IChoice extends IAuthoringMultipleChoiceChoiceMetadata {
+  choiceFeedback?: string;
+}
+
+export type ILayout = "vertical" | "horizontal" | "likert" | "dropdown";
+
+export interface IAuthoredState extends IAuthoringMultipleChoiceMetadata {
+  version: number;
+  hint?: string;
+  multipleAnswers?: boolean;
+  layout?: ILayout;
+  enableCheckAnswer?: boolean;
+  customFeedback?: boolean;
+  choices: IChoice[];
+}
+
+export interface IInteractiveState extends IRuntimeMultipleChoiceMetadata {}
+
+export const baseAuthoringProps = {
+  schema: {
+    type: "object",
+    properties: {
+      version: {
+        type: "number",
+        default: 1
+      },
+      questionType: {
+        type: "string",
+        default: "multiple_choice"
+      },
+      prompt: {
+        title: "Prompt",
+        type: "string"
+      },
+      required: {
+        title: "Required (Show submit and lock button)",
+        type: "boolean"
+      },
+      enableCheckAnswer: {
+        title: "Allow users to check answers",
+        type: "boolean",
+      },
+      hint: {
+        title: "Hint",
+        type: "string"
+      },
+      multipleAnswers: {
+        type: "boolean",
+        title: "Allow multiple answers",
+        default: false
+      },
+      layout: {
+        title: "Layout",
+        type: "string",
+        default: "vertical",
+        enum: [
+          "vertical",
+          "horizontal",
+          "likert",
+          "dropdown"
+        ],
+        enumNames: [
+          "Vertical",
+          "Horizontal",
+          "Likert",
+          "Dropdown"
+        ]
+      },
+      choices: {
+        type: "array",
+        title: "Choices",
+        items: {
+          type: "object",
+          properties: {
+            id: {
+              type: "string"
+            },
+            content: {
+              type: "string",
+              title: "Choice text",
+              default: "choice"
+            },
+            correct: {
+              type: "boolean",
+              title: "Correct",
+              default: false
+            }
+          }
+        },
+        default: [
+          {
+            id: "1",
+            content: "Choice A",
+            correct: false
+          },
+          {
+            id: "2",
+            content: "Choice B",
+            correct: false
+          },
+          {
+            id: "3",
+            content: "Choice C",
+            correct: false
+          }
+        ]
+      }
+    },
+    dependencies: {
+      required: {
+        oneOf: [
+          {
+            properties: {
+              required: {
+                enum: [
+                  false
+                ]
+              }
+            }
+          },
+          {
+            properties: {
+              required: {
+                enum: [
+                  true
+                ]
+              },
+              predictionFeedback: {
+                title: "Post-submission feedback (optional)",
+                type: "string"
+              }
+            }
+          }
+        ]
+      },
+      enableCheckAnswer: {
+        oneOf: [
+          {
+            properties: {
+              enableCheckAnswer: {
+                enum: [
+                  false
+                ]
+              }
+            }
+          },
+          {
+            properties: {
+              enableCheckAnswer: {
+                enum: [
+                  true
+                ]
+              },
+              customFeedback: {
+                title: "Show custom feedback for answers",
+                type: "boolean"
+              }
+            }
+          }
+        ]
+      },
+      customFeedback: {
+        oneOf: [
+          {
+            properties: {
+              customFeedback: {
+                enum: [
+                  false
+                ]
+              }
+            }
+          },
+          {
+            properties: {
+              customFeedback: {
+                enum: [
+                  true
+                ]
+              },
+              choices: {
+                items: {
+                  properties: {
+                    choiceFeedback: {
+                      type: "string",
+                      title: "Feedback for choice (optional)"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  } as JSONSchema6,
+
+  uiSchema: {
+    "ui:order": [
+      "prompt",
+      "required",
+      "predictionFeedback",
+      "enableCheckAnswer",
+      "customFeedback",
+      "*"
+    ],
+    version: {
+      "ui:widget": "hidden"
+    },
+    questionType: {
+      "ui:widget": "hidden"
+    },
+    prompt: {
+      "ui:widget": "textarea"
+    },
+    hint: {
+      "ui:widget": "textarea"
+    },
+    choices: {
+      items: {
+        id: {
+          "ui:widget": "hidden"
+        }
+      }
+    }
+  },
+
+  preprocessFormData: (authoredState: IAuthoredState) => {
+    // Generate choice ID if necessary.
+    authoredState.choices?.forEach(choice => {
+      if (choice.id === undefined) {
+        choice.id = uuidv4();
+      }
+    });
+    return authoredState;
+  }
+};
+
+const isAnswered = (interactiveState: IInteractiveState) => interactiveState?.selectedChoiceIds?.length > 0;
+
+export const App = () => (
+  <BaseQuestionApp<IAuthoredState, IInteractiveState>
+    Runtime={Runtime}
+    baseAuthoringProps={baseAuthoringProps}
+    isAnswered={isAnswered}
+  />
+);

--- a/src/multiple-choice-alerts/components/runtime.scss
+++ b/src/multiple-choice-alerts/components/runtime.scss
@@ -1,0 +1,113 @@
+/*
+  This is a modified version of the standard multiple choice question which uses the LARA interactive
+  API showModal() function to show feedback via modal alert rather than inline feedback. At this point
+  its sole purpose is to allow manual testing of the modal alert functionality.
+ */
+
+@import "../../shared/styles/helpers";
+
+legend.prompt {     // clear bootstrap stuff
+  display: unset;
+  width: unset;
+  margin-bottom: unset;
+  font-size: unset;
+  border: unset;
+  padding-bottom: 5px;
+}
+
+.choices {
+
+  input[type=radio], input[type=checkbox] {
+    transform: scale(1.5);
+    margin: 4px 10px 0 5px;
+  }
+
+  &.horizontal {
+    display: flex;
+    flex-wrap: wrap;
+
+    div {
+      display: flex;
+      margin-right: 25px;
+    }
+  }
+
+  &.likert {
+    display: grid;
+    grid-template-columns: repeat( auto-fit, minmax(0px, 1fr) );
+
+    div {
+      display: flex;
+      flex-direction: column-reverse;
+      align-items: center;
+
+      input[type=radio], input[type=checkbox] {
+        margin: 7px 0 4px;
+      }
+
+      label {
+        margin: 5px 0 0 0;
+      }
+    }
+  }
+
+  &.dropdown {
+    select {
+      margin: 5px;
+      padding: 2px;
+    }
+  }
+}
+
+label {
+  font-weight: normal;
+}
+
+.correctChoice {
+  color: $correctColor;
+}
+
+.incorrectChoice {
+  color: $incorrectColor;
+}
+
+.answerFeedback {
+  display: flex;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  margin-top: 9px;
+
+  .symbol {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 28px;
+    color: white;
+    border-radius: 3px 0 0 3px;
+
+    svg {
+      width: 35px;
+    }
+
+    &.incorrectSymbol {
+      background-color: #da0006;
+      svg {
+        fill: #fee5e5;
+      }
+    }
+
+    &.correctSymbol {
+      background-color: #19b533;
+      svg {
+        fill: #e9fced;
+      }
+    }
+  }
+
+  .feedback {
+    display: flex;
+    align-items: center;
+    padding: 2px 8px;
+  }
+}

--- a/src/multiple-choice-alerts/components/runtime.test.tsx
+++ b/src/multiple-choice-alerts/components/runtime.test.tsx
@@ -1,0 +1,156 @@
+/*
+  This is a modified version of the standard multiple choice question which uses the LARA interactive
+  API showModal() function to show feedback via modal alert rather than inline feedback. At this point
+  its sole purpose is to allow manual testing of the modal alert functionality.
+ */
+
+import React from "react";
+import { shallow } from "enzyme";
+import { Runtime } from "./runtime";
+import { IAuthoredState, IInteractiveState } from "./app";
+
+const authoredState = {
+  version: 1,
+  questionType: "multiple_choice",
+  prompt: "Test prompt",
+  choices: [
+    {id: "id1", content: "Choice A"},
+    {id: "id2", content: "Choice B"}
+  ],
+  layout: "vertical",
+} as IAuthoredState;
+
+const interactiveState = {
+  answerType: "multiple_choice_answer",
+  selectedChoiceIds: [ "id2" ]
+} as IInteractiveState;
+
+describe("Runtime", () => {
+  it("renders prompt, extra instructions and choices", () => {
+    const wrapper = shallow(<Runtime authoredState={authoredState} />);
+    expect(wrapper.text()).toEqual(expect.stringContaining(authoredState.prompt!));
+    expect(wrapper.text()).toEqual(expect.stringContaining(authoredState.choices[0].content!));
+    expect(wrapper.text()).toEqual(expect.stringContaining(authoredState.choices[1].content!));
+  });
+
+  it("renders radio buttons or checkboxes depending on multipleAnswers property", () => {
+    let wrapper = shallow(<Runtime authoredState={authoredState} />);
+    expect(wrapper.find("input[type='radio']").length).toEqual(2);
+    expect(wrapper.find("input[type='checkbox']").length).toEqual(0);
+    wrapper = shallow(<Runtime authoredState={Object.assign({}, authoredState, {multipleAnswers: true})} />);
+    expect(wrapper.find("input[type='radio']").length).toEqual(0);
+    expect(wrapper.find("input[type='checkbox']").length).toEqual(2);
+  });
+
+  it("handles passed interactiveState", () => {
+    const wrapper = shallow(<Runtime authoredState={authoredState} interactiveState={interactiveState} />);
+    expect(wrapper.find("input[value='id1']").props().checked).toEqual(false);
+    expect(wrapper.find("input[value='id2']").props().checked).toEqual(true);
+  });
+
+  it("calls setInteractiveState when user selects an answer - multiple answers disabled", () => {
+    const setState = jest.fn();
+    const wrapper = shallow(<Runtime authoredState={authoredState} interactiveState={interactiveState} setInteractiveState={setState} />);
+    wrapper.find("input[value='id1']").simulate("change", { target: { checked: true } });
+    let newState = setState.mock.calls[0][0](interactiveState);
+    expect(newState).toEqual({answerType: "multiple_choice_answer", selectedChoiceIds: ["id1"]});
+    wrapper.find("input[value='id2']").simulate("change", { target: { checked: true } });
+    newState = setState.mock.calls[1][0](interactiveState);
+    expect(newState).toEqual({answerType: "multiple_choice_answer", selectedChoiceIds: ["id2"]});
+  });
+
+  it("calls setInteractiveState when user selects an answer - multiple answers enabled", () => {
+    const setState = jest.fn();
+    const wrapper = shallow(<Runtime authoredState={Object.assign({}, authoredState, {multipleAnswers: true})} interactiveState={interactiveState} setInteractiveState={setState}/>);
+    wrapper.find("input[value='id1']").simulate("change", { target: { checked: true } });
+    let newState = setState.mock.calls[0][0](interactiveState);
+    expect(newState).toEqual({answerType: "multiple_choice_answer", selectedChoiceIds: ["id2", "id1"]});
+    // Note that correct state below is an empty array. This is a controlled component, it doesn't have its own state,
+    // so the previous click didn't really update interactiveState for it. We're just unchecking initially checked "id2".
+    wrapper.find("input[value='id2']").simulate("change", { target: { checked: false } });
+    newState = setState.mock.calls[1][0](interactiveState);
+    expect(newState).toEqual({answerType: "multiple_choice_answer", selectedChoiceIds: []});
+  });
+
+  describe("report mode", () => {
+    it("renders prompt, extra instructions and *disabled* choices", () => {
+      const wrapper = shallow(<Runtime authoredState={authoredState} report={true} />);
+      expect(wrapper.text()).toEqual(expect.stringContaining(authoredState.prompt!));
+      expect(wrapper.text()).toEqual(expect.stringContaining(authoredState.choices[0].content!));
+      expect(wrapper.text()).toEqual(expect.stringContaining(authoredState.choices[1].content!));
+
+      expect(wrapper.find("input[value='id1']").props().disabled).toEqual(true);
+      expect(wrapper.find("input[value='id2']").props().disabled).toEqual(true);
+    });
+
+    it("handles passed interactiveState", () => {
+      const wrapper = shallow(<Runtime authoredState={authoredState} interactiveState={interactiveState} report={true} />);
+      expect(wrapper.find("input[value='id1']").props().checked).toEqual(false);
+      expect(wrapper.find("input[value='id2']").props().checked).toEqual(true);
+    });
+
+    it("never calls setInteractiveState when user selects an answer", () => {
+      const setState = jest.fn();
+      const wrapper = shallow(<Runtime authoredState={authoredState} interactiveState={interactiveState} setInteractiveState={setState} report={true} />);
+      wrapper.find("input[value='id1']").simulate("change", { target: { checked: true } });
+      expect(setState).not.toHaveBeenCalled();
+      wrapper.find("input[value='id2']").simulate("change", { target: { checked: true } });
+      expect(setState).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("dropdown layout", () => {
+
+    const dropdownAuthoredState = {
+      version: 1,
+      prompt: "Test prompt",
+      choices: [
+        {id: "id1", content: "Choice A"},
+        {id: "id2", content: "Choice B"}
+      ],
+      layout: "dropdown",
+    } as IAuthoredState;
+
+    const dropdownInteractiveState = {
+      answerType: "multiple_choice_answer",
+      selectedChoiceIds: [ "id2" ],
+    } as IInteractiveState;
+
+    it("renders prompt, extra instructions and choices", () => {
+      const wrapper = shallow(<Runtime authoredState={dropdownAuthoredState} />);
+      expect(wrapper.text()).toEqual(expect.stringContaining(dropdownAuthoredState.prompt!));
+      expect(wrapper.text()).toEqual(expect.stringContaining(dropdownAuthoredState.choices[0].content!));
+      expect(wrapper.text()).toEqual(expect.stringContaining(dropdownAuthoredState.choices[1].content!));
+    });
+
+    it("renders dropdown select", () => {
+      const wrapper = shallow(<Runtime authoredState={dropdownAuthoredState} />);
+      expect(wrapper.find("option").length).toEqual(3);
+      expect(wrapper.find("option").first().text()).toEqual(expect.stringContaining("Select"));
+      expect(wrapper.find("option").at(1).text()).toEqual(expect.stringContaining(dropdownAuthoredState.choices[0].content!));
+    });
+
+    it("handles passed interactiveState", () => {
+      const wrapper = shallow(<Runtime authoredState={dropdownAuthoredState} interactiveState={dropdownInteractiveState} />);
+      expect(wrapper.find("select").props().value).toEqual("id2");
+    });
+
+    it("calls setInteractiveState when user selects an answer", () => {
+      const setState = jest.fn();
+      const wrapper = shallow(<Runtime authoredState={dropdownAuthoredState} interactiveState={dropdownInteractiveState} setInteractiveState={setState} />);
+      expect(wrapper.find("select").props().value).toEqual("id2");
+      wrapper.find('select').simulate('change', {target: {value : "id1"}});
+      const newState = setState.mock.calls[0][0](interactiveState);
+      expect(newState).toEqual({answerType: "multiple_choice_answer", selectedChoiceIds: ["id1"]});
+    });
+
+    describe("report mode", () => {
+
+      it("handles passed interactiveState", () => {
+        const wrapper = shallow(<Runtime authoredState={dropdownAuthoredState} interactiveState={dropdownInteractiveState} report={true} />);
+        expect(wrapper.find("select").props().disabled).toEqual(true);
+        expect(wrapper.find("select").props().value).toEqual("id2");
+      });
+    });
+  });
+});

--- a/src/multiple-choice-alerts/components/runtime.tsx
+++ b/src/multiple-choice-alerts/components/runtime.tsx
@@ -1,0 +1,183 @@
+/*
+  This is a modified version of the standard multiple choice question which uses the LARA interactive
+  API showModal() function to show feedback via modal alert rather than inline feedback. At this point
+  its sole purpose is to allow manual testing of the modal alert functionality.
+ */
+
+import React, { useState } from "react";
+import { v4 as uuidv4 } from "uuid";
+import { IAuthoredState, IChoice, IInteractiveState } from "./app";
+import { showModal } from "@concord-consortium/lara-interactive-api";
+import css from "./runtime.scss";
+import buttonCss from "../../shared/styles/helpers.scss";
+
+const DEFAULT_INCORRECT = "Sorry, that is incorrect.";
+const DEFAULT_CORRECT = "Yes! You are correct.";
+const MULTI_CHOICE_INCOMPLETE = "You're on the right track, but you didn't select all the right answers yet.";
+
+interface IProps {
+  authoredState: IAuthoredState;
+  interactiveState?: IInteractiveState | null;
+  setInteractiveState?: (updateFunc: (prevState: IInteractiveState | null) => IInteractiveState) => void;
+  report?: boolean;
+}
+
+const baseElementId = uuidv4();     // DOM id necessary to associate inputs and label-for
+
+export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, report }) => {
+
+  const [showAnswerFeedback, setShowAnswerFeedback] = useState(false);
+
+  const type = authoredState.multipleAnswers ? "checkbox" : "radio";
+  let selectedChoiceIds = interactiveState?.selectedChoiceIds || [];
+  if (!authoredState.multipleAnswers && selectedChoiceIds.length > 1) {
+    // This can happen when author changes type of the question, but student provided some answers before.
+    // Don't let multiple radio inputs be selected, as that basically breaks their behavior and event handling.
+    // Clear previous answer instead.
+    selectedChoiceIds = [];
+  }
+
+    // Question can be scored if it has at least one correct answer defined.
+  const isScorable = !!authoredState.choices && authoredState.choices.filter(c => c.correct).length > 0;
+
+  const handleRadioCheckChange = (choiceId: string, event: React.ChangeEvent<HTMLInputElement>) => {
+    const checked = event.target.checked;
+    let newChoices: string[];
+    if (!authoredState.multipleAnswers) {
+      // Radio buttons, just one answer.
+      newChoices = [ choiceId ];
+    } else {
+      // Checkboxes, multiple answers allowed.
+      newChoices = interactiveState?.selectedChoiceIds.slice() || [];
+      const currentIdx = newChoices.indexOf(choiceId);
+      if (checked && currentIdx === -1) {
+        newChoices.push(choiceId);
+      }
+      if (!checked && currentIdx !== -1) {
+        newChoices.splice(currentIdx, 1);
+      }
+    }
+    setInteractiveState?.(prevState => ({...prevState, answerType: "multiple_choice_answer", selectedChoiceIds: newChoices }));
+    setShowAnswerFeedback(false);
+  };
+
+  const handleSelectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const newChoice = [ event.target.value ];
+    setInteractiveState?.(prevState => ({...prevState, answerType: "multiple_choice_answer", selectedChoiceIds: newChoice }));
+    setShowAnswerFeedback(false);
+  };
+
+  const getChoiceClass = (choice: IChoice, checked: boolean) => {
+    if (!report || !isScorable) {
+      return undefined;
+    }
+    if (checked && choice.correct) {
+      return css.correctChoice;
+    }
+    if (!checked && choice.correct) {
+      // User didn't check correct answer. Mark it.
+      return css.incorrectChoice;
+    }
+  };
+
+  const readOnly = report || (authoredState.required && interactiveState?.submitted);
+
+  const renderRadioChecks = () => {
+    return authoredState.choices && authoredState.choices.map(choice => {
+      const checked = selectedChoiceIds.indexOf(choice.id) !== -1;
+      const inputId = baseElementId + choice.id;
+      return (
+        <div key={choice.id} className={getChoiceClass(choice, checked)}>
+          <input
+            type={type}
+            value={choice.id}
+            id={inputId}
+            name="answer"
+            checked={checked}
+            onChange={readOnly ? undefined : handleRadioCheckChange.bind(null, choice.id)}
+            readOnly={readOnly}
+            disabled={readOnly}
+          />
+          <label htmlFor={inputId}>
+            {choice.content}
+          </label>
+        </div>
+      );
+    });
+  }
+
+  const renderSelect = () => {
+    return (
+      <select value={selectedChoiceIds[0] || "placeholder"} onChange={handleSelectChange} disabled={readOnly}>
+        <option value="placeholder" disabled={true}>Select an option</option>
+        {
+          authoredState.choices && authoredState.choices.map(choice =>
+            <option key={choice.id} value={choice.id}>{ choice.content }</option>
+          )
+        }
+      </select>
+    );
+  }
+
+  const getFeedback = () => {
+    let feedback = "";
+    let isCorrect = false;
+    if (!authoredState.multipleAnswers) {
+      const choice = authoredState.choices.find(c => c.id === selectedChoiceIds[0]);
+      if (!choice) return;
+      isCorrect = !!choice.correct;
+      if (authoredState.customFeedback && choice.choiceFeedback) {
+        feedback = choice.choiceFeedback;
+      } else {
+        feedback = choice.correct ? DEFAULT_CORRECT : DEFAULT_INCORRECT;
+      }
+    } else {
+      const correctChoices = authoredState.choices.filter(c => c.correct);
+      const correctUserChoices = authoredState.choices.filter(c => selectedChoiceIds.includes(c.id) && c.correct);
+      const incorrectUserChoices = authoredState.choices.filter(c => selectedChoiceIds.includes(c.id) && !c.correct);
+      if (correctUserChoices.length === correctChoices.length && incorrectUserChoices.length === 0) {
+        isCorrect = true;
+        feedback = DEFAULT_CORRECT;
+      } else if (incorrectUserChoices.length === 0) {
+        feedback = MULTI_CHOICE_INCOMPLETE;
+      } else {
+        const firstIncorrect = incorrectUserChoices[0];
+        if (authoredState.customFeedback && firstIncorrect.choiceFeedback) {
+          feedback = firstIncorrect.choiceFeedback;
+        } else {
+          feedback = DEFAULT_INCORRECT;
+        }
+      }
+    }
+    return { isCorrect, feedback };
+  }
+
+  const layout = authoredState.layout || "vertical";
+  const isAnswered = !!interactiveState?.selectedChoiceIds?.length;
+  const handleShowAnswerFeedback = () => {
+    const feedbackResult = getFeedback();
+    const style = feedbackResult?.isCorrect ? "correct" : "incorrect";
+    showModal({ type: "alert", uuid: uuidv4(), style, text: feedbackResult?.feedback });
+  };
+
+  return (
+    <div>
+      <fieldset>
+        { authoredState.prompt && <legend className={css.prompt + " list-unstyled"}>{ authoredState.prompt }</legend> }
+        <div className={css.choices + " " + css[layout]} data-cy="choices-container">
+          {
+            authoredState.layout !== "dropdown"
+            ? renderRadioChecks()
+            : renderSelect()
+          }
+        </div>
+      </fieldset>
+      { authoredState.enableCheckAnswer && !readOnly &&
+      <button className={buttonCss.laraButton} onClick={handleShowAnswerFeedback}
+          disabled={!isAnswered} data-cy="check-answer-button">
+        Check answer
+      </button>
+      }
+    </div>
+  );
+};

--- a/src/multiple-choice-alerts/index.tsx
+++ b/src/multiple-choice-alerts/index.tsx
@@ -1,0 +1,14 @@
+/*
+  This is a modified version of the standard multiple choice question which uses the LARA interactive
+  API showModal() function to show feedback via modal alert rather than inline feedback. At this point
+  its sole purpose is to allow manual testing of the modal alert functionality.
+ */
+
+import React from "react";
+import ReactDOM from "react-dom";
+import { App } from "./components/app";
+
+ReactDOM.render(
+  <App/>,
+  document.getElementById("app")
+);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = (env, argv) => {
     devtool: 'source-map',
     entry: {
       'multiple-choice': './src/multiple-choice/index.tsx',
+      'multiple-choice-alerts': './src/multiple-choice-alerts/index.tsx',
       'open-response': './src/open-response/index.tsx',
       'fill-in-the-blank': './src/fill-in-the-blank/index.tsx',
       'scaffolded-question': './src/scaffolded-question/index.tsx',
@@ -109,6 +110,11 @@ module.exports = (env, argv) => {
       new HtmlWebpackPlugin({
         chunks: ['multiple-choice'],
         filename: 'multiple-choice/index.html',
+        template: 'src/shared/index.html'
+      }),
+      new HtmlWebpackPlugin({
+        chunks: ['multiple-choice-alerts'],
+        filename: 'multiple-choice-alerts/index.html',
         template: 'src/shared/index.html'
       }),
       new HtmlWebpackPlugin({


### PR DESCRIPTION
The `multiple-choice-alerts` interactive is a duplicate of the `multiple-choice` interactive but uses alerts for feedback. Its only purpose is to allow manual testing of the alert features of the LARA interactive API. Note that an appropriate version of the LARA interactive API has not yet been published at this point but that should happen shortly.