### PR TITLE
Demo: Image sizing tweaks and documentation

### DIFF
--- a/src/image/components/app.tsx
+++ b/src/image/components/app.tsx
@@ -127,6 +127,6 @@ export const App = () => (
   <BaseApp<IAuthoredState>
     Runtime={Runtime}
     baseAuthoringProps={baseAuthoringProps}
-    disableAutoHeight={false}
+    disableAutoHeight={true}
   />
 );

--- a/src/image/components/runtime.test.tsx
+++ b/src/image/components/runtime.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import { shallow } from "enzyme";
 import { Runtime } from "./runtime";
 import { IAuthoredState } from "./app";
@@ -31,7 +31,8 @@ const naturalWidthImageAuthoredState: IAuthoredState = {
 
 describe("Runtime", () => {
   it("renders image and all other supplied fields", () => {
-    const wrapper = shallow(<Runtime authoredState={authoredState} />);
+    const container = useRef<HTMLDivElement>(document.createElement("div"));
+    const wrapper = shallow(<Runtime authoredState={authoredState} baseContainer={container}/>);
 
     expect(wrapper.text()).toEqual(expect.stringContaining("Image showing the CC Logo"));
     expect(wrapper.text()).toEqual(expect.stringContaining("Copyright Concord Consortium"));
@@ -43,7 +44,8 @@ describe("Runtime", () => {
 
   });
   it("renders image at native resolution when specified", () => {
-    const wrapper = shallow(<Runtime authoredState={naturalWidthImageAuthoredState} />);
+    const container = useRef<HTMLDivElement>(document.createElement("div"));
+    const wrapper = shallow(<Runtime authoredState={naturalWidthImageAuthoredState} baseContainer={container}/>);
 
     expect(wrapper.find("img").at(0).hasClass(css.originalDimensions));
 

--- a/src/image/components/runtime.tsx
+++ b/src/image/components/runtime.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useRef, RefObject } from "react";
 import { IAuthoredState } from "./app";
 import { setSupportedFeatures, showModal } from "@concord-consortium/lara-interactive-api";
 import ReactDOMServer from "react-dom/server";
@@ -6,9 +6,11 @@ import { v4 as uuidv4 } from "uuid";
 import { log } from "@concord-consortium/lara-interactive-api";
 import css from "./runtime.scss";
 import ZoomIcon from "../../shared/icons/zoom.svg";
+import { useAutoHeight } from "../../shared/hooks/use-auto-height";
 
 interface IProps {
   authoredState: IAuthoredState;
+  baseContainer: RefObject<HTMLDivElement>;
   report?: boolean;
 }
 
@@ -17,9 +19,22 @@ interface IImageSize {
   height: number;
 }
 
-export const Runtime: React.FC<IProps> = ({ authoredState, report }) => {
+export const Runtime: React.FC<IProps> = ({ authoredState, baseContainer, report }) => {
 
   const imageSize = useRef<IImageSize>();
+
+  const creditTextContainer = useRef<HTMLDivElement>(null);
+
+  // We've disabled the autoHeight hook provided by the base app
+  // When the scaling is fitWidth then the image change its size based on the
+  // width of the container, so we should use LARA aspect raio setting. This
+  // way the image's width and height will be limited so the whole thing shows
+  // within the viewport.
+  // When the scaling is originalDimensions then it is best to use autoHeight
+  // because the height of the interactive is fixed based on the image height
+  // the image does not resize in this case so this is perfect for using LARA's
+  // height option
+  useAutoHeight({ container: baseContainer, disabled: authoredState.scaling === "fitWidth" });
 
   const getImageLayout = () => {
     switch (authoredState.scaling) {
@@ -33,17 +48,88 @@ export const Runtime: React.FC<IProps> = ({ authoredState, report }) => {
   const getOriginalImageSize = (e: any) => {
     if (e.target && e.target.naturalWidth && e.target.naturalHeight) {
       imageSize.current = { width: e.target.naturalWidth, height: e.target.naturalHeight };
-      const aspectRatio = e.target.naturalWidth / e.target.naturalHeight;
-      setSupportedFeatures({
-        interactiveState: true,
-        authoredState: true,
-        aspectRatio
-      });
+
+      if (authoredState.scaling === "fitWidth") {
+        if (!baseContainer.current) {
+          // FIMXE:
+          // If the image loads before the baseContainer is initialized this will
+          // default to LARA default aspect ratio of 1.3
+          // That will result in a clipped image in most cases.
+          // A better solution would be to delay the execution of this method
+          // until both the image is loaded and the baseContainer is available
+          console.error("image interactive baseContainer not available. aspectRatio will be wrong");
+          return;
+        }
+        // We use the baseContainer height to capture all of the spacing
+        // in the container. We can't use the image's aspect ratio
+        // directly because there is various bits of padding around the container.
+        const baseContainerHeight = baseContainer.current.scrollHeight;
+
+        // HACK: the aspectRatio is dependent on the iframe's width. When the iframe
+        // is more narrow, then the caption and magnifying glass will
+        // take up a larger percentage of the height. Additionally the caption
+        // can start wrapping so its actual pixel height will get larger.
+        // It is possible for the interactive to send a new aspectRatio
+        // whenever its width changes. However this can cause a race or infinite
+        // loop:
+        //   If the interactive is in the interactive box and the user resizes
+        //   the window then the width of the interactive will change. This would
+        //   trigger a re-calcuation of the aspectRatio in the interactive.
+        //   When the interactive sends this new aspectRaio to LARA,
+        //   LARA will re-calcuate the width and height of the interactive again.
+        //   LARA's calculation of the width will change if the
+        //   users browser is short so maintainig the aspect ratio means limiting
+        //   the width.  This width change will trigger the interactive to send a
+        //   new aspect ratio. This will go on and on.
+        // We can probably add some more complex logic to make sure this loop
+        // eventually stops. This would probably require some hysteresis.
+        // Instead of that complexity, here is just a fudge factor to add a little
+        // extra padding.
+        const creditTextHeight = creditTextContainer.current?.clientHeight || 0;
+
+        // This calcuation is only done once. It is best think of two cases:
+        // 1. If the interactive starts small
+        // then the percentage of the height taken up by the creditText will large
+        // so the number of pixels allocated to it will get larger if the
+        // interactive gets larger and the aspectRatio is maintained.
+        // In this case there should be no clipping issues.
+        // But there might be a large white space below the interactive.
+        // 2. If the width starts large
+        // then percentage of height taken up by the creditText will be small,
+        // so the number of pixels allocated will get too small as the width is
+        // decreased and the aspectRatio is maintained.
+        // In this case the caption will get clipped.
+        //
+        // So with calcuation below the fudgeFactor will get bigger the larger
+        // the width of the interactive is.
+        const fudgeFactor = window.innerWidth < 300 ? 0 : (window.innerWidth - 300) / 200;
+        const fudgedPadding = creditTextHeight * fudgeFactor;
+
+        const computedHeight = baseContainerHeight + fudgedPadding;
+        // I don't know if window.innerWidth is the best dimension to use here
+        // perhaps we should use rooContainer.currrent.scrollWidth instead?
+        const aspectRatio = window.innerWidth / computedHeight;
+        console.log("setting aspect ratio",
+          {baseContainerHeight, creditTextHeight, fudgedPadding,
+           computedHeight, aspectRatio});
+        setSupportedFeatures({
+          interactiveState: true,
+          authoredState: true,
+          aspectRatio
+        });
+      }
     }
   };
 
   const handleClick = () => {
     const { url, highResUrl, credit, caption } = authoredState;
+    // CHECKME: the size here is what is passed to showModal however that modal
+    // is supposed to be showing the highRes image. But the size here is the
+    // native width and height of the image. Perhaps showModal is just figuring
+    // out an aspectRatio from this size? Otherwise the modal will not really
+    // fill the space of the screen with the highRes image.
+    // If the size is used directly by the modal then it would be easy for a
+    // large main image to cause the modal to be larger than the screen.
     const size = imageSize.current?.width && imageSize.current?.height
                   ? { width: imageSize.current.width, height: imageSize.current.height }
                   : undefined;
@@ -77,10 +163,12 @@ export const Runtime: React.FC<IProps> = ({ authoredState, report }) => {
           onLoad={getOriginalImageSize}
         />
       </div>
-      {authoredState.caption && <div className={css.caption}>{authoredState.caption}</div>}
-      {authoredState.credit && <div className={css.credit}>{authoredState.credit}</div>}
-      {getCreditLink()}
-      <div className={`${css.viewHighRes} .glyphicon-zoom-in`} onClick={handleClick}><ZoomIcon /></div>
+      <div ref={creditTextContainer}>
+        {authoredState.caption && <div className={css.caption}>{authoredState.caption}</div>}
+        {authoredState.credit && <div className={css.credit}>{authoredState.credit}</div>}
+        {getCreditLink()}
+        <div className={`${css.viewHighRes} .glyphicon-zoom-in`} onClick={handleClick}><ZoomIcon /></div>
+      </div>
     </div>
   );
 };

--- a/src/shared/components/base-app.tsx
+++ b/src/shared/components/base-app.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, RefObject } from "react";
 import { useAutoHeight } from "../hooks/use-auto-height";
 import { useShutterbug } from "../hooks/use-shutterbug";
 import { BaseAuthoring, IBaseAuthoringProps } from "./base-authoring";
@@ -20,6 +20,7 @@ export interface IAuthoringComponentProps<IAuthoredState> {
 
 export interface IRuntimeComponentProps<IAuthoredState> {
   authoredState: IAuthoredState;
+  baseContainer?: RefObject<HTMLDivElement>;
 }
 
 interface IProps<IAuthoredState> {
@@ -64,7 +65,7 @@ export const BaseApp = <IAuthoredState extends IBaseAuthoredState>(props: IProps
     }
     return (
       <div className={css.runtime}>
-        <Runtime authoredState={authoredState} />
+        <Runtime authoredState={authoredState} baseContainer={container} />
       </div>
     );
   };


### PR DESCRIPTION
This PR is documentation of a path we shouldn't take, rather than something to be merged.

The point of this work on aspectRatio is so LARA can use its sizing calculations to make sure the interactive doesn't get bigger than the viewable area of the screen.  When an interactive sets its aspectRatio LARA does these calculations, when the interactive sets its height LARA doesn't do these calculations. 

It is best leaving image and video interactives working as they currently are which means they set their height and LARA can't limit their size to make sure they fit.  The current built in (non iframe) image interactive doesn't do any size limiting either, so this won't be a regression if we leave it as is.

The comments in the code document the sizing tweaks necessary for the aspectRatio to sort of work.

This also conditionally disables the autoHeight based on the authored settings of the
image interactive. This way the aspectRatio fudging is only used when it is really needed.
Conditionally disabling the autoHeight required required passing the container reference
into the Runtime component. This might cause a performance problem. It also broke the tests.

The better solution for all of this is for LARA to notify the interactive when the max viewable
height has changed. Then the interactive can decide if it wants to limit the height it
sends to LARA based on this max viewable height. The interactive won't have a way
to adjust its width, but currently this kind of width adjustment is not really visible to the user.  The only time the actual width of the interactive would only be visible is when the interactive is wrapped with a teacher edition plugin. That plugin adds a border around the interactive so that border would be bigger than necessary if the interactive letter boxed its contents. That kind of extra space does not seem like a problem to me, so it I don't think the width adjustment is necessary.

[#173174724]