### PR TITLE
Remove on-screen track of last viewed timestamp

### DIFF
--- a/src/video-player/components/runtime.test.tsx
+++ b/src/video-player/components/runtime.test.tsx
@@ -31,11 +31,6 @@ describe("Runtime", () => {
     expect(wrapper.find(".video-js").prop("poster")).toEqual(authoredState.poster);
   });
 
-  it("handles passed interactiveState", () => {
-    const wrapper = shallow(<Runtime authoredState={authoredState} interactiveState={interactiveState} />);
-    expect(wrapper.text()).toEqual(expect.stringContaining(interactiveState.lastViewedTimestamp.toString()));
-  });
-
   it("parses aspect ratio", () => {
     expect(getAspectRatio("2:1")).toEqual("2:1");
     expect(getAspectRatio("1.5")).toEqual("150:100");

--- a/src/video-player/components/runtime.test.tsx
+++ b/src/video-player/components/runtime.test.tsx
@@ -15,11 +15,11 @@ const authoredState = {
   required: true
 };
 
-const interactiveState = {
-  answerType: "interactive_state" as const,
-  percentageViewed: 0.2,
-  lastViewedTimestamp: 1.2
-};
+// const interactiveState = {
+//   answerType: "interactive_state" as const,
+//   percentageViewed: 0.2,
+//   lastViewedTimestamp: 1.2
+// };
 
 describe("Runtime", () => {
   it("renders prompt and video with credits", () => {

--- a/src/video-player/components/runtime.tsx
+++ b/src/video-player/components/runtime.tsx
@@ -188,7 +188,6 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
           />
         </div>
       </div>
-      {interactiveState?.lastViewedTimestamp && <div className={css.lastViewed}>{interactiveState.lastViewedTimestamp}</div>}
       {authoredState.credit && <div className={css.credit}>{authoredState.credit}</div>}
       {
         authoredState.creditLink &&


### PR DESCRIPTION
A quick fix for the visible 0 seen on screen if the student has never watched the video before. 