### PR TITLE
Fix auto-height hook in Safari

### DIFF
--- a/src/shared/components/base-app.tsx
+++ b/src/shared/components/base-app.tsx
@@ -39,7 +39,7 @@ export const BaseApp = <IAuthoredState extends IBaseAuthoredState>(props: IProps
   const isLoading = !initMessage;
   const isRuntimeView = initMessage?.mode === "runtime";
 
-  useAutoHeight({ container, disabled: isRuntimeView && disableAutoHeight || isLoading });
+  useAutoHeight({ container: container.current, disabled: isRuntimeView && disableAutoHeight || isLoading });
   useShutterbug({ container: "." + css.runtime });
   useBasicLogging({ disabled: !isRuntimeView });
 

--- a/src/shared/components/base-question-app.tsx
+++ b/src/shared/components/base-question-app.tsx
@@ -52,7 +52,7 @@ export const BaseQuestionApp = <IAuthoredState extends IAuthoringMetadata & IBas
   const isLoading = !initMessage;
   const isRuntimeView = initMessage?.mode === "runtime";
 
-  useAutoHeight({ container, disabled: isRuntimeView && disableAutoHeight || isLoading });
+  useAutoHeight({ container: container.current, disabled: isRuntimeView && disableAutoHeight || isLoading });
   useHint();
   useRequiredQuestion();
   useShutterbug({ container: "." + css.runtime });

--- a/src/shared/hooks/use-auto-height.test.ts
+++ b/src/shared/hooks/use-auto-height.test.ts
@@ -1,4 +1,3 @@
-import { useRef } from "react";
 import { renderHook } from "@testing-library/react-hooks";
 import { useAutoHeight } from "./use-auto-height";
 
@@ -10,14 +9,17 @@ describe("useAutoHeight", () => {
       this.observe = observeSpy;
       this.disconnect = disconnectSpy;
     };
+    const container = document.createElement("div");
     const HookWrapper = () => {
-      const container = useRef<HTMLDivElement>(document.createElement("div"));
       useAutoHeight({ container });
     };
+    container.style.overflow = "auto";
     const { unmount } = renderHook(HookWrapper);
+    expect(container.style.overflow).toEqual("hidden"); // necessary for scrollHeight to work correctly
     expect(observeSpy).toHaveBeenCalled();
     unmount();
     expect(disconnectSpy).toHaveBeenCalled();
+    expect(container.style.overflow).toEqual("auto"); // make sure that overflow is restored
   });
 
   it("shouldn't do anything when it's disabled", () => {
@@ -28,7 +30,7 @@ describe("useAutoHeight", () => {
       this.disconnect = disconnectSpy;
     };
     const HookWrapper = () => {
-      const container = useRef<HTMLDivElement>(document.createElement("div"));
+      const container = document.createElement("div");
       useAutoHeight({ container, disabled: true });
     };
     const { unmount } = renderHook(HookWrapper);

--- a/src/shared/hooks/use-auto-height.ts
+++ b/src/shared/hooks/use-auto-height.ts
@@ -34,22 +34,15 @@ export const useAutoHeight = ({ container, disabled }: IConfig) => {
       }
     });
 
-    let prevOverflowStyle: string | null = null;
-    if (container) {
-      // Set overflow=hidden style to make sure that scrollHeight reports correct value. See: https://www.pivotaltracker.com/story/show/174256088
-      prevOverflowStyle = container.style.overflow;
-      container.style.overflow = "hidden";
-      observer.observe(container);
-    }
+    // Set overflow=hidden style to make sure that scrollHeight reports correct value. See: https://www.pivotaltracker.com/story/show/174256088
+    const prevOverflowStyle = container.style.overflow;
+    container.style.overflow = "hidden";
+    observer.observe(container);
     // Cleanup function.
     return () => {
       observer.disconnect();
-      if (container) {
-        if (prevOverflowStyle !== null) {
-          container.style.overflow = prevOverflowStyle;
-        }
-        observer.observe(container);
-      }
+      container.style.overflow = prevOverflowStyle;
+      observer.observe(container);
     };
   }, [container, disabled]);
 };

--- a/src/shared/hooks/use-auto-height.ts
+++ b/src/shared/hooks/use-auto-height.ts
@@ -1,9 +1,9 @@
-import { RefObject, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import ResizeObserver from "resize-observer-polyfill";
 import { setHeight } from "@concord-consortium/lara-interactive-api";
 
 interface IConfig {
-  container: RefObject<HTMLDivElement>;
+  container: HTMLDivElement | null;
   disabled?: boolean;
 }
 
@@ -11,7 +11,7 @@ export const useAutoHeight = ({ container, disabled }: IConfig) => {
   const setHeightCalled = useRef(false);
 
   useEffect(() => {
-    if (disabled) {
+    if (disabled || !container) {
       if (setHeightCalled.current) {
         // Sending empty string to LARA will disable height and start using aspect ratio again.
         // If setHeight has been never called, it doesn't make sense to send this message to LARA.
@@ -26,18 +26,30 @@ export const useAutoHeight = ({ container, disabled }: IConfig) => {
       const entry = entries[0];
       // scrollHeight describes min height of the container necessary to avoid scrollbars.
       // It works better than offsetHeight (e.g. when we have some elements with `float:right` css props).
+      // Note that this works correctly in all browsers only when CSS overflow is set to "hidden".
       const height = entry?.target?.scrollHeight;
       if (height && height > 0) {
         setHeight(Math.ceil(height));
         setHeightCalled.current = true;
       }
     });
-    if (container.current) {
-      observer.observe(container.current);
+
+    let prevOverflowStyle: string | null = null;
+    if (container) {
+      // Set overflow=hidden style to make sure that scrollHeight reports correct value. See: https://www.pivotaltracker.com/story/show/174256088
+      prevOverflowStyle = container.style.overflow;
+      container.style.overflow = "hidden";
+      observer.observe(container);
     }
     // Cleanup function.
     return () => {
       observer.disconnect();
+      if (container) {
+        if (prevOverflowStyle !== null) {
+          container.style.overflow = prevOverflowStyle;
+        }
+        observer.observe(container);
+      }
     };
   }, [container, disabled]);
 };


### PR DESCRIPTION
[#174256088]

This issue is fixed by setting CSS overflow to "hidden". It seems to be required for scrollHeight to work correctly. I've made sure that style is restored when we disable this hook and added a test.

I've also updated arguments of autoHeight hook to accept HTML Element instead of ref, as it makes more sense and it's safer. 1st render with `container.current = null`, and second with `container.current = div element` probably wouldn't work in the old implementation.