### PR TITLE
Add IntersectionObserver polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8497,6 +8497,11 @@
       "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
       "dev": true
     },
+    "intersection-observer": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.11.0.tgz",
+      "integrity": "sha512-KZArj2QVnmdud9zTpKf279m2bbGfG+4/kn16UU0NL3pTVl52ZHiJ9IRNSsnn6jaHrL9EGLFM5eWjTx2fz/+zoQ=="
+    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "deep-equal": "^2.0.3",
     "firebase": "^7.15.2",
     "iframe-phone": "^1.2.1",
+    "intersection-observer": "^0.11.0",
     "jquery": "^3.5.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/src/shared/hooks/use-basic-logging.test.ts
+++ b/src/shared/hooks/use-basic-logging.test.ts
@@ -32,6 +32,9 @@ const triggerFocusOut = () => {
   input.dispatchEvent(event);
 };
 
+// IntersectionObserver is undefined in JSDOM.
+// However, we should include polyfill for Safari < v12.1. So, this line tests nicely if polyfill works.
+expect(window.IntersectionObserver).toBeDefined();
 // Mock IntersectionObserver
 const intersectionObserverObserve = jest.fn();
 const intersectionObserverDisconnect = jest.fn();

--- a/src/shared/hooks/use-basic-logging.ts
+++ b/src/shared/hooks/use-basic-logging.ts
@@ -1,3 +1,4 @@
+import "intersection-observer"; // polyfill, mostly to support Safari < v12.1
 import { useEffect, useRef } from "react";
 import { log, useInteractiveState } from "@concord-consortium/lara-interactive-api";
 


### PR DESCRIPTION
[#173348260]

Its code looks good:
https://github.com/w3c/IntersectionObserver/blob/master/polyfill/intersection-observer.js#L12-L34
There's early exit if IntersectionObserver is defined, so it shouldn't have any impact on browsers that do support it. It's written by Google, under w3c org, and pretty popular, so it seems it might be worth adding it.
