### PR TITLE
Fix cypress tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,11 @@ before_install:
 install:
 - travis_retry gem install s3_website -v 3.4.0
 - travis_retry npm ci
-- travis_retry cypress install
 script:
+- npm run start &
 - npm run build
 - npm run test:coverage -- --runInBand
-- npm run start &
 - wait-on http://localhost:8080
 - $(npm bin)/cypress run --config video=false
-after_script:
+after_success:
 - ./s3_deploy.sh

--- a/cypress/integration/multiple-choice.test.js
+++ b/cypress/integration/multiple-choice.test.js
@@ -1,7 +1,10 @@
 import { phonePost, phoneListen, getAndClearLastPhoneMessage } from "../support";
 
 context("Test multiple-choice interactive", () => {
+  let i = 0;
+
   beforeEach(() => {
+    if (i++ > 0) cy.wait(3000);
     cy.visit("/wrapper.html?iframe=/multiple-choice");
   });
 
@@ -392,7 +395,7 @@ context("Test multiple-choice interactive", () => {
       cy.getIframeBody().find("#root_multipleAnswers").click();
       getAndClearLastPhoneMessage(state => {
         expect(state.multipleAnswers).eql(true);
-      });
+      }, 100);
 
       cy.getIframeBody().find(".btn-add").click();
       cy.getIframeBody().find("#root_choices_0_content").clear();
@@ -401,7 +404,7 @@ context("Test multiple-choice interactive", () => {
       getAndClearLastPhoneMessage(state => {
         expect(state.choices[0].content).eql("Choice A");
         expect(state.choices[0].correct).eql(true);
-      });
+      }, 100);
 
       cy.getIframeBody().find(".btn-add").click();
       cy.getIframeBody().find("#root_choices_1_content").clear();
@@ -409,7 +412,7 @@ context("Test multiple-choice interactive", () => {
       getAndClearLastPhoneMessage(state => {
         expect(state.choices[1].content).eql("Choice B");
         expect(state.choices[1].correct).eql(false);
-      });
+      }, 100);
     });
   });
 

--- a/cypress/integration/open-response.test.js
+++ b/cypress/integration/open-response.test.js
@@ -1,7 +1,10 @@
 import { phonePost, phoneListen, getAndClearLastPhoneMessage } from "../support";
 
 context("Test open response interactive", () => {
+  let i = 0;
+
   beforeEach(() => {
+    if (i++ > 0) cy.wait(3000);
     cy.visit("/wrapper.html?iframe=/open-response");
   });
 

--- a/cypress/integration/scaffolded-question.test.js
+++ b/cypress/integration/scaffolded-question.test.js
@@ -1,7 +1,10 @@
 import { phonePost, phoneListen, getAndClearLastPhoneMessage, getAndClearAllPhoneMessage } from "../support";
 
 context("Test scaffolded question interactive", () => {
+  let i = 0;
+
   beforeEach(() => {
+    if (i++ > 0) cy.wait(4000);
     cy.visit("/wrapper.html?iframe=/scaffolded-question");
   });
 
@@ -195,12 +198,12 @@ context("Test scaffolded question interactive", () => {
       getAndClearLastPhoneMessage(state => {
         expect(state.version).eql(1);
         expect(state.prompt).include("Test prompt");
-      }, 100);
+      }, 200);
 
       cy.getIframeBody().find("#root_hint").type("Hint").tab();
       getAndClearLastPhoneMessage(state => {
         expect(state.hint).include("Hint");
-      });
+      }, 200);
 
       cy.getIframeBody().find(".btn-add").click();
       cy.getIframeBody().find("[data-cy=select-subquestion]").select("Open response");
@@ -209,7 +212,7 @@ context("Test scaffolded question interactive", () => {
       cy.getNestedIframeBody().find("#root_prompt").type("Test subquestion prompt").tab();
       getAndClearLastPhoneMessage(state => {
         expect(state.subinteractives[0].authoredState.prompt).include("Test subquestion prompt");
-      }, 100);
+      }, 200);
     });
 
     // This tests specifically a bug that was present and it's pretty subtle.

--- a/cypress/integration/video-player.test.js
+++ b/cypress/integration/video-player.test.js
@@ -14,7 +14,10 @@ const authoredStateSample = {
 
 
 context("Test Video Player interactive", () => {
+  let i = 0;
+
   beforeEach(() => {
+    if (i++ > 0) cy.wait(3000);
     cy.visit("/wrapper.html?iframe=/video-player");
   });
 
@@ -63,14 +66,14 @@ context("Test Video Player interactive", () => {
       });
       phoneListen("interactiveState");
       cy.getIframeBody().find(".vjs-big-play-button").click();
+      cy.getIframeBody().find(".vjs-text-track-cue").should("include.text", "This is a drake");
+      cy.getIframeBody().find(".vjs-current-time-display").should("include.text", "0:01");
+      cy.getIframeBody().find(".vjs-poster.vjs-hidden").should("exist");
+
       getAndClearLastPhoneMessage((state) => {
         expect(state.lastViewedTimestamp).greaterThan(1.0);
-
-        cy.getIframeBody().find(".vjs-text-track-cue").should("include.text", "This is a drake");
-        cy.getIframeBody().find(".vjs-current-time-display").should("include.text", "0:01");
-        cy.getIframeBody().find(".vjs-poster.vjs-hidden").should("exist");
-
-      });
+        // must wait for video to finish apparently
+      }, 15000);
     });
   });
   context("Authoring view", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2403,34 +2403,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/blob-util": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@types/blob-util/-/blob-util-1.3.3.tgz",
-      "integrity": "sha512-4ahcL/QDnpjWA2Qs16ZMQif7HjGP2cw3AGjHabybjw7Vm1EKu+cfQN1D78BaZbS1WJNa1opSMF5HNMztx7lR0w==",
-      "dev": true
-    },
-    "@types/bluebird": {
-      "version": "3.5.29",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.29.tgz",
-      "integrity": "sha512-kmVtnxTuUuhCET669irqQmPAez4KFnFVKvpleVRyfC3g+SHD1hIkFZcWLim9BVcwUBLO59o8VZE4yGCmTif8Yw==",
-      "dev": true
-    },
-    "@types/chai": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.7.tgz",
-      "integrity": "sha512-luq8meHGYwvky0O7u0eQZdA7B4Wd9owUCqvbw2m3XCrCU8mplYOujMBbvyS547AxJkC+pGnd0Cm15eNxEUNU8g==",
-      "dev": true
-    },
-    "@types/chai-jquery": {
-      "version": "1.1.40",
-      "resolved": "https://registry.npmjs.org/@types/chai-jquery/-/chai-jquery-1.1.40.tgz",
-      "integrity": "sha512-mCNEZ3GKP7T7kftKeIs7QmfZZQM7hslGSpYzKbOlR2a2HCFf9ph4nlMRA9UnuOETeOQYJVhJQK7MwGqNZVyUtQ==",
-      "dev": true,
-      "requires": {
-        "@types/chai": "*",
-        "@types/jquery": "*"
-      }
-    },
     "@types/cheerio": {
       "version": "0.22.18",
       "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.18.tgz",
@@ -2570,25 +2542,10 @@
         "pretty-format": "^25.2.1"
       }
     },
-    "@types/jquery": {
-      "version": "3.3.31",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.31.tgz",
-      "integrity": "sha512-Lz4BAJihoFw5nRzKvg4nawXPzutkv7wmfQ5121avptaSIXlDNJCUuxZxX/G+9EVidZGuO0UBlk+YjKbwRKJigg==",
-      "dev": true,
-      "requires": {
-        "@types/sizzle": "*"
-      }
-    },
     "@types/json-schema": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
       "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
-      "dev": true
-    },
-    "@types/lodash": {
-      "version": "4.14.149",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
-      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
       "dev": true
     },
     "@types/long": {
@@ -2600,12 +2557,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-      "dev": true
-    },
-    "@types/mocha": {
-      "version": "5.2.7",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
-      "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
       "dev": true
     },
     "@types/node": {
@@ -2681,21 +2632,11 @@
         "@types/react": "*"
       }
     },
-    "@types/sinon": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.1.tgz",
-      "integrity": "sha512-EZQUP3hSZQyTQRfiLqelC9NMWd1kqLcmQE0dMiklxBkgi84T+cHOhnKpgk4NnOWpGX863yE6+IaGnOXUNFqDnQ==",
+    "@types/sinonjs__fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz",
+      "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==",
       "dev": true
-    },
-    "@types/sinon-chai": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.3.tgz",
-      "integrity": "sha512-TOUFS6vqS0PVL1I8NGVSNcFaNJtFoyZPXZ5zur+qlhDfOmQECZZM4H4kKgca6O8L+QceX/ymODZASfUfn+y4yQ==",
-      "dev": true,
-      "requires": {
-        "@types/chai": "*",
-        "@types/sinon": "*"
-      }
     },
     "@types/sizzle": {
       "version": "2.3.2",
@@ -3213,9 +3154,9 @@
       "dev": true
     },
     "arch": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
-      "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.2.tgz",
+      "integrity": "sha512-NTBIIbAfkJeIletyABbVtdPgeKfDafR+1mZV/AyyfC1UkVkp9iUjV+wwmqtUgphHYajbI86jejBJp5e+jkGTiQ==",
       "dev": true
     },
     "are-we-there-yet": {
@@ -5497,9 +5438,9 @@
       }
     },
     "commander": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
-      "integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
       "dev": true
     },
     "common-tags": {
@@ -6003,48 +5944,39 @@
       "dev": true
     },
     "cypress": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.5.0.tgz",
-      "integrity": "sha512-2A4g5FW5d2fHzq8HKUGAMVTnW6P8nlWYQALiCoGN4bqBLvgwhYM/oG9oKc2CS6LnvgHFiKivKzpm9sfk3uU3zQ==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.10.0.tgz",
+      "integrity": "sha512-eFv1WPp4zFrAgZ6mwherBGVsTpHvay/hEF5F7U7yfAkTxsUQn/ZG/LdX67fIi3bKDTQXYzFv/CvywlQSeug8Bg==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
         "@cypress/request": "2.88.5",
         "@cypress/xvfb": "1.2.4",
-        "@types/blob-util": "1.3.3",
-        "@types/bluebird": "3.5.29",
-        "@types/chai": "4.2.7",
-        "@types/chai-jquery": "1.1.40",
-        "@types/jquery": "3.3.31",
-        "@types/lodash": "4.14.149",
-        "@types/minimatch": "3.0.3",
-        "@types/mocha": "5.2.7",
-        "@types/sinon": "7.5.1",
-        "@types/sinon-chai": "3.2.3",
+        "@types/sinonjs__fake-timers": "6.0.1",
         "@types/sizzle": "2.3.2",
-        "arch": "2.1.1",
+        "arch": "2.1.2",
         "bluebird": "3.7.2",
         "cachedir": "2.3.0",
         "chalk": "2.4.2",
         "check-more-types": "2.24.0",
         "cli-table3": "0.5.1",
-        "commander": "4.1.0",
+        "commander": "4.1.1",
         "common-tags": "1.8.0",
         "debug": "4.1.1",
-        "eventemitter2": "4.1.2",
+        "eventemitter2": "6.4.2",
         "execa": "1.0.0",
         "executable": "4.1.1",
         "extract-zip": "1.7.0",
         "fs-extra": "8.1.0",
-        "getos": "3.1.4",
+        "getos": "3.2.1",
         "is-ci": "2.0.0",
-        "is-installed-globally": "0.1.0",
+        "is-installed-globally": "0.3.2",
         "lazy-ass": "1.6.0",
         "listr": "0.14.3",
         "lodash": "4.17.15",
         "log-symbols": "3.0.0",
         "minimist": "1.2.5",
-        "moment": "2.24.0",
+        "moment": "2.26.0",
         "ospath": "1.2.2",
         "pretty-bytes": "5.3.0",
         "ramda": "0.26.1",
@@ -6851,9 +6783,9 @@
       "dev": true
     },
     "eventemitter2": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-4.1.2.tgz",
-      "integrity": "sha1-DhqEd6+CGm7zmVsxG/dMI6UkfxU=",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.2.tgz",
+      "integrity": "sha512-r/Pwupa5RIzxIHbEKCkNXqpEQIIT4uQDxmP4G/Lug/NokVUWj0joz/WzWl3OxRpC5kDrH/WdiUJoR+IrwvXJEw==",
       "dev": true
     },
     "eventemitter3": {
@@ -7796,12 +7728,12 @@
       }
     },
     "getos": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/getos/-/getos-3.1.4.tgz",
-      "integrity": "sha512-UORPzguEB/7UG5hqiZai8f0vQ7hzynMQyJLxStoQ8dPGAcmgsfXOPA4iE/fGtweHYkK+z4zc9V0g+CIFRf5HYw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
+      "integrity": "sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==",
       "dev": true,
       "requires": {
-        "async": "^3.1.0"
+        "async": "^3.2.0"
       }
     },
     "getpass": {
@@ -7865,12 +7797,12 @@
       }
     },
     "global-dirs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
+      "integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
       "dev": true,
       "requires": {
-        "ini": "^1.3.4"
+        "ini": "^1.3.5"
       }
     },
     "global-modules": {
@@ -8970,13 +8902,13 @@
       "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
     },
     "is-installed-globally": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
-      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
+      "integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
       "dev": true,
       "requires": {
-        "global-dirs": "^0.1.0",
-        "is-path-inside": "^1.0.0"
+        "global-dirs": "^2.0.1",
+        "is-path-inside": "^3.0.1"
       }
     },
     "is-map": {
@@ -9031,13 +8963,10 @@
       }
     },
     "is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "^1.0.1"
-      }
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
+      "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+      "dev": true
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -10964,9 +10893,9 @@
       }
     },
     "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
+      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw==",
       "dev": true
     },
     "moo": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "babel-jest": "^25.5.1",
     "copy-webpack-plugin": "^5.1.1",
     "css-loader": "^3.5.3",
-    "cypress": "^4.5.0",
+    "cypress": "^4.10.0",
     "cypress-plugin-tab": "^1.0.5",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",


### PR DESCRIPTION
Cypress tests have been somewhat inexplicably failing on master and on several PR branches for reasons that don't seem obviously related to any recent code changes. After working with @eireland for a while this afternoon/evening, the following changes seem to be sufficient, although it's not entirely clear which are necessary:
- update to cypress 4.10
- add waits before page visits
- video interactive waits for video to finish before querying received messages
- video interactive rearranges the order of some assertions
