### PR TITLE
Log different events for the video player

### DIFF
--- a/cypress/integration/video-player.test.js
+++ b/cypress/integration/video-player.test.js
@@ -17,7 +17,7 @@ context("Test Video Player interactive", () => {
   let i = 0;
 
   beforeEach(() => {
-    if (i++ > 0) cy.wait(3000);
+    if (i++ > 0) cy.wait(4000);
     cy.visit("/wrapper.html?iframe=/video-player");
   });
 
@@ -70,10 +70,10 @@ context("Test Video Player interactive", () => {
       cy.getIframeBody().find(".vjs-current-time-display").should("include.text", "0:01");
       cy.getIframeBody().find(".vjs-poster.vjs-hidden").should("exist");
 
-      getAndClearLastPhoneMessage((state) => {
+      getAndClearLastPhoneMessage(state => {
         expect(state.lastViewedTimestamp).greaterThan(1.0);
         // must wait for video to finish apparently
-      }, 15000);
+      }, 22000);
     });
   });
   context("Authoring view", () => {

--- a/src/video-player/components/runtime.tsx
+++ b/src/video-player/components/runtime.tsx
@@ -83,8 +83,9 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
           // Store a ref to the captions track s we can check visibility later. There is no easy toggle event for captions show/hide
           captionsTrackRef.current = player.textTracks()[0];
           if (captionsTrackRef.current) {
-            captionsTrackRef.current.addEventListener("cuechange", (cue) => {
-              log("cue change", { videoUrl: authoredState.videoUrl });
+            captionsTrackRef.current.addEventListener("cuechange", () => {
+              const currentCue = captionsTrackRef.current?.activeCues?.length && captionsTrackRef.current?.activeCues.length > 0 && captionsTrackRef.current?.activeCues[0];
+              log("cue change", { videoUrl: authoredState.videoUrl, currentCue: (currentCue as VTTCue).text });
             });
           }
         }
@@ -131,7 +132,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     if (captionsTrackRef.current) {
       setCaptionDisplayState(captionsTrackRef.current.mode);
     }
-    updateState();
+    updateState(false, null);
   };
 
   const handlePlay = () => {
@@ -146,7 +147,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     updateState(true, "video stopped");
   };
 
-  const updateState = (forceSave = false, logMessage = "") => {
+  const updateState = (forceSave: boolean, logMessage: string | null) => {
     // store current playback progress each second
     const updateIntervalReady = Math.trunc(getViewTime()) > saveStateInterval.current;
     if (updateIntervalReady || forceSave) {
@@ -159,11 +160,11 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
         percentageViewed,
         lastViewedTimestamp: getViewTime()
       }));
-      if (logMessage.length > 0) {
+      if (logMessage) {
         log(logMessage, { videoUrl: authoredState.videoUrl, percentage_viewed: percentageViewed });
       }
       if (captionsTrackRef.current && captionsTrackRef.current.mode !== captionDisplayState) {
-        log(`video captions toggled: ${captionsTrackRef.current.mode}`, { videoIrl: authoredState.videoUrl });
+        log(`video captions toggled: ${captionsTrackRef.current.mode}`, { videoUrl: authoredState.videoUrl });
         setCaptionDisplayState(captionsTrackRef.current.mode);
       }
     }

--- a/src/video-player/components/runtime.tsx
+++ b/src/video-player/components/runtime.tsx
@@ -163,7 +163,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
         log(logMessage, { videoUrl: authoredState.videoUrl, percentage_viewed: percentageViewed });
       }
       if (captionsTrackRef.current && captionsTrackRef.current.mode !== captionDisplayState) {
-        log(`Video captions toggled: ${captionsTrackRef.current.mode}`, { videoIrl: authoredState.videoUrl });
+        log(`video captions toggled: ${captionsTrackRef.current.mode}`, { videoIrl: authoredState.videoUrl });
         setCaptionDisplayState(captionsTrackRef.current.mode);
       }
     }


### PR DESCRIPTION
We were already logging the play / stop of the video player, this PR addresses the events relating to captions / subtitles, and handling the user scrubbing through a video as a separate logged event.

There are no easy hooks to capture the toggle of a caption so I'm relying on the regular state save interval to check on the current state and report if it has been changed. This keeps us from having to dig through the control bar hierarchy to find the actual toggle. 