### PR TITLE
Fix layout of vertical multiple choice answers

### DIFF
--- a/src/multiple-choice/components/runtime.scss
+++ b/src/multiple-choice/components/runtime.scss
@@ -16,6 +16,12 @@ legend.prompt {     // clear bootstrap stuff
     margin: 4px 10px 0 5px;
   }
 
+  &.vertical {
+    div {
+      display: flex;
+    }
+  }
+
   &.horizontal {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
This just adds a flex layout to the input+label of vertical multiple choice answers, to ensure that a long answer remains to the right of the checkbox.

No test for it, but the screenshot shows the change (new version at the bottom).

<img width="589" alt="Screen Shot 2020-06-29 at 10 06 12 AM" src="https://user-images.githubusercontent.com/35721/86015950-36267100-b9f0-11ea-974d-4bb402a69764.png">
