### PR TITLE
Drawing tool

### DIFF
--- a/cypress/integration/drawing-tool.test.js
+++ b/cypress/integration/drawing-tool.test.js
@@ -1,0 +1,51 @@
+import { phonePost, phoneListen, getAndClearLastPhoneMessage } from "../support";
+
+const authoredStateWithoutStamps = {
+  version: 1,
+  questionType: "open_response",
+  imageFit: "shrinkBackgroundToCanvas",
+  imagePosition: "center",
+  stampCollections: []
+};
+
+const authoredStateWithStamps = {
+  version: 1,
+  questionType: "open_response",
+  imageFit: "shrinkBackgroundToCanvas",
+  imagePosition: "center",
+  stampCollections: [{
+    collection: "custom",
+    name: "My stamps",
+    stamps: [
+      "https://interactions-resources.concord.org/stamps/simple-atom.svg"
+    ]
+  }]
+};
+
+context("Test Image interactive", () => {
+  beforeEach(() => {
+    // cy.viewport(800, 600);
+    cy.visit("/wrapper.html?iframe=/drawing-tool");
+  });
+
+  context("Runtime view", () => {
+    it("renders drawing tool without stamps", () => {
+      phonePost("initInteractive", {
+        mode: "runtime",
+        authoredState: authoredStateWithoutStamps
+      });
+
+      cy.getIframeBody().find(".dt-container").should('exist');
+      cy.getIframeBody().find('[title="Stamp tool (click and hold to show available categories)"]').should('not.exist');
+    });
+
+    it("renders drawing tool with stamps", () => {
+      phonePost("initInteractive", {
+        mode: "runtime",
+        authoredState: authoredStateWithStamps
+      });
+
+      cy.getIframeBody().find('[title="Stamp tool (click and hold to show available categories)"]').should('exist');
+    });
+  });
+});

--- a/cypress/integration/drawing-tool.test.js
+++ b/cypress/integration/drawing-tool.test.js
@@ -1,4 +1,4 @@
-import { phonePost, phoneListen, getAndClearLastPhoneMessage } from "../support";
+import { phonePost } from "../support";
 
 const authoredStateWithoutStamps = {
   version: 1,

--- a/cypress/integration/drawing-tool.test.js
+++ b/cypress/integration/drawing-tool.test.js
@@ -2,7 +2,7 @@ import { phonePost, phoneListen, getAndClearLastPhoneMessage } from "../support"
 
 const authoredStateWithoutStamps = {
   version: 1,
-  questionType: "open_response",
+  questionType: "iframe_interactve",
   imageFit: "shrinkBackgroundToCanvas",
   imagePosition: "center",
   stampCollections: []
@@ -10,7 +10,7 @@ const authoredStateWithoutStamps = {
 
 const authoredStateWithStamps = {
   version: 1,
-  questionType: "open_response",
+  questionType: "iframe_interactve",
   imageFit: "shrinkBackgroundToCanvas",
   imagePosition: "center",
   stampCollections: [{

--- a/package-lock.json
+++ b/package-lock.json
@@ -4462,6 +4462,17 @@
       "integrity": "sha512-OvGZqalCwmapci76ISq5q4kuAskb1ebqF3FEQBv1LE1kWht0pojlDDqzFlmk5jgYkuZN7MNZ1n+ULwe/7MaDNQ==",
       "dev": true
     },
+    "canvas": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.6.1.tgz",
+      "integrity": "sha512-S98rKsPcuhfTcYbtF53UIJhcbgIAK533d1kJKMwsMwAIFgfd58MOyxRud3kktlzWiEkFliaJtvyZCBtud/XVEA==",
+      "optional": true,
+      "requires": {
+        "nan": "^2.14.0",
+        "node-pre-gyp": "^0.11.0",
+        "simple-get": "^3.0.3"
+      }
+    },
     "capture-exit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -6240,6 +6251,15 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "optional": true,
+      "requires": {
+        "mimic-response": "^2.0.0"
+      }
+    },
     "deep-equal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.3.tgz",
@@ -6268,11 +6288,16 @@
         }
       }
     },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "optional": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "deepmerge": {
       "version": "4.2.2",
@@ -6434,6 +6459,12 @@
       "requires": {
         "repeating": "^2.0.0"
       }
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "optional": true
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -6608,6 +6639,24 @@
       "requires": {
         "no-case": "^3.0.3",
         "tslib": "^1.10.0"
+      }
+    },
+    "drawing-tool": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/drawing-tool/-/drawing-tool-2.0.1.tgz",
+      "integrity": "sha512-8wx38dZSP5ebMHFHFjMBtvGfyPvf++UBP3CiYp4tj5r86JiZL/BNu135Se0cCiB02BUw6AN2A5uopS9gR2vZ+g==",
+      "requires": {
+        "eventemitter2": "~0.4.14",
+        "fabric": "3.6.3",
+        "hammerjs": "~2.0.4",
+        "query-string": "^4.3.2"
+      },
+      "dependencies": {
+        "eventemitter2": {
+          "version": "0.4.14",
+          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+          "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas="
+        }
       }
     },
     "duplexify": {
@@ -7719,6 +7768,15 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
+    "fabric": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/fabric/-/fabric-3.6.3.tgz",
+      "integrity": "sha512-PwJKZG7Zbst+B1PSmt2OddK8UJ9tQ23a9gslodCSrXCzj8S+1RcOaQuA9gbpoQWpXYUB0qsBhdBvAVyOi7oM9g==",
+      "requires": {
+        "canvas": "^2.6.1",
+        "jsdom": "^15.1.0"
+      }
+    },
     "fast-deep-equal": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
@@ -8184,6 +8242,15 @@
         "universalify": "^0.1.0"
       }
     },
+    "fs-minipass": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "optional": true,
+      "requires": {
+        "minipass": "^2.6.0"
+      }
+    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -8537,6 +8604,11 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true,
       "optional": true
+    },
+    "hammerjs": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
+      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
     },
     "handle-thing": {
       "version": "2.0.1",
@@ -9106,6 +9178,15 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
       "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
       "dev": true
+    },
+    "ignore-walk": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+      "optional": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
     },
     "immutable": {
       "version": "3.8.2",
@@ -11432,6 +11513,12 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
+    "mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "optional": true
+    },
     "min-document": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
@@ -11478,6 +11565,25 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
+    },
+    "minipass": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "optional": true,
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "optional": true,
+      "requires": {
+        "minipass": "^2.9.0"
+      }
     },
     "mississippi": {
       "version": "3.0.0",
@@ -11676,6 +11782,28 @@
         }
       }
     },
+    "needle": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.0.tgz",
+      "integrity": "sha512-o/qITSDR0JCyCKEQ1/1bnUXMmznxabbwi/Y4WwJElf+evwJNFNwIDMCCt5IigFVxgeGBJESLohGtIS9gEzo1fA==",
+      "optional": true,
+      "requires": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "optional": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -11849,6 +11977,60 @@
         }
       }
     },
+    "node-pre-gyp": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",
+      "integrity": "sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==",
+      "optional": true,
+      "requires": {
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.1",
+        "needle": "^2.2.1",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.2.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+          "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+          "optional": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "tar": {
+          "version": "4.4.13",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+          "optional": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.3"
+          }
+        }
+      }
+    },
     "node-releases": {
       "version": "1.1.53",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.53.tgz",
@@ -11985,6 +12167,32 @@
         "prepend-http": "^1.0.0",
         "query-string": "^4.1.0",
         "sort-keys": "^1.0.0"
+      }
+    },
+    "npm-bundled": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+      "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+      "optional": true,
+      "requires": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+      "optional": true
+    },
+    "npm-packlist": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+      "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
+      "optional": true,
+      "requires": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1",
+        "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "npm-run-all": {
@@ -13301,6 +13509,18 @@
       "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
       "integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao=",
       "dev": true
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "optional": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      }
     },
     "react": {
       "version": "16.13.1",
@@ -14679,6 +14899,23 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
+    },
+    "simple-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+      "optional": true
+    },
+    "simple-get": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+      "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+      "optional": true,
+      "requires": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "sisteransi": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@concord-consortium/slate-editor": "^0.3.0",
     "deep-equal": "^2.0.3",
     "dompurify": "^2.0.12",
+    "drawing-tool": "^2.0.1",
     "firebase": "^7.15.2",
     "html-react-parser": "^0.13.0",
     "iframe-phone": "^1.2.1",

--- a/src/drawing-tool/components/app.tsx
+++ b/src/drawing-tool/components/app.tsx
@@ -125,6 +125,10 @@ const baseAuthoringProps = {
         title: "Prompt",
         type: "string"
       },
+      required: {
+        title: "Required (Show submit and lock button)",
+        type: "boolean"
+      },
       hint: {
         title: "Hint",
         type: "string"

--- a/src/drawing-tool/components/app.tsx
+++ b/src/drawing-tool/components/app.tsx
@@ -22,7 +22,9 @@ export interface IAuthoredState extends IAuthoringInteractiveMetadata {
   stampCollections: StampCollection[];
 }
 
-export interface IInteractiveState extends IRuntimeInteractiveMetadata {}
+export interface IInteractiveState extends IRuntimeInteractiveMetadata {
+  drawingState: string;
+}
 
 const baseAuthoringProps = {
   schema: {

--- a/src/drawing-tool/components/app.tsx
+++ b/src/drawing-tool/components/app.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { Runtime } from "./runtime";
+import { JSONSchema6 } from "json-schema";
+import { IAuthoringOpenResponseMetadata, IRuntimeInteractiveMetadata } from "@concord-consortium/lara-interactive-api";
+import { BaseQuestionApp } from "../../shared/components/base-question-app";
+
+// Note that TS interfaces should match JSON schema. Currently there's no way to generate one from the other.
+// TS interfaces are not available in runtime in contrast to JSON schema.
+
+export interface IAuthoredState extends IAuthoringOpenResponseMetadata {
+  version: number;
+  backgroundImageUrl?: string;
+  imageFit: string;
+  imagePosition: string;
+}
+
+export interface IInteractiveState extends IRuntimeInteractiveMetadata {}
+
+const baseAuthoringProps = {
+  schema: {
+    type: "object",
+    properties: {
+      version: {
+        type: "number",
+        default: 1
+      },
+      backgroundImageUrl: {
+        title: "Background Image URL",
+        type: "string",
+        format: "uri"
+      },
+      imageFit: {
+        title: "Background image fit",
+        type: "string",
+        default: "shrinkBackgroundToCanvas",
+        enum: [
+          "shrinkBackgroundToCanvas",
+          "resizeBackgroundToCanvas",
+          "resizeCanvasToBackground"
+        ],
+        enumNames: [
+          "Shrink image if needed (do not grow)",
+          "Set image to canvas size",
+          "Set canvas to image size"
+        ]
+      },
+      imagePosition: {
+        title: "Background image position (for smaller images)",
+        type: "string",
+        default: "center",
+        enum: [
+          "center",
+          "top-left"
+        ],
+        enumNames: [
+          "Center",
+          "Top-left"
+        ]
+      }
+    }
+  } as JSONSchema6,
+
+  uiSchema: {
+    version: {
+      "ui:widget": "hidden"
+    },
+    backgroundImageUrl: {
+      "ui:help": "Path to hosted image file (jpg, png, gif, etc)"
+    },
+    imageFit: {
+      "ui:widget": "radio"
+    },
+    imagePosition: {
+      "ui:widget": "radio"
+    }
+  }
+};
+
+const isAnswered = (interactiveState: IInteractiveState | null) => !!interactiveState?.answerText;
+
+export const App = () => (
+  <BaseQuestionApp<IAuthoredState, IInteractiveState>
+    Runtime={Runtime}
+    baseAuthoringProps={baseAuthoringProps}
+    disableAutoHeight={false}
+    isAnswered={isAnswered}
+  />
+);

--- a/src/drawing-tool/components/app.tsx
+++ b/src/drawing-tool/components/app.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Runtime } from "./runtime";
 import { JSONSchema6 } from "json-schema";
-import { IAuthoringOpenResponseMetadata, IRuntimeInteractiveMetadata } from "@concord-consortium/lara-interactive-api";
+import { IRuntimeInteractiveMetadata, IAuthoringInteractiveMetadata } from "@concord-consortium/lara-interactive-api";
 import { BaseQuestionApp } from "../../shared/components/base-question-app";
 
 // Note that TS interfaces should match JSON schema. Currently there's no way to generate one from the other.
@@ -13,7 +13,7 @@ interface StampCollection {
   stamps?: string[];
 }
 
-export interface IAuthoredState extends IAuthoringOpenResponseMetadata {
+export interface IAuthoredState extends IAuthoringInteractiveMetadata {
   version: number;
   hint?: string;
   backgroundImageUrl?: string;
@@ -119,7 +119,7 @@ const baseAuthoringProps = {
       },
       questionType: {
         type: "string",
-        default: "drawing_tool"
+        default: "iframe_interactive"
       },
       prompt: {
         title: "Prompt",

--- a/src/drawing-tool/components/app.tsx
+++ b/src/drawing-tool/components/app.tsx
@@ -15,6 +15,7 @@ interface StampCollection {
 
 export interface IAuthoredState extends IAuthoringOpenResponseMetadata {
   version: number;
+  hint?: string;
   backgroundImageUrl?: string;
   imageFit: string;
   imagePosition: string;
@@ -116,6 +117,18 @@ const baseAuthoringProps = {
         type: "number",
         default: 1
       },
+      questionType: {
+        type: "string",
+        default: "drawing_tool"
+      },
+      prompt: {
+        title: "Prompt",
+        type: "string"
+      },
+      hint: {
+        title: "Hint",
+        type: "string"
+      },
       backgroundImageUrl: {
         title: "Background Image URL",
         type: "string",
@@ -162,6 +175,12 @@ const baseAuthoringProps = {
   uiSchema: {
     version: {
       "ui:widget": "hidden"
+    },
+    questionType: {
+      "ui:widget": "hidden"
+    },
+    prompt: {
+      "ui:widget": "richtext"
     },
     backgroundImageUrl: {
       "ui:help": "Path to hosted image file (jpg, png, gif, etc)"

--- a/src/drawing-tool/components/runtime.scss
+++ b/src/drawing-tool/components/runtime.scss
@@ -1,0 +1,4 @@
+@import "../../shared/styles/helpers";
+.runtime {
+  margin-left: -20px;
+}

--- a/src/drawing-tool/components/runtime.scss
+++ b/src/drawing-tool/components/runtime.scss
@@ -1,4 +1,22 @@
 @import "../../shared/styles/helpers";
-.runtime {
-  margin-left: -20px;
+
+.drawingtoolWrapper {
+  position: relative;
+  height: 600px;
+  width: 100%;
 }
+
+.runtime, .clickShield {
+  position: absolute;
+  left: -18px;
+  top: 0;
+}
+
+.clickShield {
+  right: -12px;
+  height: 100%;
+  background-color: #DDD;
+  opacity: 0.2;
+  z-index: 1010;      // drawing-tool buttons are z-index 1000...
+}
+

--- a/src/drawing-tool/components/runtime.tsx
+++ b/src/drawing-tool/components/runtime.tsx
@@ -39,7 +39,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
       const baseName = collection.name || collection.collection.charAt(0).toUpperCase() + collection.collection.slice(1);
       let name = baseName;
       let i = 0;
-      while (!!stampCollections[name]) {
+      while (stampCollections[name]) {
         name = `${baseName} ${++i}`;
       }
       let stamps: string[];
@@ -58,7 +58,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     const drawingToolOpts: DrawingToolOpts = {
       width: windowWidth - kToolbarWidth - 10,
       height: kToolbarHeight
-    }
+    };
 
     if (Object.keys(stampCollections).length > 0) {
       drawingToolOpts.stamps = stampCollections;
@@ -70,7 +70,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
       const imageOpts = {
         src: authoredState.backgroundImageUrl,
         position: authoredState.imagePosition
-      }
+      };
 
       if (authoredState.imageFit === "resizeCanvasToBackground") {
         imageOpts.position = "center";      // anything else is an invalid combo
@@ -93,7 +93,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
         ...prevState,
         answerText: userState,
         answerType: "interactive_state"
-      }))
+      }));
     });
   }, []);
 

--- a/src/drawing-tool/components/runtime.tsx
+++ b/src/drawing-tool/components/runtime.tsx
@@ -91,7 +91,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
       const userState = drawingTool.save();
       setInteractiveState?.(prevState => ({
         ...prevState,
-        answerText: userState,
+        drawingState: userState,
         answerType: "interactive_state"
       }));
     });

--- a/src/drawing-tool/components/runtime.tsx
+++ b/src/drawing-tool/components/runtime.tsx
@@ -37,7 +37,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     const windowWidth = window.innerWidth;
 
     const stampCollections: StampCollections = {};
-    authoredState.stampCollections.forEach(collection => {
+    authoredState.stampCollections?.forEach(collection => {
       const baseName = collection.name || collection.collection.charAt(0).toUpperCase() + collection.collection.slice(1);
       let name = baseName;
       let i = 0;

--- a/src/drawing-tool/components/runtime.tsx
+++ b/src/drawing-tool/components/runtime.tsx
@@ -1,10 +1,11 @@
-import React, { useRef, useEffect } from "react";
+import React from "react";
 import DrawingTool from "drawing-tool";
 import 'drawing-tool/dist/drawing-tool.css';
 import { IAuthoredState, IInteractiveState } from "./app";
 import css from "./runtime.scss";
 import predefinedStampCollections from "./stamp-collections";
 import { renderHTML } from "../../shared/utilities/render-html";
+import { useOnMount } from "../../shared/hooks/use-on-mount";
 
 const kToolbarWidth = 40;
 const kToolbarHeight = 600;
@@ -30,8 +31,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
 
   const readOnly = !!(report || (authoredState.required && interactiveState?.submitted));
 
-  // equivalent to componentDidLoad
-  useEffect(() => {
+  useOnMount(() => {
     const windowWidth = window.innerWidth;
 
     const stampCollections: StampCollections = {};
@@ -95,7 +95,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
         answerType: "interactive_state"
       }));
     });
-  }, []);
+  });
 
   return (
     <div>

--- a/src/drawing-tool/components/runtime.tsx
+++ b/src/drawing-tool/components/runtime.tsx
@@ -28,6 +28,8 @@ interface DrawingToolOpts {
 
 export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, report }) => {
 
+  const readOnly = !!(report || (authoredState.required && interactiveState?.submitted));
+
   // equivalent to componentDidLoad
   useEffect(() => {
     const windowWidth = window.innerWidth;
@@ -54,7 +56,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     });
 
     const drawingToolOpts: DrawingToolOpts = {
-      width: windowWidth - kToolbarWidth - 5,
+      width: windowWidth - kToolbarWidth - 10,
       height: kToolbarHeight
     }
 
@@ -85,6 +87,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     }
 
     drawingTool.on('drawing:changed', () => {
+      if (readOnly) return;
       const userState = drawingTool.save();
       setInteractiveState?.(prevState => ({
         ...prevState,
@@ -97,7 +100,10 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   return (
     <div>
       { authoredState.prompt && <div>{renderHTML(authoredState.prompt)}</div>}
-      <div id="drawing-tool-container" className={css.runtime} />
+      <div className={css.drawingtoolWrapper}>
+        { readOnly && <div className={css.clickShield} /> }
+        <div id="drawing-tool-container" className={css.runtime} />
+      </div>
     </div>
   );
 };

--- a/src/drawing-tool/components/runtime.tsx
+++ b/src/drawing-tool/components/runtime.tsx
@@ -4,6 +4,7 @@ import 'drawing-tool/dist/drawing-tool.css';
 import { IAuthoredState, IInteractiveState } from "./app";
 import css from "./runtime.scss";
 import predefinedStampCollections from "./stamp-collections";
+import { renderHTML } from "../../shared/utilities/render-html";
 
 const kToolbarWidth = 40;
 const kToolbarHeight = 600;
@@ -13,11 +14,6 @@ interface IProps {
   interactiveState?: IInteractiveState | null;
   setInteractiveState?: (updateFunc: (prevState: IInteractiveState | null) => IInteractiveState) => void;
   report?: boolean;
-}
-
-interface IImageSize {
-  width: number;
-  height: number;
 }
 
 interface StampCollections {
@@ -99,6 +95,9 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   }, []);
 
   return (
-    <div id="drawing-tool-container" className={css.runtime} />
+    <div>
+      { authoredState.prompt && <div>{renderHTML(authoredState.prompt)}</div>}
+      <div id="drawing-tool-container" className={css.runtime} />
+    </div>
   );
 };

--- a/src/drawing-tool/components/runtime.tsx
+++ b/src/drawing-tool/components/runtime.tsx
@@ -1,0 +1,66 @@
+import React, { useRef, useEffect } from "react";
+import DrawingTool from "drawing-tool";
+import 'drawing-tool/dist/drawing-tool.css';
+import { IAuthoredState, IInteractiveState } from "./app";
+import css from "./runtime.scss";
+
+const kToolbarWidth = 40;
+const kToolbarHeight = 600;
+
+interface IProps {
+  authoredState: IAuthoredState;
+  interactiveState?: IInteractiveState | null;
+  setInteractiveState?: (updateFunc: (prevState: IInteractiveState | null) => IInteractiveState) => void;
+  report?: boolean;
+}
+
+interface IImageSize {
+  width: number;
+  height: number;
+}
+
+export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, report }) => {
+
+  // equivalent to componentDidLoad
+  useEffect(() => {
+    const windowWidth = window.innerWidth;
+
+    const drawingTool = new DrawingTool("#drawing-tool-container", {
+      width: windowWidth - kToolbarWidth - 5,
+      height: kToolbarHeight
+    });
+
+    if (authoredState.backgroundImageUrl) {
+      const imageOpts = {
+        src: authoredState.backgroundImageUrl,
+        position: authoredState.imagePosition
+      }
+
+      if (authoredState.imageFit === "resizeCanvasToBackground") {
+        imageOpts.position = "center";      // anything else is an invalid combo
+      }
+
+      drawingTool.pauseHistory();
+      drawingTool.setBackgroundImage(imageOpts, authoredState.imageFit, () => {
+        drawingTool.unpauseHistory();
+      });
+    }
+
+    if (interactiveState) {
+      drawingTool.load(interactiveState.answerText, null, true);
+    }
+
+    drawingTool.on('drawing:changed', () => {
+      const userState = drawingTool.save();
+      setInteractiveState?.(prevState => ({
+        ...prevState,
+        answerText: userState,
+        answerType: "interactive_state"
+      }))
+    });
+  }, []);
+
+  return (
+    <div id="drawing-tool-container" className={css.runtime} />
+  );
+};

--- a/src/drawing-tool/components/runtime.tsx
+++ b/src/drawing-tool/components/runtime.tsx
@@ -3,6 +3,7 @@ import DrawingTool from "drawing-tool";
 import 'drawing-tool/dist/drawing-tool.css';
 import { IAuthoredState, IInteractiveState } from "./app";
 import css from "./runtime.scss";
+import predefinedStampCollections from "./stamp-collections";
 
 const kToolbarWidth = 40;
 const kToolbarHeight = 600;
@@ -19,16 +20,53 @@ interface IImageSize {
   height: number;
 }
 
+interface StampCollections {
+  [collectionName: string]: string[];
+}
+
+interface DrawingToolOpts {
+  width: number;
+  height: number;
+  stamps?: StampCollections;
+}
+
 export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, report }) => {
 
   // equivalent to componentDidLoad
   useEffect(() => {
     const windowWidth = window.innerWidth;
 
-    const drawingTool = new DrawingTool("#drawing-tool-container", {
+    const stampCollections: StampCollections = {};
+    authoredState.stampCollections.forEach(collection => {
+      const baseName = collection.name || collection.collection.charAt(0).toUpperCase() + collection.collection.slice(1);
+      let name = baseName;
+      let i = 0;
+      while (!!stampCollections[name]) {
+        name = `${baseName} ${++i}`;
+      }
+      let stamps: string[];
+      if (collection.collection === "custom") {
+        stamps = collection.stamps || [];
+        const urlRegex = /^(https:|http:)\/\/\S+/;
+        stamps = stamps.map(url => url.replace(/ /g,'')).filter(url => url.match(urlRegex));
+      } else {
+        stamps = predefinedStampCollections[collection.collection];
+      }
+      if (stamps && stamps.length) {
+        stampCollections[name] = stamps;
+      }
+    });
+
+    const drawingToolOpts: DrawingToolOpts = {
       width: windowWidth - kToolbarWidth - 5,
       height: kToolbarHeight
-    });
+    }
+
+    if (Object.keys(stampCollections).length > 0) {
+      drawingToolOpts.stamps = stampCollections;
+    }
+
+    const drawingTool = new DrawingTool("#drawing-tool-container", drawingToolOpts);
 
     if (authoredState.backgroundImageUrl) {
       const imageOpts = {

--- a/src/drawing-tool/components/stamp-collections.tsx
+++ b/src/drawing-tool/components/stamp-collections.tsx
@@ -1,0 +1,28 @@
+const predefinedStampCollections = {
+  molecules: [
+    "https://interactions-resources.concord.org/stamps/simple-atom.svg",
+    "https://interactions-resources.concord.org/stamps/diatomic.svg",
+    "https://interactions-resources.concord.org/stamps/diatomic-red.svg",
+    "https://interactions-resources.concord.org/stamps/triatomic.svg",
+    "https://interactions-resources.concord.org/stamps/positive-charge-symbol.svg",
+    "https://interactions-resources.concord.org/stamps/negative-charge-symbol.svg",
+    "https://interactions-resources.concord.org/stamps/positive-atom.svg",
+    "https://interactions-resources.concord.org/stamps/negative-atom.svg",
+    "https://interactions-resources.concord.org/stamps/slow-particle.svg",
+    "https://interactions-resources.concord.org/stamps/medium-particle.svg",
+    "https://interactions-resources.concord.org/stamps/fast-particle.svg",
+    "https://interactions-resources.concord.org/stamps/low-density-particles.svg"
+  ],
+  ngsaObjects: [
+    "https://interactions-resources.concord.org/stamps/car-facing-east.svg",
+    "https://interactions-resources.concord.org/stamps/car-facing-west.svg",
+    "https://interactions-resources.concord.org/stamps/front-crushed-east.svg",
+    "https://interactions-resources.concord.org/stamps/front-crushed-west.svg",
+    "https://interactions-resources.concord.org/stamps/N-S-magnet.svg",
+    "https://interactions-resources.concord.org/stamps/S-N-magnet.svg",
+    "https://interactions-resources.concord.org/stamps/new-phone.svg",
+    "https://interactions-resources.concord.org/stamps/broken-phone.svg"
+  ]
+}
+
+export default predefinedStampCollections;

--- a/src/drawing-tool/components/stamp-collections.tsx
+++ b/src/drawing-tool/components/stamp-collections.tsx
@@ -23,6 +23,6 @@ const predefinedStampCollections = {
     "https://interactions-resources.concord.org/stamps/new-phone.svg",
     "https://interactions-resources.concord.org/stamps/broken-phone.svg"
   ]
-}
+};
 
 export default predefinedStampCollections;

--- a/src/drawing-tool/index.tsx
+++ b/src/drawing-tool/index.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { App } from "./components/app";
+
+ReactDOM.render(
+  <App/>,
+  document.getElementById("app")
+);

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -2,4 +2,4 @@ declare module "*.scss";
 declare module "*.svg";
 declare module "shutterbug";
 declare module "iframe-phone";
-
+declare module "drawing-tool";

--- a/src/shared/hooks/use-on-mount.ts
+++ b/src/shared/hooks/use-on-mount.ts
@@ -1,4 +1,0 @@
-import { useEffect } from "react";
-
-// eslint-disable-next-line react-hooks/exhaustive-deps
-export const useOnMount = (fn: () => void) => useEffect(fn, []);

--- a/src/shared/hooks/use-on-mount.ts
+++ b/src/shared/hooks/use-on-mount.ts
@@ -1,0 +1,4 @@
+import { useEffect } from "react";
+
+// eslint-disable-next-line react-hooks/exhaustive-deps
+export const useOnMount = (fn: () => void) => useEffect(fn, []);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,7 @@ module.exports = (env, argv) => {
       'scaffolded-question': './src/scaffolded-question/index.tsx',
       'video-player': './src/video-player/index.tsx',
       'image': './src/image/index.tsx',
+      'drawing-tool': './src/drawing-tool/index.tsx',
       'wrapper': './src/shared/wrapper.tsx'
     },
     mode: 'development',
@@ -150,6 +151,11 @@ module.exports = (env, argv) => {
       new HtmlWebpackPlugin({
         chunks: ['image'],
         filename: 'image/index.html',
+        template: 'src/shared/index.html'
+      }),
+      new HtmlWebpackPlugin({
+        chunks: ['drawing-tool'],
+        filename: 'drawing-tool/index.html',
         template: 'src/shared/index.html'
       }),
       new HtmlWebpackPlugin({


### PR DESCRIPTION
This adds the drawing tool, with authoring for background images and stamps collections.

The drawing tool can be seen here: https://lara-master.concordqa.org/activities/20000/pages/304600/edit

@pjanik I was a little confused about the types for the authoring state. I made it `IAuthoringOpenResponseMetadata` which made `BaseQuestionApp` happy. If I tried to make it the more generic type `IAuthoringMetadataBase` it complained. This seems fine, except that the tests then require the authored data to contain `questionType: "open_response"`, which is a little weird.

I set the actual questionType to `drawing_tool`, also unsure if that's correct.