### PR TITLE
Add `linkedInteractives` support, necessary hooks, and use them in ImageQuestion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1214,18 +1214,11 @@
       }
     },
     "@concord-consortium/lara-interactive-api": {
-      "version": "0.5.0-pre.4",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-0.5.0-pre.4.tgz",
-      "integrity": "sha512-mKdoemcMbSDAZQf/q6FWoXfyBSuVShUUEnEW4el9FP3n4QfIinJGR1gKcvsEOyaE5cv3+R2fpglsI9p9a37/Xg==",
+      "version": "0.6.0-pre.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-0.6.0-pre.1.tgz",
+      "integrity": "sha512-f9GpaUDArpBeZKoevc+mcitr4n6RW3kHMULFfbXkbzzhigD6feDbJeHX2gC9htf4lVhsngRU0YPRWIFB4SbImg==",
       "requires": {
         "iframe-phone": "^1.3.1"
-      },
-      "dependencies": {
-        "iframe-phone": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/iframe-phone/-/iframe-phone-1.3.1.tgz",
-          "integrity": "sha512-pipd9e4l5AE0K3+ZcQxb/+zd1pvCWbu6wuQlxdqChIfwe9jnnm2HwcNra/GvLovDxe36+uZusFMN0rNKlFIvdQ=="
-        }
       }
     },
     "@concord-consortium/slate-editor": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16365,6 +16365,11 @@
         "scheduler": "^0.19.1"
       }
     },
+    "react-hooks-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/react-hooks-use-previous/-/react-hooks-use-previous-1.1.1.tgz",
+      "integrity": "sha512-UNUDGZYC+pHOxHJcTb1dgYs1+GK7SHQszSs+h78O1vjtNe8BaHzXSv12M7PmSUGhuFaVyHqeTCXHX8m/M0ivhg=="
+    },
     "react-immutable-proptypes": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/react-immutable-proptypes/-/react-immutable-proptypes-2.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7531,8 +7531,7 @@
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "default-gateway": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "jquery": "^3.5.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-hooks-use-previous": "^1.1.1",
     "react-jsonschema-form": "^1.8.1",
     "resize-observer-polyfill": "^1.5.1",
     "shutterbug": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
-    "@concord-consortium/lara-interactive-api": "0.5.0-pre.4",
+    "@concord-consortium/lara-interactive-api": "0.6.0-pre.1",
     "@concord-consortium/slate-editor": "^0.6.0",
     "deep-equal": "^2.0.3",
     "deepmerge": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "@concord-consortium/lara-interactive-api": "0.5.0-pre.4",
     "@concord-consortium/slate-editor": "^0.6.0",
     "deep-equal": "^2.0.3",
+    "deepmerge": "^4.2.2",
     "dompurify": "^2.0.14",
     "drawing-tool": "^2.0.1",
     "firebase": "^7.19.0",

--- a/src/image-question/components/app.test.tsx
+++ b/src/image-question/components/app.test.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { render } from "@testing-library/react";
-import { useAuthoredState, useInitMessage, useInteractiveState
-        } from "@concord-consortium/lara-interactive-api";
+import { useAuthoredState, useInitMessage, useInteractiveState } from "@concord-consortium/lara-interactive-api";
 import { App } from "./app";
 import { IAuthoredState, IInteractiveState } from "./types";
 
@@ -11,7 +10,8 @@ jest.mock("@concord-consortium/lara-interactive-api", () => ({
   useInitMessage: jest.fn(),
   useAuthoredState: jest.fn(),
   useInteractiveState: jest.fn(),
-  setSupportedFeatures: jest.fn()
+  setSupportedFeatures: jest.fn(),
+  getInteractiveList: jest.fn(() => new Promise(() => { /* never resolve */ }))
 }));
 
 const useInitMessageMock = useInitMessage as jest.Mock;
@@ -32,7 +32,7 @@ const interactiveState = {
   answerText: "Test answer",
 } as IInteractiveState;
 
-describe("Open response question", () => {
+describe("Image question", () => {
   beforeEach(() => {
     // JSDOM doesn't support selection yet, but Slate handles a null return
     // cf. https://github.com/jsdom/jsdom/issues/317#ref-commit-30bedcf

--- a/src/image-question/components/app.tsx
+++ b/src/image-question/components/app.tsx
@@ -6,7 +6,6 @@ import { Runtime } from "./runtime";
 import { StampCollection } from "../../drawing-tool/components/app";
 import { drawingToolAuthoringProps, stampCollectionDefinition, drawingToolAuthoringSchema } from "../../drawing-tool/components/app";
 
-
 export interface IAuthoredState extends IAuthoringInteractiveMetadata {
   version: number;
   hint?: string;
@@ -19,6 +18,8 @@ export interface IAuthoredState extends IAuthoringInteractiveMetadata {
   answerType: string;
   defaultAnswer: string;
   modalSupported?: boolean;
+  useSnapshot?: boolean;
+  snapshotTarget?: string;
 }
 
 export interface IInteractiveState extends IRuntimeInteractiveMetadata {
@@ -58,6 +59,16 @@ const baseAuthoringProps = {
       defaultAnswer: {
         type: "string",
         title: "Default answer"
+      },
+      useSnapshot: {
+        title: "Use snapshot button",
+        type: "boolean"
+      },
+      snapshotTarget: {
+        title: "Snapshot target",
+        type: "string",
+        enum: [],
+        enumNames: []
       }
     },
     dependencies: {
@@ -117,5 +128,6 @@ export const App = () => (
     Runtime={Runtime}
     baseAuthoringProps={baseAuthoringProps}
     isAnswered={isAnswered}
+    linkedInteractiveProps={[{ label: "snapshotTarget", supportsSnapshots: true }]}
   />
 );

--- a/src/image-question/components/runtime.tsx
+++ b/src/image-question/components/runtime.tsx
@@ -2,13 +2,13 @@ import React, { useMemo, useRef, useState } from "react";
 import { IRuntimeQuestionComponentProps } from "../../shared/components/base-question-app";
 import { renderHTML } from "../../shared/utilities/render-html";
 import { IAuthoredState, IInteractiveState } from "./app";
-import css from "./runtime.scss";
 import { Runtime as DrawingToolRuntime } from "../../drawing-tool/components/runtime";
 import { IAuthoredState as IDrawingAuthoredState } from "../../drawing-tool/components/app";
 import { IInteractiveState as IDrawingInteractiveState } from "../../drawing-tool/components/app";
 import { showModal } from "@concord-consortium/lara-interactive-api";
 import ZoomIcon from "../../shared/icons/zoom.svg";
 import { v4 as uuidv4 } from "uuid";
+import css from "./runtime.scss";
 
 // https://stackoverflow.com/a/52703444
 type OptionalExceptFor<T, TRequired extends keyof T> = Partial<T> & Pick<T, TRequired>;
@@ -82,6 +82,8 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
         />
       </div>
       {modalSupported && <div className={`${css.viewHighRes} .glyphicon-zoom-in`} onClick={handleModal}><ZoomIcon /></div>}
+
+      <p>Snapshot target: { authoredState.snapshotTarget }</p>
     </fieldset>
   );
 };

--- a/src/shared/components/base-app.tsx
+++ b/src/shared/components/base-app.tsx
@@ -3,9 +3,10 @@ import { useAutoHeight } from "../hooks/use-auto-height";
 import { useShutterbug } from "../hooks/use-shutterbug";
 import { BaseAuthoring, IBaseAuthoringProps } from "./base-authoring";
 import { setSupportedFeatures, useAuthoredState, useInitMessage } from "@concord-consortium/lara-interactive-api";
-
-import css from "./base-app.scss";
 import { useBasicLogging } from "../hooks/use-basic-logging";
+import {useLinkedInteractives} from "../hooks/use-linked-interactives";
+import {ILinkedInteractiveProp} from "../hooks/use-linked-interactives-authoring";
+import css from "./base-app.scss";
 
 export type UpdateFunc<State> = (prevState: State | null) => State;
 
@@ -28,11 +29,12 @@ interface IProps<IAuthoredState> {
   baseAuthoringProps?: Omit<IBaseAuthoringProps<IAuthoredState>, "authoredState" | "setAuthoredState">;
   Runtime: React.FC<IRuntimeComponentProps<IAuthoredState>>;
   disableAutoHeight?: boolean;
+  linkedInteractiveProps?: ILinkedInteractiveProp[];
 }
 
 // BaseApp for interactives that don't save interactive state and don't show up in the report. E.g. image, video.
 export const BaseApp = <IAuthoredState extends IBaseAuthoredState>(props: IProps<IAuthoredState>) => {
-  const { Authoring, baseAuthoringProps, Runtime, disableAutoHeight } = props;
+  const { Authoring, baseAuthoringProps, Runtime, disableAutoHeight, linkedInteractiveProps } = props;
   const container = useRef<HTMLDivElement>(null);
   const { authoredState, setAuthoredState } = useAuthoredState<IAuthoredState>();
   const initMessage = useInitMessage();
@@ -42,6 +44,7 @@ export const BaseApp = <IAuthoredState extends IBaseAuthoredState>(props: IProps
   useAutoHeight({ container: container.current, disabled: isRuntimeView && disableAutoHeight || isLoading });
   useShutterbug({ container: "." + css.runtime });
   useBasicLogging({ disabled: !isRuntimeView });
+  useLinkedInteractives(linkedInteractiveProps?.map(li => li.label));
 
   useEffect(() => {
     setSupportedFeatures({

--- a/src/shared/components/base-authoring.test.tsx
+++ b/src/shared/components/base-authoring.test.tsx
@@ -3,6 +3,13 @@ import { mount, shallow } from "enzyme";
 import { BaseAuthoring } from "./base-authoring";
 import { JSONSchema6 } from "json-schema";
 import Form from "react-jsonschema-form";
+import { useLinkedInteractivesAuthoring } from "../hooks/use-linked-interactives-authoring";
+
+jest.mock("../hooks/use-linked-interactives-authoring", () => ({
+  useLinkedInteractivesAuthoring: jest.fn((props: any) => props.schema)
+}));
+
+const useLinkedInteractivesAuthoringMock = useLinkedInteractivesAuthoring as jest.Mock;
 
 interface ITestAuthoredState {
   version: number;
@@ -29,6 +36,10 @@ const authoredState = {
 };
 
 describe("BaseAuthoring", () => {
+  beforeEach(() => {
+    useLinkedInteractivesAuthoringMock.mockClear();
+  });
+
   it("renders react-jsonschema-form and passes the authoredState", () => {
     const setState = jest.fn();
     const uiSchema = {};
@@ -77,5 +88,14 @@ describe("BaseAuthoring", () => {
       version: 1,
       testValue: "New test value!!!"
     });
+  });
+
+  it("uses useLinkedInteractivesHook", () => {
+    mount(<BaseAuthoring<ITestAuthoredState>
+        authoredState={authoredState}
+        setAuthoredState={jest.fn()}
+        schema={schema}
+    />);
+    expect(useLinkedInteractivesAuthoringMock).toHaveBeenCalled();
   });
 });

--- a/src/shared/components/base-authoring.tsx
+++ b/src/shared/components/base-authoring.tsx
@@ -3,7 +3,7 @@ import Form, { Field, FormValidation, IChangeEvent, UiSchema } from "react-jsons
 import { JSONSchema6 } from "json-schema";
 import { useDelayedValidation } from "../hooks/use-delayed-validation";
 import { RichTextWidget } from "../widgets/rich-text/rich-text-widget";
-
+import { ILinkedInteractiveProp, useLinkedInteractivesAuthoring } from "../hooks/use-linked-interactives-authoring";
 import "../../shared/styles/boostrap-3.3.7.css"; // necessary to style react-jsonschema-form
 import css from "../../shared/styles/authoring.scss";
 
@@ -17,6 +17,7 @@ export interface IBaseAuthoringProps<IAuthoredState> {
   // react-jsonschema-form additional fields.
   fields?: { [name: string]: Field };
   validate?: (formData: IAuthoredState, errors: FormValidation) => FormValidation;
+  linkedInteractiveProps?: ILinkedInteractiveProp[];
 }
 
 // custom widgets
@@ -24,7 +25,7 @@ const widgets = {
   richtext: RichTextWidget
 };
 
-export const BaseAuthoring = <IAuthoredState,>({ authoredState, setAuthoredState, preprocessFormData, schema, uiSchema, fields, validate }: IBaseAuthoringProps<IAuthoredState>) => {
+export const BaseAuthoring = <IAuthoredState,>({ authoredState, setAuthoredState, preprocessFormData, schema, uiSchema, fields, validate, linkedInteractiveProps }: IBaseAuthoringProps<IAuthoredState>) => {
   const formRef = useRef<Form<IAuthoredState>>(null);
   const triggerDelayedValidation = useDelayedValidation({ formRef });
 
@@ -43,11 +44,14 @@ export const BaseAuthoring = <IAuthoredState,>({ authoredState, setAuthoredState
     validate && triggerDelayedValidation();
   }, [validate, triggerDelayedValidation]);
 
+  // This hook provides list of interactives on a given page and saving of the linked interactive IDs.
+  const schemaWithInteractives = useLinkedInteractivesAuthoring({ linkedInteractiveProps, schema });
+
   return (
     <div className={css.authoring}>
       <Form
         ref={formRef}
-        schema={schema}
+        schema={schemaWithInteractives}
         uiSchema={uiSchema}
         widgets={widgets}
         formData={authoredState || {}}

--- a/src/shared/components/base-question-app.tsx
+++ b/src/shared/components/base-question-app.tsx
@@ -11,8 +11,10 @@ import {
 } from "@concord-consortium/lara-interactive-api";
 import { IBaseAuthoredState, UpdateFunc, IAuthoringComponentProps, IRuntimeComponentProps } from "./base-app";
 import { useBasicLogging } from "../hooks/use-basic-logging";
-
+import {useLinkedInteractives} from "../hooks/use-linked-interactives";
+import {ILinkedInteractiveProp} from "../hooks/use-linked-interactives-authoring";
 import css from "./base-app.scss";
+
 
 interface IBaseQuestionAuthoredState extends IBaseAuthoredState {
   hint?: string;
@@ -39,12 +41,13 @@ interface IProps<IAuthoredState, IInteractiveState> {
   disableSubmitBtnRendering?: boolean;
   // Note that isAnswered is required when `disableSubmitBtnRendering` is false.
   isAnswered?: (state: IInteractiveState | null) => boolean;
+  linkedInteractiveProps?: ILinkedInteractiveProp[];
 }
 
 // BaseApp for interactives that save interactive state and show in the report. E.g. open response, multiple choice.
 export const BaseQuestionApp = <IAuthoredState extends IAuthoringMetadata & IBaseQuestionAuthoredState,
   IInteractiveState extends IRuntimeMetadata & IBaseQuestionInteractiveState>(props: IProps<IAuthoredState, IInteractiveState>) => {
-  const { Authoring, baseAuthoringProps, Runtime, isAnswered, disableAutoHeight, disableSubmitBtnRendering } = props;
+  const { Authoring, baseAuthoringProps, Runtime, isAnswered, disableAutoHeight, disableSubmitBtnRendering, linkedInteractiveProps } = props;
   const container = useRef<HTMLDivElement>(null);
   const { authoredState, setAuthoredState } = useAuthoredState<IAuthoredState>();
   const { interactiveState, setInteractiveState } = useInteractiveState<IInteractiveState>();
@@ -57,6 +60,7 @@ export const BaseQuestionApp = <IAuthoredState extends IAuthoringMetadata & IBas
   useRequiredQuestion();
   useShutterbug({ container: "." + css.runtime });
   useBasicLogging({ disabled: !isRuntimeView });
+  useLinkedInteractives(linkedInteractiveProps?.map(li => li.label));
 
   useEffect(() => {
     setSupportedFeatures({
@@ -74,7 +78,12 @@ export const BaseQuestionApp = <IAuthoredState extends IAuthoringMetadata & IBas
       return <Authoring authoredState={authoredState} setAuthoredState={setAuthoredState} />;
     }
     if (!Authoring && baseAuthoringProps) {
-      return <BaseAuthoring {...baseAuthoringProps} authoredState={authoredState} setAuthoredState={setAuthoredState} />;
+      return <BaseAuthoring
+        {...baseAuthoringProps}
+        linkedInteractiveProps={linkedInteractiveProps}
+        authoredState={authoredState}
+        setAuthoredState={setAuthoredState}
+      />;
     }
   };
 

--- a/src/shared/hooks/use-linked-interactives-authoring.test.ts
+++ b/src/shared/hooks/use-linked-interactives-authoring.test.ts
@@ -73,7 +73,7 @@ describe("useLinkedInteractives", () => {
     });
   });
 
-  it("does not calls setLinkedInteractives when it's not necessary (linkedInteractives array and authoredState are matching)", () => {
+  it("does not call setLinkedInteractives when it's not necessary (linkedInteractives array and authoredState are matching)", () => {
     initMessage = {
       mode: "authoring",
       linkedInteractives: [{id: "ID1", label: "linkedInteractive1"}]

--- a/src/shared/hooks/use-linked-interactives-authoring.test.ts
+++ b/src/shared/hooks/use-linked-interactives-authoring.test.ts
@@ -109,9 +109,16 @@ describe("useLinkedInteractives", () => {
         schema: {}
       });
     };
-    renderHook(HookWrapper);
+    const { rerender } = renderHook(HookWrapper);
+    expect(setLinkedInteractivesMock).not.toHaveBeenCalled(); // Nothing should happen during initial render!
+    rerender();
+    expect(setLinkedInteractivesMock).not.toHaveBeenCalled(); // Still nothing, authored state wasn't updated.
+    authoredState = {
+      linkedInteractive1: "ID2"
+    };
+    rerender();
     expect(setLinkedInteractivesMock).toHaveBeenCalledWith({
-      linkedInteractives: [{id: "ID1", label: "linkedInteractive1"}]
+      linkedInteractives: [{id: "ID2", label: "linkedInteractive1"}]
     });
   });
 
@@ -121,7 +128,7 @@ describe("useLinkedInteractives", () => {
       linkedInteractives: [{id: "ID1", label: "linkedInteractive1"}]
     };
     authoredState = {
-      linkedInteractive1: undefined
+      linkedInteractive1: "ID2"
     };
     const HookWrapper = () => {
       return useLinkedInteractivesAuthoring({
@@ -131,7 +138,14 @@ describe("useLinkedInteractives", () => {
         schema: {}
       });
     };
-    renderHook(HookWrapper);
+    const { rerender } = renderHook(HookWrapper);
+    expect(setLinkedInteractivesMock).not.toHaveBeenCalled(); // Nothing should happen during initial render!
+    rerender();
+    expect(setLinkedInteractivesMock).not.toHaveBeenCalled(); // Still nothing, authored state wasn't updated.
+    authoredState = {
+      linkedInteractive1: undefined
+    };
+    rerender();
     expect(setLinkedInteractivesMock).toHaveBeenCalledWith({
       linkedInteractives: []
     });
@@ -153,9 +167,16 @@ describe("useLinkedInteractives", () => {
         schema: {}
       });
     };
-    renderHook(HookWrapper);
+    const { rerender } = renderHook(HookWrapper);
+    expect(setLinkedInteractivesMock).not.toHaveBeenCalled(); // Nothing should happen during initial render!
+    rerender();
+    expect(setLinkedInteractivesMock).not.toHaveBeenCalled(); // Still nothing, authored state wasn't updated.
+    authoredState = {
+      linkedInteractive1: "new ID 2"
+    };
+    rerender();
     expect(setLinkedInteractivesMock).toHaveBeenCalledWith({
-      linkedInteractives: [{id: "new ID", label: "linkedInteractive1"}]
+      linkedInteractives: [{id: "new ID 2", label: "linkedInteractive1"}]
     });
   });
 });

--- a/src/shared/hooks/use-linked-interactives-authoring.test.ts
+++ b/src/shared/hooks/use-linked-interactives-authoring.test.ts
@@ -93,7 +93,7 @@ describe("useLinkedInteractives", () => {
     expect(setLinkedInteractivesMock).not.toHaveBeenCalled();
   });
 
-  it("monitors authoredState updates and calls setLinkedInteractives when necessary - 1", () => {
+  it("monitors authoredState updates and calls setLinkedInteractives when necessary - 1", async () => {
     initMessage = {
       mode: "authoring",
       linkedInteractives: []

--- a/src/shared/hooks/use-linked-interactives-authoring.test.ts
+++ b/src/shared/hooks/use-linked-interactives-authoring.test.ts
@@ -1,0 +1,161 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { useLinkedInteractivesAuthoring } from "./use-linked-interactives-authoring";
+import { act } from "@testing-library/react";
+import {getInteractiveList, setLinkedInteractives} from "@concord-consortium/lara-interactive-api";
+
+let initMessage: any;
+let authoredState: any;
+let interactiveList: any;
+
+jest.mock("@concord-consortium/lara-interactive-api", () => ({
+  useInitMessage: jest.fn(() => initMessage),
+  useAuthoredState: jest.fn(() => ({
+    authoredState
+  })),
+  setLinkedInteractives: jest.fn(),
+  getInteractiveList: jest.fn(() => new Promise(resolve => setTimeout(() => resolve({ interactives: interactiveList }), 50)))
+}));
+
+const getInteractiveListMock = getInteractiveList as jest.Mock;
+const setLinkedInteractivesMock = setLinkedInteractives as jest.Mock;
+
+describe("useLinkedInteractives", () => {
+  beforeEach(() => {
+    initMessage = {};
+    authoredState = {};
+    interactiveList = [];
+    getInteractiveListMock.mockClear();
+    setLinkedInteractivesMock.mockClear();
+  });
+
+  it("downloads list of page interactives for properties present in schema and listed in linkedInteractiveProps", async () => {
+    initMessage = {
+      mode: "authoring"
+    };
+    interactiveList = [
+      { id: "ID1", name: "int 1" },
+      { id: "ID2", name: "int 2" },
+    ];
+    const schema = {
+      properties: {
+        linkedInteractive1: {},
+        linkedInteractive2: {}
+      }
+    };
+    const HookWrapper = () => {
+      return useLinkedInteractivesAuthoring({
+        linkedInteractiveProps: [
+          { label: "linkedInteractive1", supportsSnapshots: true },
+          { label: "linkedInteractive2" },
+          { label: "linkedInteractive3" } // this one is not present in the schema definition above
+        ],
+        schema
+      });
+    };
+    await act(async () => {
+      const { result, waitForNextUpdate } = renderHook(HookWrapper);
+      await waitForNextUpdate();
+      expect(result.current).toEqual({
+        properties: {
+          linkedInteractive1: {
+            enum: [ "ID1", "ID2" ],
+            enumNames: [ "ID1 (int 1)", "ID2 (int 2)" ]
+          },
+          linkedInteractive2: {
+            enum: [ "ID1", "ID2" ],
+            enumNames: [ "ID1 (int 1)", "ID2 (int 2)" ]
+          }
+          // Note that linkedInteractive3 wasn't listed in the original schema, so it's not added here either.
+        }
+      });
+      expect(getInteractiveListMock.mock.calls[0][0]).toEqual({ scope: "page", supportsSnapshots: true });
+      expect(getInteractiveListMock.mock.calls[1][0]).toEqual({ scope: "page", supportsSnapshots: undefined });
+    });
+  });
+
+  it("does not calls setLinkedInteractives when it's not necessary (linkedInteractives array and authoredState are matching)", () => {
+    initMessage = {
+      mode: "authoring",
+      linkedInteractives: [{id: "ID1", label: "linkedInteractive1"}]
+    };
+    authoredState = {
+      linkedInteractive1: "ID1"
+    };
+    const HookWrapper = () => {
+      return useLinkedInteractivesAuthoring({
+        linkedInteractiveProps: [
+          { label: "linkedInteractive1" },
+        ],
+        schema: {}
+      });
+    };
+    renderHook(HookWrapper);
+    expect(setLinkedInteractivesMock).not.toHaveBeenCalled();
+  });
+
+  it("monitors authoredState updates and calls setLinkedInteractives when necessary - 1", () => {
+    initMessage = {
+      mode: "authoring",
+      linkedInteractives: []
+    };
+    authoredState = {
+      linkedInteractive1: "ID1"
+    };
+    const HookWrapper = () => {
+      return useLinkedInteractivesAuthoring({
+        linkedInteractiveProps: [
+          { label: "linkedInteractive1" },
+        ],
+        schema: {}
+      });
+    };
+    renderHook(HookWrapper);
+    expect(setLinkedInteractivesMock).toHaveBeenCalledWith({
+      linkedInteractives: [{id: "ID1", label: "linkedInteractive1"}]
+    });
+  });
+
+  it("monitors authoredState updates and calls setLinkedInteractives when necessary - 2", () => {
+    initMessage = {
+      mode: "authoring",
+      linkedInteractives: [{id: "ID1", label: "linkedInteractive1"}]
+    };
+    authoredState = {
+      linkedInteractive1: undefined
+    };
+    const HookWrapper = () => {
+      return useLinkedInteractivesAuthoring({
+        linkedInteractiveProps: [
+          { label: "linkedInteractive1" },
+        ],
+        schema: {}
+      });
+    };
+    renderHook(HookWrapper);
+    expect(setLinkedInteractivesMock).toHaveBeenCalledWith({
+      linkedInteractives: []
+    });
+  });
+
+  it("monitors authoredState updates and calls setLinkedInteractives when necessary - 3", () => {
+    initMessage = {
+      mode: "authoring",
+      linkedInteractives: [{id: "ID1", label: "linkedInteractive1"}]
+    };
+    authoredState = {
+      linkedInteractive1: "new ID"
+    };
+    const HookWrapper = () => {
+      return useLinkedInteractivesAuthoring({
+        linkedInteractiveProps: [
+          { label: "linkedInteractive1" },
+        ],
+        schema: {}
+      });
+    };
+    renderHook(HookWrapper);
+    expect(setLinkedInteractivesMock).toHaveBeenCalledWith({
+      linkedInteractives: [{id: "new ID", label: "linkedInteractive1"}]
+    });
+  });
+});

--- a/src/shared/hooks/use-linked-interactives-authoring.tsx
+++ b/src/shared/hooks/use-linked-interactives-authoring.tsx
@@ -68,7 +68,7 @@ export const useLinkedInteractivesAuthoring = ({ linkedInteractiveProps, schema 
     }
   }, [authoredState, cachedLinkedInteractives, currentLinkedInteractives, initMessage?.mode, linkedInteractiveProps]);
 
-  // Get the interactive list that are on the same page.
+  // Get the list of interactives that are on the same page.
   const interactiveItemId = initMessage?.mode === "authoring" && initMessage.interactiveItemId;
   useEffect(() => {
     if (linkedInteractiveProps && initMessage?.mode === "authoring") {

--- a/src/shared/hooks/use-linked-interactives-authoring.tsx
+++ b/src/shared/hooks/use-linked-interactives-authoring.tsx
@@ -15,7 +15,7 @@ export interface IProps {
   schema: JSONSchema6;
 }
 
-type AuthoredState = {[key: string]: any};
+type AuthoredState = Record<string, any>;
 const emptyArray: ILinkedInteractive[] = [];
 
 

--- a/src/shared/hooks/use-linked-interactives-authoring.tsx
+++ b/src/shared/hooks/use-linked-interactives-authoring.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from "react";
+import deepmerge from "deepmerge";
+import { JSONSchema6 } from "json-schema";
+import {
+  useAuthoredState, useInitMessage, getInteractiveList, ILinkedInteractive, setLinkedInteractives
+} from "@concord-consortium/lara-interactive-api";
+
+export interface ILinkedInteractiveProp {
+  label: string;
+  supportsSnapshots?: boolean;
+}
+
+export interface IProps {
+  linkedInteractiveProps?: ILinkedInteractiveProp[];
+  schema: JSONSchema6;
+}
+
+type AuthoredState = {[key: string]: any};
+
+const emptyArray: ILinkedInteractive[] = [];
+
+export const useLinkedInteractivesAuthoring = ({ linkedInteractiveProps, schema }: IProps) => {
+  const initMessage = useInitMessage<AuthoredState>();
+  const [ interactiveList, setInteractiveList ] = useState<{[label: string]: {names: string[], ids: string[]}}>({});
+  const [ cachedLinkedInteractives, setCachedLinkedInteractives ] = useState<ILinkedInteractive[]>();
+  const { authoredState } = useAuthoredState<AuthoredState>();
+
+  // Note that initMessage.linkedInteractives is never updated, even after setLinkedInteractives is sent.
+  // So, cachedLinkedInteractives is used to keep the most recent value after updates.
+  const currentLinkedInteractives = cachedLinkedInteractives || (initMessage?.mode === "authoring" && initMessage?.linkedInteractives) || emptyArray;
+
+  // Handle authored state update. Each time one of the linked interactive properties is updated, send updated
+  // linkedInteractives array to LARA parent window. cachedLinkedInteractives acts only as a cache, so we don't
+  // send the message each time the authoredState is updated (e.g. its other, unrelated fields).
+  useEffect(() => {
+    if (linkedInteractiveProps && authoredState && initMessage?.mode === "authoring") {
+      linkedInteractiveProps.forEach(li => {
+        const name = li.label;
+        const authoredStateVal = authoredState[name];
+        const linkedInteractive = currentLinkedInteractives.find(l => l.label === name);
+        if (!linkedInteractive && authoredStateVal !== undefined) {
+          // Add a new item.
+          const newArray = currentLinkedInteractives.concat({
+            id: authoredStateVal,
+            label: name
+          });
+          setCachedLinkedInteractives(newArray); // Set cached value
+          setLinkedInteractives({linkedInteractives: newArray}); // Send to LARA
+        } else if (linkedInteractive && authoredStateVal === undefined) {
+          // Remove item from the array.
+          const idx = currentLinkedInteractives.indexOf(linkedInteractive);
+          const newArray = currentLinkedInteractives.slice();
+          newArray.splice(idx, 1);
+          setCachedLinkedInteractives(newArray); // Set cached value
+          setLinkedInteractives({linkedInteractives: newArray}); // Send to LARA
+        } else if (linkedInteractive && linkedInteractive.id !== authoredStateVal) {
+          // Update array item.
+          const idx = currentLinkedInteractives.indexOf(linkedInteractive);
+          const newArray = currentLinkedInteractives.slice();
+          newArray.splice(idx, 1, {
+            id: authoredStateVal,
+            label: name
+          });
+          setCachedLinkedInteractives(newArray); // Set cached value
+          setLinkedInteractives({linkedInteractives: newArray}); // Send to LARA
+        }
+      });
+    }
+  }, [authoredState, cachedLinkedInteractives, currentLinkedInteractives, initMessage?.mode, linkedInteractiveProps]);
+
+  // Get the interactive list that are on the same page.
+  const interactiveItemId = initMessage?.mode === "authoring" && initMessage.interactiveItemId;
+  useEffect(() => {
+    if (linkedInteractiveProps && initMessage?.mode === "authoring") {
+      linkedInteractiveProps.forEach(li => {
+        const name = li.label;
+        if (schema?.properties?.[name]) {
+          getInteractiveList({scope: "page", supportsSnapshots: li.supportsSnapshots}).then(response => {
+            const otherInteractives = response.interactives.filter(int => int.id !== interactiveItemId);
+            const ids = otherInteractives.map(int => int.id);
+            const names = otherInteractives.map(int => int.name ? `${int.id} (${int.name})` : int.id);
+            setInteractiveList(prevIntList => Object.assign({}, prevIntList, {[li.label]: {names, ids}}));
+          });
+        }
+      });
+    }
+  }, [initMessage?.mode, interactiveItemId, linkedInteractiveProps, schema?.properties]);
+
+  // Generate new schema with interactives list.
+  let schemaWithInteractives = schema;
+  linkedInteractiveProps?.forEach(li => {
+    const name = li.label;
+    if (schema?.properties?.[name]) {
+      schemaWithInteractives = deepmerge(schemaWithInteractives, {
+        properties: {
+          [name]: {
+            enum: interactiveList[name]?.ids,
+            enumNames: interactiveList[name]?.names
+          }
+        }
+      });
+    }
+  });
+
+  return schemaWithInteractives;
+};

--- a/src/shared/hooks/use-linked-interactives.test.ts
+++ b/src/shared/hooks/use-linked-interactives.test.ts
@@ -85,7 +85,7 @@ describe("useLinkedInteractives", () => {
     expect(updatedState2).toEqual({ linkedInteractive1: "new ID 1", linkedInteractive2: "new ID 2" });
   });
 
-  it("do nothing if the mode is not authoring or runtime", () => {
+  it("does nothing if the mode is not authoring or runtime", () => {
     initMessage = {
       mode: "report",
       linkedInteractives: [

--- a/src/shared/hooks/use-linked-interactives.test.ts
+++ b/src/shared/hooks/use-linked-interactives.test.ts
@@ -1,0 +1,124 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { useLinkedInteractives } from "./use-linked-interactives";
+
+let initMessage: any;
+let authoredState: any;
+const setAuthoredState = jest.fn();
+
+jest.mock("@concord-consortium/lara-interactive-api", () => ({
+  useInitMessage: jest.fn(() => initMessage),
+  useAuthoredState: jest.fn(() => ({
+    authoredState,
+    setAuthoredState
+  }))
+}));
+
+describe("useLinkedInteractives", () => {
+  beforeEach(() => {
+    initMessage = {};
+    authoredState = {};
+    setAuthoredState.mockClear();
+  });
+
+  it("removes linked interactive IDs from authored state if linkedInteractives array is empty or undefined", () => {
+    initMessage = {
+      mode: "authoring"
+    };
+    authoredState = {
+      linkedInteractive1: "ID 1",
+      linkedInteractive2: "ID 2"
+    };
+    const HookWrapper = () => {
+      return useLinkedInteractives([ "linkedInteractive1", "linkedInteractive2" ]);
+    };
+    renderHook(HookWrapper);
+    expect(setAuthoredState).toHaveBeenCalledTimes(2);
+    const updatedState1 = setAuthoredState.mock.calls[0][0](authoredState);
+    const updatedState2 = setAuthoredState.mock.calls[1][0](updatedState1);
+    expect(updatedState1).toEqual({ linkedInteractive1: undefined, linkedInteractive2: "ID 2" });
+    expect(updatedState2).toEqual({ linkedInteractive1: undefined, linkedInteractive2: undefined });
+  });
+
+  it("overwrites linked interactive IDs in authored state if linkedInteractives array is defined - 1", () => {
+    initMessage = {
+      mode: "authoring",
+      linkedInteractives: [
+        { id: "new ID 1", label: "linkedInteractive1" },
+      ]
+    };
+    authoredState = {
+      linkedInteractive1: "ID 1",
+      linkedInteractive2: "ID 2"
+    };
+    const HookWrapper = () => {
+      return useLinkedInteractives([ "linkedInteractive1", "linkedInteractive2" ]);
+    };
+    renderHook(HookWrapper);
+    expect(setAuthoredState).toHaveBeenCalledTimes(2);
+    const updatedState1 = setAuthoredState.mock.calls[0][0](authoredState);
+    const updatedState2 = setAuthoredState.mock.calls[1][0](updatedState1);
+    expect(updatedState1).toEqual({ linkedInteractive1: "new ID 1", linkedInteractive2: "ID 2" });
+    expect(updatedState2).toEqual({ linkedInteractive1: "new ID 1", linkedInteractive2: undefined });
+  });
+
+  it("overwrites linked interactive IDs in authored state if linkedInteractives array is defined - 2", () => {
+    initMessage = {
+      mode: "authoring",
+      linkedInteractives: [
+        { id: "new ID 1", label: "linkedInteractive1" },
+        { id: "new ID 2", label: "linkedInteractive2" },
+        { id: "new ID 3", label: "linkedInteractive3" },
+      ]
+    };
+    authoredState = {
+      linkedInteractive1: "ID 1",
+      linkedInteractive2: "ID 2"
+    };
+    const HookWrapper = () => {
+      return useLinkedInteractives([ "linkedInteractive1", "linkedInteractive2" ]);
+    };
+    renderHook(HookWrapper);
+    expect(setAuthoredState).toHaveBeenCalledTimes(2);
+    const updatedState1 = setAuthoredState.mock.calls[0][0](authoredState);
+    const updatedState2 = setAuthoredState.mock.calls[1][0](updatedState1);
+    expect(updatedState1).toEqual({ linkedInteractive1: "new ID 1", linkedInteractive2: "ID 2" });
+    expect(updatedState2).toEqual({ linkedInteractive1: "new ID 1", linkedInteractive2: "new ID 2" });
+  });
+
+  it("do nothing if the mode is not authoring or runtime", () => {
+    initMessage = {
+      mode: "report",
+      linkedInteractives: [
+        { id: "new ID 1", label: "linkedInteractive1" },
+        { id: "new ID 2", label: "linkedInteractive2" },
+        { id: "new ID 3", label: "linkedInteractive3" },
+      ]
+    };
+    authoredState = {
+      linkedInteractive1: "ID 1",
+      linkedInteractive2: "ID 2"
+    };
+    const HookWrapper = () => {
+      return useLinkedInteractives([ "linkedInteractive1", "linkedInteractive2" ]);
+    };
+    renderHook(HookWrapper);
+    expect(setAuthoredState).not.toHaveBeenCalled();
+  });
+
+  it("does nothing if linkedInteractives array is matching authored state", () => {
+    initMessage = {
+      mode: "authoring",
+      linkedInteractives: [
+        { id: "ID 1", label: "linkedInteractive1" }
+      ]
+    };
+    authoredState = {
+      linkedInteractive1: "ID 1"
+    };
+    const HookWrapper = () => {
+      return useLinkedInteractives([ "linkedInteractive1", "linkedInteractive2" ]);
+    };
+    renderHook(HookWrapper);
+    expect(setAuthoredState).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/hooks/use-linked-interactives.test.ts
+++ b/src/shared/hooks/use-linked-interactives.test.ts
@@ -32,11 +32,9 @@ describe("useLinkedInteractives", () => {
       return useLinkedInteractives([ "linkedInteractive1", "linkedInteractive2" ]);
     };
     renderHook(HookWrapper);
-    expect(setAuthoredState).toHaveBeenCalledTimes(2);
-    const updatedState1 = setAuthoredState.mock.calls[0][0](authoredState);
-    const updatedState2 = setAuthoredState.mock.calls[1][0](updatedState1);
-    expect(updatedState1).toEqual({ linkedInteractive1: undefined, linkedInteractive2: "ID 2" });
-    expect(updatedState2).toEqual({ linkedInteractive1: undefined, linkedInteractive2: undefined });
+    expect(setAuthoredState).toHaveBeenCalledTimes(1);
+    const updatedState = setAuthoredState.mock.calls[0][0](authoredState);
+    expect(updatedState).toEqual({ linkedInteractive1: undefined, linkedInteractive2: undefined });
   });
 
   it("overwrites linked interactive IDs in authored state if linkedInteractives array is defined - 1", () => {
@@ -53,12 +51,14 @@ describe("useLinkedInteractives", () => {
     const HookWrapper = () => {
       return useLinkedInteractives([ "linkedInteractive1", "linkedInteractive2" ]);
     };
-    renderHook(HookWrapper);
-    expect(setAuthoredState).toHaveBeenCalledTimes(2);
-    const updatedState1 = setAuthoredState.mock.calls[0][0](authoredState);
-    const updatedState2 = setAuthoredState.mock.calls[1][0](updatedState1);
-    expect(updatedState1).toEqual({ linkedInteractive1: "new ID 1", linkedInteractive2: "ID 2" });
-    expect(updatedState2).toEqual({ linkedInteractive1: "new ID 1", linkedInteractive2: undefined });
+    const { rerender } = renderHook(HookWrapper);
+    expect(setAuthoredState).toHaveBeenCalledTimes(1);
+    const updatedState = setAuthoredState.mock.calls[0][0](authoredState);
+    expect(updatedState).toEqual({ linkedInteractive1: "new ID 1", linkedInteractive2: undefined });
+
+    // Check if the update happens only once.
+    rerender();
+    expect(setAuthoredState).toHaveBeenCalledTimes(1);
   });
 
   it("overwrites linked interactive IDs in authored state if linkedInteractives array is defined - 2", () => {
@@ -77,12 +77,14 @@ describe("useLinkedInteractives", () => {
     const HookWrapper = () => {
       return useLinkedInteractives([ "linkedInteractive1", "linkedInteractive2" ]);
     };
-    renderHook(HookWrapper);
-    expect(setAuthoredState).toHaveBeenCalledTimes(2);
-    const updatedState1 = setAuthoredState.mock.calls[0][0](authoredState);
-    const updatedState2 = setAuthoredState.mock.calls[1][0](updatedState1);
-    expect(updatedState1).toEqual({ linkedInteractive1: "new ID 1", linkedInteractive2: "ID 2" });
-    expect(updatedState2).toEqual({ linkedInteractive1: "new ID 1", linkedInteractive2: "new ID 2" });
+    const { rerender } = renderHook(HookWrapper);
+    expect(setAuthoredState).toHaveBeenCalledTimes(1);
+    const updatedState = setAuthoredState.mock.calls[0][0](authoredState);
+    expect(updatedState).toEqual({ linkedInteractive1: "new ID 1", linkedInteractive2: "new ID 2" });
+
+    // Check if the update happens only once.
+    rerender();
+    expect(setAuthoredState).toHaveBeenCalledTimes(1);
   });
 
   it("does nothing if the mode is not authoring or runtime", () => {

--- a/src/shared/hooks/use-linked-interactives.tsx
+++ b/src/shared/hooks/use-linked-interactives.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useAuthoredState, useInitMessage } from "@concord-consortium/lara-interactive-api";
 
-// This hook accepts list of props that are pointing to other interactives and ensures the most recent ID
+// This hook accepts a list of props that are pointing to other interactives and ensures the most recent ID
 // coming from LARA is being used. Note that ID might change when activity is copied or when interactive is removed.
 // It works both in authoring and runtime mode.
 export const useLinkedInteractives = (linkedInteractiveNames: string[] | undefined) => {

--- a/src/shared/hooks/use-linked-interactives.tsx
+++ b/src/shared/hooks/use-linked-interactives.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from "react";
+import { useAuthoredState, useInitMessage } from "@concord-consortium/lara-interactive-api";
+
+// This hook accepts list of props that are pointing to other interactives and ensures the most recent ID
+// coming from LARA is being used. Note that ID might change when activity is copied or when interactive is removed.
+// It works both in authoring and runtime mode.
+export const useLinkedInteractives = (linkedInteractiveNames: string[] | undefined) => {
+  const initMessage = useInitMessage();
+  const { authoredState, setAuthoredState } = useAuthoredState<any>();
+  const initialLinkedInteractivesProcessed = useRef(false);
+  const linkedInteractives = (initMessage?.mode === "authoring" || initMessage?.mode === "runtime") && initMessage.linkedInteractives;
+
+  useEffect(() => {
+    // Note that this hook needs to be executed only once, right after interactive is initialized.
+    // In the authoring mode an author might later change a property that is a linked interactive. It shouldn't
+    // be reset in this case. This case it's handled by useLinkedInteractivesAuthoring hook.
+    if (linkedInteractiveNames &&
+        authoredState &&
+        (initMessage?.mode === "authoring" || initMessage?.mode === "runtime") &&
+        !initialLinkedInteractivesProcessed.current)
+    {
+      linkedInteractiveNames.forEach(name => {
+        const authoredStateVal = authoredState[name];
+        const linkedInteractive = linkedInteractives && linkedInteractives.find(l => l.label === name);
+        if (!linkedInteractive && authoredStateVal !== undefined) {
+          // Linked interactive no longer present, clear the authoredState value.
+          setAuthoredState((prevAuthoredState: any) => Object.assign({}, prevAuthoredState, {[name]: undefined}));
+        } else if (linkedInteractive && linkedInteractive.id !== authoredStateVal) {
+          // Update authoredState value.
+          setAuthoredState((prevAuthoredState: any) => Object.assign({}, prevAuthoredState, {[name]: linkedInteractive.id}));
+        }
+      });
+      initialLinkedInteractivesProcessed.current = true;
+    }
+  }, [initMessage?.mode, linkedInteractives, linkedInteractiveNames, authoredState, setAuthoredState]);
+};


### PR DESCRIPTION
LARA provides `linkedInteractives` in a separate array within initMessage. This PR adds two new hooks that let question interactives handle that in a bit easier way and provide authoring interface:
- useLinkedInteractives
- useLinkedInteractivesAuthoring

The second commit updates ImageQuestion just to provide an example.

It all might not be super obvious, but hopefully comments help. Also, hooks are more complicated than their usage (as usual). Looking at the image-question implementation, it seems it's pretty simple to link an interactive.

@scytacki, I haven't thought about adding a custom widget or field. It could be a nice option too. The only thing is that LARA expects all the linked interactives to be provided in one array. This makes widget implementation not so great, as it'd need to monitor other linked interactive widgets too, collect all the values, and generate one array before sending it to LARA. It'd make sense to provide a widget if we could set linked interactives independently, e.g. based on the label or something like that.

This PR depends on: https://github.com/concord-consortium/lara/pull/634