### PR TITLE
Change rendering of credit links on images in lightbox

### DIFF
--- a/src/image/components/runtime.tsx
+++ b/src/image/components/runtime.tsx
@@ -50,21 +50,26 @@ export const Runtime: React.FC<IProps> = ({ authoredState, report }) => {
     const allowUpscale = authoredState.scaling === "fitWidth";
     const modalImageUrl = highResUrl || url;
     const uuid = uuidv4();
-    const title = `<strong>${caption || ""}</strong> <em>${credit || ""}</em> ${ReactDOMServer.renderToString(getCreditLink() || <span/>)}`;
+    const title = `<strong>${caption || ""}</strong> <em>${credit || ""}</em> ${ReactDOMServer.renderToString(getCreditLink(false) || <span/>)}`;
     modalImageUrl && showModal({ uuid, type: "lightbox", url: modalImageUrl,
                         isImage: true, size, allowUpscale, title });
     log("image zoomed in", { url });
   };
 
-  const getCreditLink = () => {
+  const getCreditLink = (displayBlock = true) => {
     const { creditLink, creditLinkDisplayText } = authoredState;
-    return creditLink && (
-      <div className={css.creditLink}>
-        <a href={creditLink} target="_blank" rel="noreferrer noopener">
-          {creditLinkDisplayText || creditLink}
-        </a>
-      </div>
-    );
+    const link = <a href={creditLink} target="_blank" rel="noreferrer noopener">
+                  {creditLinkDisplayText || creditLink}
+                </a>
+    if (displayBlock === true) {
+      return creditLink && (
+        <div className={css.creditLink}>
+          {link}
+        </div>
+      )
+    } else {
+      return creditLink && link
+    }
   };
 
   return (

--- a/src/image/components/runtime.tsx
+++ b/src/image/components/runtime.tsx
@@ -59,16 +59,16 @@ export const Runtime: React.FC<IProps> = ({ authoredState, report }) => {
   const getCreditLink = (displayBlock = true) => {
     const { creditLink, creditLinkDisplayText } = authoredState;
     const link = <a href={creditLink} target="_blank" rel="noreferrer noopener">
-                  {creditLinkDisplayText || creditLink}
-                </a>
+      {creditLinkDisplayText || creditLink}
+    </a>;
     if (displayBlock) {
       return creditLink && (
         <div className={css.creditLink}>
           {link}
         </div>
-      )
+      );
     } else {
-      return creditLink && link
+      return creditLink && link;
     }
   };
 

--- a/src/image/components/runtime.tsx
+++ b/src/image/components/runtime.tsx
@@ -61,7 +61,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, report }) => {
     const link = <a href={creditLink} target="_blank" rel="noreferrer noopener">
                   {creditLinkDisplayText || creditLink}
                 </a>
-    if (displayBlock === true) {
+    if (displayBlock) {
       return creditLink && (
         <div className={css.creditLink}>
           {link}


### PR DESCRIPTION
Tweak the rendering so that images that are in the lightbox have all text on one line