### PR TITLE
Add logging

### DIFF
--- a/cypress/integration/multiple-choice.test.js
+++ b/cypress/integration/multiple-choice.test.js
@@ -52,12 +52,12 @@ context("Test multiple-choice interactive", () => {
 
       cy.getIframeBody().find("input[value='id1']").click();
       getAndClearLastPhoneMessage((state) => {
-        expect(state).eql({ answerType: "multiple_choice_answer", selectedChoiceIds: [ "id1" ] });
+        expect(state).eql({ answerType: "multiple_choice_answer", selectedChoiceIds: [ "id1" ], answerText: "choice A" });
       });
 
       cy.getIframeBody().find("input[value='id2']").click();
       getAndClearLastPhoneMessage((state) => {
-        expect(state).eql({ answerType: "multiple_choice_answer", selectedChoiceIds: [ "id2" ] });
+        expect(state).eql({ answerType: "multiple_choice_answer", selectedChoiceIds: [ "id2" ], answerText: "choice B" });
       });
     });
   });

--- a/cypress/integration/scaffolded-question.test.js
+++ b/cypress/integration/scaffolded-question.test.js
@@ -113,37 +113,38 @@ context("Test Scaffolded Question interactive", () => {
       cy.wait(200);
 
       getAndClearAllPhoneMessage((messages) => {
-        expect(messages.length).eql(3);
+        expect(messages.length).eql(2);
 
         expect(messages[0]).eql({
           action: "focus in",
           data: {
-            focus_target: "textarea",
+            target_element: 'textarea',
+            target_type: 'textarea',
+            target_id: '',
+            target_name: '',
+            target_value: '',
             scaffolded_question_level: 1,
             subinteractive_url: "/open-response",
             subinteractive_type: "open_response",
-            subinteractive_sub_type: undefined
+            subinteractive_sub_type: undefined,
+            subinteractive_id: 'int1'
           }
         });
 
         expect(messages[1]).eql({
           action: "focus out",
           data: {
+            target_element: 'textarea',
+            target_type: 'textarea',
+            target_id: '',
+            target_name: '',
+            target_value: 'Test subquestion answer',
             scaffolded_question_level: 1,
             subinteractive_url: '/open-response',
             subinteractive_type: 'open_response',
-            subinteractive_sub_type: undefined
-          }
-        });
-
-        expect(messages[2]).eql({
-          action: "answer saved",
-          data: {
-            answer_text: "Test subquestion answer",
-            scaffolded_question_level: 1,
-            subinteractive_url: "/open-response",
-            subinteractive_type: "open_response",
-            subinteractive_sub_type: undefined
+            subinteractive_sub_type: undefined,
+            subinteractive_id: 'int1',
+            answer_text: 'Test subquestion answer'
           }
         });
       });

--- a/cypress/integration/scaffolded-question.test.js
+++ b/cypress/integration/scaffolded-question.test.js
@@ -1,6 +1,6 @@
 import { phonePost, phoneListen, getAndClearLastPhoneMessage } from "../support";
 
-context("Test open response interactive", () => {
+context("Test Scaffolded Question interactive", () => {
   beforeEach(() => {
     cy.visit("/wrapper.html?iframe=/scaffolded-question");
   });
@@ -79,7 +79,8 @@ context("Test open response interactive", () => {
               answerType: "open_response_answer",
               answerText: "Test subquestion answer"
             }
-          }
+          },
+          answerText: "[Level: 1] Test subquestion answer"
         });
       });
     });

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -43,6 +43,10 @@ export const phoneListen = (type) => {
     cy.window().then(window => {
       phone.addListener(type, newState => {
         window.receivedMessage = newState;
+        if (!window.receivedMessages) {
+          window.receivedMessages = [];
+        }
+        window.receivedMessages.push(newState);
       });
     });
   });
@@ -56,5 +60,18 @@ export const getAndClearLastPhoneMessage = (callback) => {
     // Important - clear message so when getAndClearLastPhoneMessage is called again, it can wait for a new one
     // (using cy.window().should("have.property", "receivedMessage") call above) instead of returning stale message.
     delete window.receivedMessage;
+    delete window.receivedMessages;
+  });
+};
+
+export const getAndClearAllPhoneMessage = (callback) => {
+  // This will wait until window.receivedMessages is defined.
+  cy.window().should("have.property", "receivedMessages");
+  cy.window().then(window => {
+    callback(window.receivedMessages);
+    // Important - clear message so when getAndClearAllPhoneMessage is called again, it can wait for a new one
+    // (using cy.window().should("have.property", "receivedMessages") call above) instead of returning stale message.
+    delete window.receivedMessage;
+    delete window.receivedMessages;
   });
 };

--- a/src/image/components/runtime.tsx
+++ b/src/image/components/runtime.tsx
@@ -3,6 +3,7 @@ import { IAuthoredState } from "./app";
 import { setSupportedFeatures, showModal } from "@concord-consortium/lara-interactive-api";
 import ReactDOMServer from "react-dom/server";
 import { v4 as uuidv4 } from "uuid";
+import { log } from "@concord-consortium/lara-interactive-api";
 import css from "./runtime.scss";
 import ZoomIcon from "../../shared/icons/zoom.svg";
 
@@ -42,7 +43,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, report }) => {
   };
 
   const handleClick = () => {
-    const { url, highResUrl, credit, caption, creditLink } = authoredState;
+    const { url, highResUrl, credit, caption } = authoredState;
     const size = imageSize.current?.width && imageSize.current?.height
                   ? { width: imageSize.current.width, height: imageSize.current.height }
                   : undefined;
@@ -52,6 +53,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, report }) => {
     const title = `<strong>${caption || ""}</strong> <em>${credit || ""}</em> ${ReactDOMServer.renderToString(getCreditLink() || <span/>)}`;
     modalImageUrl && showModal({ uuid, type: "lightbox", url: modalImageUrl,
                         isImage: true, size, allowUpscale, title });
+    log("image zoomed in", { url });
   }
 
   const getCreditLink = () => {

--- a/src/multiple-choice/components/runtime.test.tsx
+++ b/src/multiple-choice/components/runtime.test.tsx
@@ -47,10 +47,10 @@ describe("Runtime", () => {
     const wrapper = shallow(<Runtime authoredState={authoredState} interactiveState={interactiveState} setInteractiveState={setState} />);
     wrapper.find("input[value='id1']").simulate("change", { target: { checked: true } });
     let newState = setState.mock.calls[0][0](interactiveState);
-    expect(newState).toEqual({answerType: "multiple_choice_answer", selectedChoiceIds: ["id1"]});
+    expect(newState).toEqual({answerType: "multiple_choice_answer", selectedChoiceIds: ["id1"], answerText: "Choice A"});
     wrapper.find("input[value='id2']").simulate("change", { target: { checked: true } });
     newState = setState.mock.calls[1][0](interactiveState);
-    expect(newState).toEqual({answerType: "multiple_choice_answer", selectedChoiceIds: ["id2"]});
+    expect(newState).toEqual({answerType: "multiple_choice_answer", selectedChoiceIds: ["id2"], answerText: "Choice B"});
   });
 
   it("calls setInteractiveState when user selects an answer - multiple answers enabled", () => {
@@ -58,12 +58,12 @@ describe("Runtime", () => {
     const wrapper = shallow(<Runtime authoredState={Object.assign({}, authoredState, {multipleAnswers: true})} interactiveState={interactiveState} setInteractiveState={setState}/>);
     wrapper.find("input[value='id1']").simulate("change", { target: { checked: true } });
     let newState = setState.mock.calls[0][0](interactiveState);
-    expect(newState).toEqual({answerType: "multiple_choice_answer", selectedChoiceIds: ["id2", "id1"]});
+    expect(newState).toEqual({answerType: "multiple_choice_answer", selectedChoiceIds: ["id2", "id1"], answerText: "Choice B, Choice A"});
     // Note that correct state below is an empty array. This is a controlled component, it doesn't have its own state,
     // so the previous click didn't really update interactiveState for it. We're just unchecking initially checked "id2".
     wrapper.find("input[value='id2']").simulate("change", { target: { checked: false } });
     newState = setState.mock.calls[1][0](interactiveState);
-    expect(newState).toEqual({answerType: "multiple_choice_answer", selectedChoiceIds: []});
+    expect(newState).toEqual({answerType: "multiple_choice_answer", selectedChoiceIds: [], answerText: ""});
   });
 
   describe("report mode", () => {
@@ -135,7 +135,7 @@ describe("Runtime", () => {
       expect(wrapper.find("select").props().value).toEqual("id2");
       wrapper.find('select').simulate('change', {target: {value : "id1"}});
       const newState = setState.mock.calls[0][0](interactiveState);
-      expect(newState).toEqual({answerType: "multiple_choice_answer", selectedChoiceIds: ["id1"]});
+      expect(newState).toEqual({answerType: "multiple_choice_answer", selectedChoiceIds: ["id1"], answerText: "Choice A"});
     });
 
     describe("report mode", () => {

--- a/src/multiple-choice/components/runtime.tsx
+++ b/src/multiple-choice/components/runtime.tsx
@@ -5,6 +5,7 @@ import CheckIcon from "../../shared/icons/correct.svg";
 import CrossIcon from "../../shared/icons/incorrect.svg";
 import css from "./runtime.scss";
 import buttonCss from "../../shared/styles/helpers.scss";
+import { log } from "@concord-consortium/lara-interactive-api";
 
 const DEFAULT_INCORRECT = "Sorry, that is incorrect.";
 const DEFAULT_CORRECT = "Yes! You are correct.";
@@ -35,6 +36,16 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     // Question can be scored if it has at least one correct answer defined.
   const isScorable = !!authoredState.choices && authoredState.choices.filter(c => c.correct).length > 0;
 
+  const getAnswerText = (choiceIds: string[]) => {
+    return choiceIds.map(choiceId => {
+      const choice = authoredState.choices.find(c => c.id === choiceId);
+      if (!choice) {
+        return "";
+      }
+      return choice.correct ? `(correct) ${choice.content}` : choice.content;
+    }).join(", ");
+  };
+
   const handleRadioCheckChange = (choiceId: string, event: React.ChangeEvent<HTMLInputElement>) => {
     const checked = event.target.checked;
     let newChoices: string[];
@@ -52,13 +63,23 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
         newChoices.splice(currentIdx, 1);
       }
     }
-    setInteractiveState?.(prevState => ({...prevState, answerType: "multiple_choice_answer", selectedChoiceIds: newChoices }));
+    setInteractiveState?.(prevState => ({
+      ...prevState,
+      answerType: "multiple_choice_answer",
+      selectedChoiceIds: newChoices,
+      answerText: getAnswerText(newChoices)
+    }));
     setShowAnswerFeedback(false);
   };
 
   const handleSelectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const newChoice = [ event.target.value ];
-    setInteractiveState?.(prevState => ({...prevState, answerType: "multiple_choice_answer", selectedChoiceIds: newChoice }));
+    setInteractiveState?.(prevState => ({
+      ...prevState,
+      answerType: "multiple_choice_answer",
+      selectedChoiceIds: newChoice,
+      answerText: getAnswerText(newChoice)
+    }));
     setShowAnswerFeedback(false);
   };
 
@@ -156,7 +177,10 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
 
   const layout = authoredState.layout || "vertical";
   const isAnswered = !!interactiveState?.selectedChoiceIds?.length;
-  const handleShowAnswerFeedback = () => setShowAnswerFeedback(!showAnswerFeedback);
+  const handleShowAnswerFeedback = () => {
+    setShowAnswerFeedback(!showAnswerFeedback);
+    log("answer feedback shown");
+  }
 
   return (
     <div>

--- a/src/scaffolded-question/components/app.tsx
+++ b/src/scaffolded-question/components/app.tsx
@@ -103,5 +103,11 @@ export const App = () => (
     Runtime={Runtime}
     baseAuthoringProps={baseAuthoringProps}
     disableSubmitBtnRendering={true}
+    // Disable default focus in, focus out and answer saved events logging. Scaffolded Question Runtime
+    // listens to subquestion logs and passes them to LARA (adding some context info). Logging answer text second time
+    // from the parent question creates more confusing event stream. Also, focus in and out events don't work too
+    // well, as iframe is not treated as input. So default focus in and out would be only triggered if user used
+    // hint or submit buttons. But these events also make event stream more confusing.
+    disableBasicLogging={true}
   />
 );

--- a/src/scaffolded-question/components/app.tsx
+++ b/src/scaffolded-question/components/app.tsx
@@ -103,11 +103,5 @@ export const App = () => (
     Runtime={Runtime}
     baseAuthoringProps={baseAuthoringProps}
     disableSubmitBtnRendering={true}
-    // Disable default focus in, focus out and answer saved events logging. Scaffolded Question Runtime
-    // listens to subquestion logs and passes them to LARA (adding some context info). Logging answer text second time
-    // from the parent question creates more confusing event stream. Also, focus in and out events don't work too
-    // well, as iframe is not treated as input. So default focus in and out would be only triggered if user used
-    // hint or submit buttons. But these events also make event stream more confusing.
-    disableBasicLogging={true}
   />
 );

--- a/src/scaffolded-question/components/iframe-runtime.tsx
+++ b/src/scaffolded-question/components/iframe-runtime.tsx
@@ -12,6 +12,7 @@ interface ILogRequest {
 
 interface IProps {
   url: string;
+  id: string;
   authoredState: any;
   interactiveState: any;
   setInteractiveState: (state: any) => void;
@@ -20,7 +21,7 @@ interface IProps {
 }
 
 export const IframeRuntime: React.FC<IProps> =
-  ({ url, authoredState, interactiveState, setInteractiveState, report, scaffoldedQuestionLevel }) => {
+  ({ url, id, authoredState, interactiveState, setInteractiveState, report, scaffoldedQuestionLevel }) => {
   const [ iframeHeight, setIframeHeight ] = useState(300);
   const [ hint, setHint ] = useState("");
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -46,7 +47,8 @@ export const IframeRuntime: React.FC<IProps> =
         scaffolded_question_level: scaffoldedQuestionLevel,
         subinteractive_url: url,
         subinteractive_type: authoredState.questionType,
-        subinteractive_sub_type: authoredState.questionSubType
+        subinteractive_sub_type: authoredState.questionSubType,
+        subinteractive_id: id
       });
     });
     phone.post("initInteractive", {

--- a/src/scaffolded-question/components/iframe-runtime.tsx
+++ b/src/scaffolded-question/components/iframe-runtime.tsx
@@ -2,17 +2,25 @@ import React, { useEffect, useRef, useState } from "react";
 import { IframePhone } from "../../shared/types";
 import iframePhone from "iframe-phone";
 import css from "./iframe-runtime.scss";
-import { IHintRequest } from "@concord-consortium/lara-interactive-api";
+import { IHintRequest, log } from "@concord-consortium/lara-interactive-api";
+
+// This should be part of lara-interactive-api
+interface ILogRequest {
+  action: string;
+  data: object;
+}
 
 interface IProps {
   url: string;
   authoredState: any;
   interactiveState: any;
   setInteractiveState: (state: any) => void;
+  scaffoldedQuestionLevel: number;
   report?: boolean;
 }
 
-export const IframeRuntime: React.FC<IProps> = ({ url, authoredState, interactiveState, setInteractiveState, report }) => {
+export const IframeRuntime: React.FC<IProps> =
+  ({ url, authoredState, interactiveState, setInteractiveState, report, scaffoldedQuestionLevel }) => {
   const [ iframeHeight, setIframeHeight ] = useState(300);
   const [ hint, setHint ] = useState("");
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -31,6 +39,15 @@ export const IframeRuntime: React.FC<IProps> = ({ url, authoredState, interactiv
     });
     phone.addListener("hint", (newHint: IHintRequest) => {
       setHint(newHint.text || "");
+    });
+    phone.addListener("log", (logData: ILogRequest) => {
+      log(logData.action, {
+        ...logData.data,
+        scaffolded_question_level: scaffoldedQuestionLevel,
+        subinteractive_url: url,
+        subinteractive_type: authoredState.questionType,
+        subinteractive_sub_type: authoredState.questionSubType
+      });
     });
     phone.post("initInteractive", {
       mode: report ? "report" : "runtime",

--- a/src/scaffolded-question/components/runtime.tsx
+++ b/src/scaffolded-question/components/runtime.tsx
@@ -83,6 +83,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
       { authoredState.prompt && <div>{ authoredState.prompt }</div> }
       <IframeRuntime
         key={currentInteractive.id}
+        id={currentInteractive.id}
         url={currentInteractive.url}
         authoredState={currentInteractive.authoredState}
         interactiveState={subState}

--- a/src/scaffolded-question/components/runtime.tsx
+++ b/src/scaffolded-question/components/runtime.tsx
@@ -5,6 +5,7 @@ import { IAuthoredState } from "./app";
 import { SubmitButton } from "../../shared/components/submit-button";
 import { LockedInfo } from "../../shared/components/locked-info";
 import { useStudentSettings } from "../../shared/hooks/use-student-settings";
+import { log } from "@concord-consortium/lara-interactive-api";
 import css from "./runtime.scss";
 
 interface IProps {
@@ -47,10 +48,18 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   // User can submit answer only if any answer has been provided before.
   const isAnswered = !!subState;
 
+  const getAnswerText = (level: number, subinteractiveAnswerText: string | undefined) =>
+    `[Level: ${level}] ${subinteractiveAnswerText ? subinteractiveAnswerText : "no response"}`;
+
   const handleNewInteractiveState = (interactiveId: string, newInteractiveState: any) => {
     setInteractiveState?.((prevState: IInteractiveState) => {
       const updatedStates = {...prevState?.subinteractiveStates, [interactiveId]: newInteractiveState };
-      return {...prevState, answerType: "interactive_state", subinteractiveStates: updatedStates };
+      return {
+        ...prevState,
+        answerType: "interactive_state",
+        subinteractiveStates: updatedStates,
+        answerText: getAnswerText(currentLevel, newInteractiveState.answerText)
+      };
     });
   };
 
@@ -62,14 +71,15 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
           ...prevState,
           answerType: "interactive_state",
           currentSubinteractiveId: newInteractive.id,
-          answerText: `Hint has been used ${ currentSubintIndex + 1 } times.`
+          answerText: getAnswerText(currentLevel - 1, undefined) // new subinteractive state is not available yet
         };
       });
+      log("hint used", { current_level: currentLevel, new_level: currentLevel - 1,  });
     }
   };
 
   return (
-    <div className={css.runtime}>
+    <div className={css.runtime} tabIndex={1}>
       { authoredState.prompt && <div>{ authoredState.prompt }</div> }
       <IframeRuntime
         key={currentInteractive.id}
@@ -77,6 +87,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
         authoredState={currentInteractive.authoredState}
         interactiveState={subState}
         setInteractiveState={readOnly ? undefined : handleNewInteractiveState.bind(null, currentInteractive.id)}
+        scaffoldedQuestionLevel={currentLevel}
         report={readOnly}
       />
       {

--- a/src/scaffolded-question/components/runtime.tsx
+++ b/src/scaffolded-question/components/runtime.tsx
@@ -74,7 +74,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
           answerText: getAnswerText(currentLevel - 1, undefined) // new subinteractive state is not available yet
         };
       });
-      log("hint used", { current_level: currentLevel, new_level: currentLevel - 1,  });
+      log("scaffolded question hint used", { current_level: currentLevel, new_level: currentLevel - 1,  });
     }
   };
 

--- a/src/shared/components/base-app.tsx
+++ b/src/shared/components/base-app.tsx
@@ -28,12 +28,11 @@ interface IProps<IAuthoredState> {
   baseAuthoringProps?: Omit<IBaseAuthoringProps<IAuthoredState>, "authoredState" | "setAuthoredState">;
   Runtime: React.FC<IRuntimeComponentProps<IAuthoredState>>;
   disableAutoHeight?: boolean;
-  disableBasicLogging?: boolean;
 }
 
 // BaseApp for interactives that don't save interactive state and don't show up in the report. E.g. image, video.
 export const BaseApp = <IAuthoredState extends IBaseAuthoredState>(props: IProps<IAuthoredState>) => {
-  const { Authoring, baseAuthoringProps, Runtime, disableAutoHeight, disableBasicLogging } = props;
+  const { Authoring, baseAuthoringProps, Runtime, disableAutoHeight } = props;
   const container = useRef<HTMLDivElement>(null);
   const { authoredState, setAuthoredState } = useAuthoredState<IAuthoredState>();
   const initMessage = useInitMessage();
@@ -41,7 +40,7 @@ export const BaseApp = <IAuthoredState extends IBaseAuthoredState>(props: IProps
 
   useAutoHeight({ container, disabled: disableAutoHeight });
   useShutterbug({ container: "." + css.runtime });
-  useBasicLogging({ disabled: disableBasicLogging || !isRuntimeView });
+  useBasicLogging({ disabled: !isRuntimeView });
 
   useEffect(() => {
     setSupportedFeatures({

--- a/src/shared/components/base-app.tsx
+++ b/src/shared/components/base-app.tsx
@@ -5,6 +5,7 @@ import { BaseAuthoring, IBaseAuthoringProps } from "./base-authoring";
 import { setSupportedFeatures, useAuthoredState, useInitMessage } from "@concord-consortium/lara-interactive-api";
 
 import css from "./base-app.scss";
+import { useBasicLogging } from "../hooks/use-basic-logging";
 
 export type UpdateFunc<State> = (prevState: State | null) => State;
 
@@ -27,17 +28,20 @@ interface IProps<IAuthoredState> {
   baseAuthoringProps?: Omit<IBaseAuthoringProps<IAuthoredState>, "authoredState" | "setAuthoredState">;
   Runtime: React.FC<IRuntimeComponentProps<IAuthoredState>>;
   disableAutoHeight?: boolean;
+  disableBasicLogging?: boolean;
 }
 
 // BaseApp for interactives that don't save interactive state and don't show up in the report. E.g. image, video.
 export const BaseApp = <IAuthoredState extends IBaseAuthoredState>(props: IProps<IAuthoredState>) => {
-  const { Authoring, baseAuthoringProps, Runtime, disableAutoHeight } = props;
+  const { Authoring, baseAuthoringProps, Runtime, disableAutoHeight, disableBasicLogging } = props;
   const container = useRef<HTMLDivElement>(null);
   const { authoredState, setAuthoredState } = useAuthoredState<IAuthoredState>();
   const initMessage = useInitMessage();
+  const isRuntimeView = initMessage?.mode === "runtime";
 
   useAutoHeight({ container, disabled: disableAutoHeight });
   useShutterbug({ container: "." + css.runtime });
+  useBasicLogging({ disabled: disableBasicLogging || !isRuntimeView });
 
   useEffect(() => {
     setSupportedFeatures({

--- a/src/shared/components/base-question-app.tsx
+++ b/src/shared/components/base-question-app.tsx
@@ -39,13 +39,12 @@ interface IProps<IAuthoredState, IInteractiveState> {
   disableSubmitBtnRendering?: boolean;
   // Note that isAnswered is required when `disableSubmitBtnRendering` is false.
   isAnswered?: (state: IInteractiveState | null) => boolean;
-  disableBasicLogging?: boolean;
 }
 
 // BaseApp for interactives that save interactive state and show in the report. E.g. open response, multiple choice.
 export const BaseQuestionApp = <IAuthoredState extends IAuthoringMetadata & IBaseQuestionAuthoredState,
   IInteractiveState extends IRuntimeMetadata & IBaseQuestionInteractiveState>(props: IProps<IAuthoredState, IInteractiveState>) => {
-  const { Authoring, baseAuthoringProps, Runtime, isAnswered, disableAutoHeight, disableSubmitBtnRendering, disableBasicLogging } = props;
+  const { Authoring, baseAuthoringProps, Runtime, isAnswered, disableAutoHeight, disableSubmitBtnRendering } = props;
   const container = useRef<HTMLDivElement>(null);
   const { authoredState, setAuthoredState } = useAuthoredState<IAuthoredState>();
   const { interactiveState, setInteractiveState } = useInteractiveState<IInteractiveState>();
@@ -56,7 +55,7 @@ export const BaseQuestionApp = <IAuthoredState extends IAuthoringMetadata & IBas
   useHint();
   useRequiredQuestion();
   useShutterbug({ container: "." + css.runtime });
-  useBasicLogging({ disabled: disableBasicLogging || !isRuntimeView });
+  useBasicLogging({ disabled: !isRuntimeView });
 
   useEffect(() => {
     setSupportedFeatures({

--- a/src/shared/components/base-question-app.tsx
+++ b/src/shared/components/base-question-app.tsx
@@ -56,13 +56,7 @@ export const BaseQuestionApp = <IAuthoredState extends IAuthoringMetadata & IBas
   useHint();
   useRequiredQuestion();
   useShutterbug({ container: "." + css.runtime });
-  const logging = useBasicLogging({ disabled: disableBasicLogging || !isRuntimeView });
-
-  const setInteractiveStateWithLogging = (updateFunc: UpdateFunc<IInteractiveState>) => {
-    setInteractiveState(updateFunc);
-    // Notify logging helper that answer has been updated by user. Only then it'll be logged on blur.
-    logging.onAnswerUpdate(updateFunc(interactiveState).answerText);
-  };
+  useBasicLogging({ disabled: disableBasicLogging || !isRuntimeView });
 
   useEffect(() => {
     setSupportedFeatures({
@@ -90,7 +84,7 @@ export const BaseQuestionApp = <IAuthoredState extends IAuthoringMetadata & IBas
     }
     return (
       <div className={css.runtime}>
-        <Runtime authoredState={authoredState} interactiveState={interactiveState} setInteractiveState={setInteractiveStateWithLogging} />
+        <Runtime authoredState={authoredState} interactiveState={interactiveState} setInteractiveState={setInteractiveState} />
         {
           !disableSubmitBtnRendering &&
           <div>

--- a/src/shared/components/submit-button.tsx
+++ b/src/shared/components/submit-button.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import LockIcon from "../icons/lock.svg";
-import { useAuthoredState, useInteractiveState } from "@concord-consortium/lara-interactive-api";
+import { log, useAuthoredState, useInteractiveState } from "@concord-consortium/lara-interactive-api";
 import css from "../styles/helpers.scss";
 
 interface IProps {
@@ -11,7 +11,7 @@ interface IProps {
 // `submitted` property in its interactive state (student state).
 export const SubmitButton: React.FC<IProps> = ({ isAnswered }) => {
   const { authoredState } = useAuthoredState<{ required?: boolean }>();
-  const { interactiveState, setInteractiveState } = useInteractiveState<{ submitted?: boolean }>();
+  const { interactiveState, setInteractiveState } = useInteractiveState<{ submitted?: boolean, answerText?: string }>();
 
   if (!authoredState?.required || interactiveState?.submitted) {
     // Question is not required or has been already submitted.
@@ -20,6 +20,7 @@ export const SubmitButton: React.FC<IProps> = ({ isAnswered }) => {
 
   const handleSubmit = () => {
     setInteractiveState?.(prevState => ({...prevState, submitted: true }));
+    log("answer submitted", { answer_text: interactiveState?.answerText });
   };
 
   return (

--- a/src/shared/hooks/use-basic-logging.test.ts
+++ b/src/shared/hooks/use-basic-logging.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from "@testing-library/react-hooks";
-import { useBasicLogging, INTERSECTION_DELAY } from "./use-basic-logging";
+import { useBasicLogging, _setIntersectionDelay } from "./use-basic-logging";
 import { log } from "@concord-consortium/lara-interactive-api";
 
 jest.mock("@concord-consortium/lara-interactive-api", () => ({
@@ -43,6 +43,11 @@ let intersectionObserverCallback: any = null;
     disconnect: intersectionObserverDisconnect
   } as any as IntersectionObserver;
 };
+
+// Speed up tests.
+const intersectionObserverDelay = 1;
+_setIntersectionDelay(intersectionObserverDelay);
+
 
 describe("useBasicLogging", () => {
   beforeEach(() => {
@@ -107,7 +112,7 @@ describe("useBasicLogging", () => {
       expect(intersectionObserverDisconnect).toHaveBeenCalled();
 
       done();
-    }, INTERSECTION_DELAY + 1);
+    }, intersectionObserverDelay + 1);
   });
 
 

--- a/src/shared/hooks/use-basic-logging.test.ts
+++ b/src/shared/hooks/use-basic-logging.test.ts
@@ -1,0 +1,91 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { useBasicLogging } from "./use-basic-logging";
+import { log } from "@concord-consortium/lara-interactive-api";
+
+jest.mock("@concord-consortium/lara-interactive-api", () => ({
+  log: jest.fn()
+}));
+
+const logMock = log as jest.Mock;
+
+const input = document.createElement("input");
+document.body.append(input);
+
+const triggerFocusIn = () => {
+  // focus() doesn't work in JSDOM.
+  const event = new FocusEvent("focusin", { bubbles: true });
+  input.dispatchEvent(event);
+};
+
+const triggerFocusOut = () => {
+  // blur() doesn't work in JSDOM.
+  const event = new FocusEvent("focusout", { bubbles: true });
+  input.dispatchEvent(event);
+};
+
+describe("useBasicLogging", () => {
+  beforeEach(() => {
+    logMock.mockClear();
+  });
+
+  it("should log focusin and focusout, and cleanup event listeners on unmount", () => {
+    const HookWrapper = () => {
+      return useBasicLogging();
+    }
+    const { unmount } = renderHook(HookWrapper);
+
+    triggerFocusIn();
+    expect(logMock).toHaveBeenCalledTimes(1);
+    expect(logMock).toHaveBeenCalledWith("focus in", { focus_target: "input" });
+
+    triggerFocusOut();
+    expect(logMock).toHaveBeenCalledTimes(2);
+    expect(logMock).toHaveBeenCalledWith("focus out");
+
+    unmount();
+    triggerFocusIn();
+    triggerFocusOut();
+    expect(logMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("should log an answerText on focusout event if answer has been updated", () => {
+    const HookWrapper = () => {
+      return useBasicLogging();
+    }
+    const { unmount, result } = renderHook(HookWrapper);
+    triggerFocusOut();
+    // "focus out" only, no "answer saved"
+    expect(logMock).toHaveBeenCalledTimes(1);
+    expect(logMock.mock.calls[0][0]).toEqual("focus out");
+
+    logMock.mockClear();
+    result.current.onAnswerUpdate("test answer");
+    triggerFocusOut();
+    expect(logMock).toHaveBeenCalledTimes(2);
+    expect(logMock).toHaveBeenCalledWith("answer saved", {answer_text: "test answer"});
+
+    logMock.mockClear();
+    triggerFocusOut();
+    // "focus out" only, no "answer saved"
+    expect(logMock).toHaveBeenCalledTimes(1);
+    expect(logMock.mock.calls[0][0]).toEqual("focus out");
+
+    logMock.mockClear();
+    unmount();
+    result.current.onAnswerUpdate("test answer");
+    triggerFocusOut();
+    // no logs after unmount.
+    expect(logMock).toHaveBeenCalledTimes(0);
+  });
+
+  it("shouldn't do anything when it's disabled", () => {
+    const HookWrapper = () => {
+      return useBasicLogging({ disabled: true });
+    }
+    renderHook(HookWrapper);
+    triggerFocusIn();
+    expect(logMock).toHaveBeenCalledTimes(0);
+    triggerFocusOut();
+    expect(logMock).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/shared/hooks/use-basic-logging.ts
+++ b/src/shared/hooks/use-basic-logging.ts
@@ -7,12 +7,16 @@ interface IConfig {
 
 // Threshold used by IntersectionObserver to log when element scrolls into view. 0.8 means that event will be logged
 // when 80% of the question container is scrolled into viewport.
-export const INTERSECTION_THRESHOLD = 0.8;
+export const intersectionThreshold = 0.8;
 // Delay observing intersection. Otherwise lots of events will be triggered at the beginning when the page is still
 // loading and interactives are resizing. When IntersectionObserver starts observing, it triggers callback with
 // the initial state. So, researchers will have access to the initial visibility anyway and no info should be lost.
-// Don't use delay in Node.js / test environment.
-export const INTERSECTION_DELAY = typeof process === "undefined" ? 6000 : 1; // ms
+export let intersectionDelay = 6000; // ms
+
+// Useful in test environment.
+export const _setIntersectionDelay = (value: number) => {
+  intersectionDelay = value;
+};
 
 export const useBasicLogging = (options?: IConfig) => {
   const disabled = options?.disabled;
@@ -58,18 +62,19 @@ export const useBasicLogging = (options?: IConfig) => {
         log(entries[0].isIntersecting ? "scrolled into view" : "scrolled out of view");
       }
     }, {
-      threshold: INTERSECTION_THRESHOLD
+      threshold: intersectionThreshold
     });
     // Delay observing intersection. Otherwise lots of events will be triggered at the beginning when the page is still
     // loading and interactives are resizing. When IntersectionObserver starts observing, it triggers callback with
     // the initial state. So, researchers will have access to the initial visibility anyway and no info should be lost.
-    setTimeout(() => {
+    const timeoutId = window.setTimeout(() => {
       observer.observe(window.document.body);
-    }, INTERSECTION_DELAY);
+    }, intersectionDelay);
 
     return () => {
       window.removeEventListener("focusin", focusIn);
       window.removeEventListener("focusout", focusOut);
+      window.clearTimeout(timeoutId);
       observer.disconnect();
     }
   }, [disabled]);

--- a/src/shared/hooks/use-basic-logging.ts
+++ b/src/shared/hooks/use-basic-logging.ts
@@ -15,22 +15,26 @@ export const useBasicLogging = (options?: IConfig) => {
     }
 
     const focusIn = (e: FocusEvent) => {
-      // event.relatedTarget === null means that user is most likely coming from outer window, and not changing focus
-      // within the interactive iframe (eg clicking various buttons). We want to log only "main" focus event.
-      if (!e.relatedTarget) {
-        log("focus in", { focus_target: (e.target as HTMLElement).tagName.toLowerCase() });
-      }
+      const target = (e.target as HTMLInputElement);
+      log("focus in", {
+        target_element: target.tagName.toLowerCase(),
+        target_id: target.id,
+        target_name: target.name,
+        target_value: target.value
+      });
     };
     const focusOut = (e: FocusEvent) => {
-      // event.relatedTarget === null means that user is most likely leaving to outer window, and not changing focus
-      // within the interactive iframe (eg clicking various buttons). We want to log only "main" blur event.
-      if (!e.relatedTarget) {
-        log("focus out");
-        if (answerToLog.current !== undefined) {
-          // LARA uses "answer saved" message for its basic questions too.
-          log("answer saved", { answer_text: answerToLog.current });
-          answerToLog.current = undefined;
-        }
+      const target = (e.target as HTMLInputElement);
+      log("focus out", {
+        target_element: target.tagName.toLowerCase(),
+        target_id: target.id,
+        target_name: target.name,
+        target_value: target.value
+      });
+      if (answerToLog.current !== undefined) {
+        // LARA uses "answer saved" message for its basic questions too.
+        log("answer saved", { answer_text: answerToLog.current });
+        answerToLog.current = undefined;
       }
     };
     // Note that difference between focusin/focusout and focus/blur is that focusin/focusout bubbles

--- a/src/shared/hooks/use-basic-logging.ts
+++ b/src/shared/hooks/use-basic-logging.ts
@@ -5,7 +5,8 @@ interface IConfig {
   disabled?: boolean;
 }
 
-export const useBasicLogging = ({ disabled }: IConfig) => {
+export const useBasicLogging = (options?: IConfig) => {
+  const disabled = options?.disabled;
   const answerToLog = useRef<string | undefined>(undefined);
 
   useEffect(() => {
@@ -32,6 +33,8 @@ export const useBasicLogging = ({ disabled }: IConfig) => {
         }
       }
     };
+    // Note that difference between focusin/focusout and focus/blur is that focusin/focusout bubbles
+    // while focus/blur does not.
     window.addEventListener("focusin", focusIn);
     window.addEventListener("focusout", focusOut);
     return () => {

--- a/src/shared/hooks/use-basic-logging.ts
+++ b/src/shared/hooks/use-basic-logging.ts
@@ -20,6 +20,7 @@ export const useBasicLogging = (options?: IConfig) => {
       const target = (e.target as HTMLInputElement);
       log("focus in", {
         target_element: target.tagName.toLowerCase(),
+        target_type: target.type,
         target_id: target.id,
         target_name: target.name,
         target_value: target.value
@@ -29,6 +30,7 @@ export const useBasicLogging = (options?: IConfig) => {
       const target = (e.target as HTMLInputElement);
       log("focus out", {
         target_element: target.tagName.toLowerCase(),
+        target_type: target.type,
         target_id: target.id,
         target_name: target.name,
         target_value: target.value,

--- a/src/shared/hooks/use-basic-logging.ts
+++ b/src/shared/hooks/use-basic-logging.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from "react";
+import { log } from "@concord-consortium/lara-interactive-api";
+
+interface IConfig {
+  disabled?: boolean;
+}
+
+export const useBasicLogging = ({ disabled }: IConfig) => {
+  const answerToLog = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (disabled) {
+      return;
+    }
+
+    const focusIn = (e: FocusEvent) => {
+      // event.relatedTarget === null means that user is most likely coming from outer window, and not changing focus
+      // within the interactive iframe (eg clicking various buttons). We want to log only "main" focus event.
+      if (!e.relatedTarget) {
+        log("focus in", { focus_target: (e.target as HTMLElement).tagName.toLowerCase() });
+      }
+    };
+    const focusOut = (e: FocusEvent) => {
+      // event.relatedTarget === null means that user is most likely leaving to outer window, and not changing focus
+      // within the interactive iframe (eg clicking various buttons). We want to log only "main" blur event.
+      if (!e.relatedTarget) {
+        log("focus out");
+        if (answerToLog.current !== undefined) {
+          // LARA uses "answer saved" message for its basic questions too.
+          log("answer saved", { answer_text: answerToLog.current });
+          answerToLog.current = undefined;
+        }
+      }
+    };
+    window.addEventListener("focusin", focusIn);
+    window.addEventListener("focusout", focusOut);
+    return () => {
+      window.removeEventListener("focusin", focusIn);
+      window.removeEventListener("focusout", focusOut);
+    }
+  }, [disabled]);
+
+  return {
+    onAnswerUpdate: (newAnswer: string | undefined) => {
+      answerToLog.current = newAnswer;
+    }
+  }
+};

--- a/src/video-player/components/runtime.tsx
+++ b/src/video-player/components/runtime.tsx
@@ -2,7 +2,7 @@ import React, { useRef, useEffect, useState } from "react";
 import videojs from "video.js";
 import { IAuthoredState } from "./app";
 import { IInteractiveState } from "./app";
-import { setSupportedFeatures } from "@concord-consortium/lara-interactive-api";
+import { setSupportedFeatures, log } from "@concord-consortium/lara-interactive-api";
 import css from "./runtime.scss";
 import "./video-js.css";
 
@@ -107,7 +107,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     return player;
   };
 
-  const handlePlaying = (e: any) => {
+  const handlePlaying = () => {
     setHasStartedPlayback(true);
     // store current playback progress each second
     if (Math.trunc(getViewTime()) > saveStateInterval.current) {
@@ -116,8 +116,15 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     }
   };
 
-  const handleStop = (e: any) => {
+  const handlePlay = () => {
+    const percentageViewed = getViewPercentage();
+    log("video started", { videoUrl: authoredState.videoUrl, percentage_viewed: percentageViewed });
+  }
+
+  const handleStop = () => {
     updateState();
+    const percentageViewed = getViewPercentage();
+    log("video stopped", { video_url: authoredState.videoUrl, percentage_viewed: percentageViewed });
   };
 
   const updateState = () => {
@@ -144,10 +151,12 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
       { authoredState.prompt && <div className={css.prompt}>{ authoredState.prompt }</div> }
       <div className={`${css.videoPlayerContainer} last-viewed${viewedTimestamp}`}>
         <div className="video-player" data-vjs-player={true}>
-          <video ref={playerRef} className="video-js vjs-big-play-centered vjs-fluid"
+          <video
+            ref={playerRef}
+            className="video-js vjs-big-play-centered vjs-fluid"
             poster={getPoster()}
             onTimeUpdate={readOnly ? undefined : handlePlaying}
-            onEnded={readOnly ? undefined : handleStop}
+            onPlay={handlePlay}
             onPause={readOnly ? undefined : handleStop}
             controls={!readOnly}
           />


### PR DESCRIPTION
I've added `useBaseLogging` and used it in `BaseQuestionApp` and `BaseApp`. So, every interactive will log by default:
- "focus in", focus_target: ...
- "focus out"
- "answer saved", answer_text: ... IF interactive specifies `answerText`, sent on focus out event
This is what LARA used to log. Additionally, new interactives will also log:
- "answer submitted", answer_text: ... IF interactive specifies `answerText` and uses submit button

That's why I changed answerText of Scaoffolded Question to be more informative and added answerText to MC question.

Scaffolded question:
It doesn't use base logging, as it didn't work too well. There's a comment in the code explaining this - most of the input elements are inside iframe, so focus in/out events aren't detected. They can only come from button click, but then the event stream looks confusing. So, it forwards logs from subquestion and adds extra info like current level, subinteractive_url, subinteractive_type, subinteractive_sub_type. Plus, it uses default Submit button logging, and a hint button click is logged too.

Additional / custom events in other interactives:
- "video started", video_url: ..., percentage_viewed: ...
- "video stopped", video_url: ..., percentage_viewed: ...
- "image zoomed in", url: ...

There are Jest tests of the hook and Cypress test of Scaffolded Question logging.
 
