### PR TITLE
Move snapshot support to Drawing Tool from Image Question, refactor both interactives

### DIFF
--- a/src/drawing-tool/components/app.tsx
+++ b/src/drawing-tool/components/app.tsx
@@ -4,7 +4,7 @@ import { JSONSchema6 } from "json-schema";
 import { IRuntimeInteractiveMetadata, IAuthoringInteractiveMetadata } from "@concord-consortium/lara-interactive-api";
 import { BaseQuestionApp } from "../../shared/components/base-question-app";
 
-// Note that TS interfaces should match JSON schema. Currently there's no way to generate one from the other.
+// Note that TS interfaces should match JSON schema. Currently there"s no way to generate one from the other.
 // TS interfaces are not available in runtime in contrast to JSON schema.
 
 export interface StampCollection {
@@ -16,14 +16,20 @@ export interface StampCollection {
 export interface IAuthoredState extends IAuthoringInteractiveMetadata {
   version: number;
   hint?: string;
-  backgroundImageUrl?: string;
-  imageFit: string;
-  imagePosition: string;
-  stampCollections: StampCollection[];
+  prompt?: string;
+  required?: boolean;
+  predictionFeedback?: string;
+  backgroundSource?: "url" | "upload" | "snapshot";
+  backgroundImageUrl?: string; // predefined by author
+  snapshotTarget?: string;
+  imageFit?: string;
+  imagePosition?: string;
+  stampCollections?: StampCollection[];
 }
 
 export interface IInteractiveState extends IRuntimeInteractiveMetadata {
-  drawingState: string;
+  drawingState?: string;
+  userBackgroundImageUrl?: string; // snapshot or upload done by student
 }
 
 export const stampCollectionDefinition = {
@@ -110,12 +116,7 @@ export const stampCollectionDefinition = {
   }
 };
 
-export const drawingToolAuthoringProps = {
-  backgroundImageUrl: {
-    title: "Background Image URL",
-    type: "string",
-    format: "uri"
-  },
+const backgroundProps = {
   imageFit: {
     title: "Background image fit",
     type: "string",
@@ -143,29 +144,10 @@ export const drawingToolAuthoringProps = {
       "Center",
       "Top-left"
     ]
-  },
-  stampCollections: {
-    type: "array",
-    title: "Stamp collections",
-    items: {
-      "$ref": "#/definitions/stampCollection"
-    }
   }
 };
 
-export const drawingToolAuthoringSchema = {
-  backgroundImageUrl: {
-    "ui:help": "Path to hosted image file (jpg, png, gif, etc)"
-  },
-  imageFit: {
-    "ui:widget": "radio"
-  },
-  imagePosition: {
-    "ui:widget": "radio"
-  }
-};
-
-const baseAuthoringProps = {
+export const baseAuthoringProps = {
   schema: {
     type: "object",
     definitions: {
@@ -192,11 +174,98 @@ const baseAuthoringProps = {
         title: "Hint",
         type: "string"
       },
-      ...drawingToolAuthoringProps
+      stampCollections: {
+        type: "array",
+        title: "Stamp collections",
+        items: {
+          "$ref": "#/definitions/stampCollection"
+        }
+      },
+      backgroundSource: {
+        title: "Background source",
+        type: "string",
+        enum: [
+          "url",
+          "upload",
+          "snapshot"
+        ],
+        enumNames: [
+          "URL",
+          "Upload",
+          "Snapshot"
+        ]
+      }
+    },
+    dependencies: {
+      backgroundSource: {
+        oneOf: [
+          {
+            properties: {
+              backgroundSource: {
+                enum: [ "url" ]
+              },
+              backgroundImageUrl: {
+                title: "Background Image URL",
+                type: "string",
+                format: "uri"
+              },
+              ...backgroundProps
+            }
+          },
+          {
+            properties: {
+              backgroundSource: {
+                enum: [ "upload" ]
+              },
+              ...backgroundProps
+            }
+          },
+          {
+            properties: {
+              backgroundSource: {
+                enum: [ "snapshot" ]
+              },
+              snapshotTarget: {
+                title: "Snapshot target",
+                type: "string",
+                enum: [],
+                enumNames: []
+              },
+              ...backgroundProps
+            }
+          }
+        ]
+      },
+      required: {
+        oneOf: [
+          {
+            properties: {
+              required: {
+                enum: [ false ]
+              }
+            }
+          },
+          {
+            properties: {
+              required: {
+                enum: [ true ]
+              },
+              predictionFeedback: {
+                title: "Post-submission feedback (optional)",
+                type: "string"
+              }
+            }
+          }
+        ]
+      },
     }
   } as JSONSchema6,
 
   uiSchema: {
+    "ui:order": [
+      "prompt", "required", "predictionFeedback", "hint", "backgroundSource", "snapshotTarget", "backgroundImageUrl",
+      "imageFit", "imagePosition",  "stampCollections", "version", "questionType"
+    ],
     version: {
       "ui:widget": "hidden"
     },
@@ -206,10 +275,17 @@ const baseAuthoringProps = {
     prompt: {
       "ui:widget": "richtext"
     },
-    ...drawingToolAuthoringSchema
+    backgroundImageUrl: {
+      "ui:help": "Path to hosted image file (jpg, png, gif, etc)"
+    },
+    imageFit: {
+      "ui:widget": "radio"
+    },
+    imagePosition: {
+      "ui:widget": "radio"
+    }
   },
-
-  // Can't get defaults to work with custom stamps, so validating would be ugly and confusing for users until
+  // Can"t get defaults to work with custom stamps, so validating would be ugly and confusing for users until
   // they enter the required properties after they select a custom stamp, so skipping this for now.
   // validate: (formData: IAuthoredState, errors: FormValidation) => {
   //   return errors;
@@ -224,5 +300,6 @@ export const App = () => (
     baseAuthoringProps={baseAuthoringProps}
     disableAutoHeight={false}
     isAnswered={isAnswered}
+    linkedInteractiveProps={[{ label: "snapshotTarget", supportsSnapshots: true }]}
   />
 );

--- a/src/drawing-tool/components/app.tsx
+++ b/src/drawing-tool/components/app.tsx
@@ -285,7 +285,7 @@ export const baseAuthoringProps = {
       "ui:widget": "radio"
     }
   },
-  // Can"t get defaults to work with custom stamps, so validating would be ugly and confusing for users until
+  // Can't get defaults to work with custom stamps, so validating would be ugly and confusing for users until
   // they enter the required properties after they select a custom stamp, so skipping this for now.
   // validate: (formData: IAuthoredState, errors: FormValidation) => {
   //   return errors;

--- a/src/drawing-tool/components/runtime.test.tsx
+++ b/src/drawing-tool/components/runtime.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { Runtime } from "./runtime";
+import { IAuthoredState, IInteractiveState } from "./app";
+import { getInteractiveSnapshot } from "@concord-consortium/lara-interactive-api";
+
+jest.mock("@concord-consortium/lara-interactive-api", () => ({
+  getInteractiveSnapshot: jest.fn(() => new Promise(resolve => resolve({success: true, snapshotUrl: "http://snapshot/123" })))
+}));
+const getInteractiveSnapshotMock = getInteractiveSnapshot as jest.Mock;
+
+
+const authoredState: IAuthoredState = {
+  version: 1,
+  questionType: "iframe_interactive" as const,
+  prompt: "Test prompt",
+  hint: "hint",
+  required: false,
+  imageFit: "center",
+  imagePosition: "center",
+  stampCollections: []
+};
+
+const authoredRichState = {
+  ...authoredState,
+  prompt: "<p><strong>Rich</strong> <em>text</em> <u>prompt</u>"
+};
+
+const interactiveState: IInteractiveState = {
+  drawingState: "",
+  answerType: "interactive_state" as const,
+};
+
+describe("Runtime", () => {
+  beforeEach(() => {
+    getInteractiveSnapshotMock.mockClear();
+  });
+
+  it("renders rich text prompt", () => {
+    const wrapper = shallow(<Runtime authoredState={authoredRichState} />);
+    expect(wrapper.html()).toEqual(expect.stringContaining(authoredRichState.prompt));
+  });
+
+  it("renders snapshot button when useSnapshot=true and snapshotTarget is set", () => {
+    const wrapperWithoutSnapshot = shallow(<Runtime authoredState={authoredState} interactiveState={interactiveState} />);
+    expect(wrapperWithoutSnapshot.find("[data-test='snapshot-btn']").length).toEqual(0);
+
+    const authoredStateWithSnapshot = {...authoredState, backgroundSource: "snapshot" as const, snapshotTarget: "interactive_123"};
+    const wrapper = shallow(<Runtime authoredState={authoredStateWithSnapshot} interactiveState={interactiveState} />);
+
+    expect(wrapper.find("[data-test='snapshot-btn']").length).toEqual(1);
+    wrapper.find("[data-test='snapshot-btn']").simulate("click");
+    expect(getInteractiveSnapshotMock).toHaveBeenCalledWith({ interactiveItemId: "interactive_123" });
+  });
+
+  it("renders warning when useSnapshot=true and snapshotTarget is not set", () => {
+    const authoredStateWithoutSnapshotTarget = {...authoredState, backgroundSource: "snapshot" as const };
+    const wrapper = shallow(<Runtime authoredState={authoredStateWithoutSnapshotTarget} interactiveState={interactiveState} />);
+
+    expect(wrapper.find("[data-test='snapshot-btn']").length).toEqual(0);
+    expect(wrapper.text()).toEqual(expect.stringContaining("Snapshot won't work, as the target interactive is not selected"));
+  });
+});

--- a/src/drawing-tool/components/runtime.tsx
+++ b/src/drawing-tool/components/runtime.tsx
@@ -63,7 +63,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     const bgPosition = authoredState.imagePosition || "center";
     const bgFit = authoredState.imageFit || "shrinkBackgroundToCanvas";
     const imageOpts = {
-      src: backgroundImgSrc, // not that undefined / null is a valid value (used to remove background)
+      src: backgroundImgSrc, // note that undefined / null is a valid value (used to remove background)
       position: bgPosition
     };
     if (bgFit === "resizeCanvasToBackground") {
@@ -160,7 +160,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
       { snapshotInProgress && <p>Please wait while the snapshot is being taken...</p> }
       {
         useSnapshot && authoredState.snapshotTarget === undefined &&
-        <p className={css.warn}>Snapshot won&apos;t work, as the target interactive is not selected</p>
+        <p className={css.warn}>Snapshot won&apos;t work, as no target interactive is selected</p>
       }
     </div>
   );

--- a/src/drawing-tool/components/runtime.tsx
+++ b/src/drawing-tool/components/runtime.tsx
@@ -1,10 +1,13 @@
-import React, { useCallback, useEffect, useRef } from "react";
+import React, {useCallback, useEffect, useRef, useState} from "react";
 import DrawingTool from "drawing-tool";
 import 'drawing-tool/dist/drawing-tool.css';
 import { IAuthoredState, IInteractiveState } from "./app";
 import css from "./runtime.scss";
 import predefinedStampCollections from "./stamp-collections";
 import { renderHTML } from "../../shared/utilities/render-html";
+import {getInteractiveSnapshot} from "@concord-consortium/lara-interactive-api";
+import cssHelpers from "../../shared/styles/helpers.scss";
+import CameraIcon from "../../shared/icons/camera.svg";
 
 const kToolbarWidth = 40;
 const kToolbarHeight = 600;
@@ -14,8 +17,7 @@ export interface IProps {
   interactiveState?: IInteractiveState | null;
   setInteractiveState?: (updateFunc: (prevState: IInteractiveState | null) => IInteractiveState) => void;
   report?: boolean;
-  onDrawingChange?: (userState: string) => void;
-  snapshotBackgroundUrl?: string; // useful when DrawingToolRuntime is used within ImageQuestionRuntime
+  onDrawingChange?: (userState: Partial<IInteractiveState>) => void;
 }
 
 interface StampCollections {
@@ -28,48 +30,30 @@ interface DrawingToolOpts {
   stamps?: StampCollections;
 }
 
-export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, snapshotBackgroundUrl, setInteractiveState, report, onDrawingChange }) => {
+export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, report, onDrawingChange }) => {
   const readOnly = !!(report || (authoredState.required && interactiveState?.submitted));
+  const [ snapshotInProgress, setSnapshotInProgress ] = useState(false);
 
   // need a wrapper as `useRef` expects (state) => void
-  const handleSetInteractiveState = (userState: string) => {
+  const handleSetInteractiveState = (newState: Partial<IInteractiveState>) => {
     if (onDrawingChange) {
       // handle the change in a parent component
-      onDrawingChange(userState);
+      onDrawingChange(newState);
     } else {
       setInteractiveState?.(prevState => ({
         ...prevState,
-        drawingState: userState,
+        ...newState,
         answerType: "interactive_state"
       }));
     }
   };
   // useRef to avoid passing interactiveState into useEffect, or it will reload on every drawing edit
-  const initialInteractiveStateRef = useRef<any>(interactiveState);
+  const initialInteractiveStateRef = useRef<IInteractiveState | null | undefined>(interactiveState);
   const setInteractiveStateRef = useRef<((state: any) => void)>(handleSetInteractiveState);
-  const initialSnapshotBgUrlRef = useRef(snapshotBackgroundUrl);
   initialInteractiveStateRef.current = interactiveState;
-  initialSnapshotBgUrlRef.current = snapshotBackgroundUrl;
   setInteractiveStateRef.current = handleSetInteractiveState;
 
   const drawingToolRef = useRef<any>();
-
-  const setBackgroundImage = useCallback((bgProps: { backgroundImageUrl?: string; imagePosition?: string; imageFit?: string}) => {
-    if (!drawingToolRef.current || !bgProps.backgroundImageUrl) {
-      return;
-    }
-    const imageOpts = {
-      src: bgProps.backgroundImageUrl,
-      position: bgProps.imagePosition
-    };
-    if (bgProps.imageFit === "resizeCanvasToBackground") {
-      imageOpts.position = "center"; // anything else is an invalid combo
-    }
-    drawingToolRef.current.pauseHistory();
-    drawingToolRef.current.setBackgroundImage(imageOpts, bgProps.imageFit, () => {
-      drawingToolRef.current.unpauseHistory();
-    });
-  }, []);
 
   useEffect(() => {
     const windowWidth = window.innerWidth;
@@ -106,41 +90,68 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, sna
 
     drawingToolRef.current = new DrawingTool("#drawing-tool-container", drawingToolOpts);
 
-    // Snapshot background has higher priority than authored background.
-    if (initialSnapshotBgUrlRef.current) {
-      setBackgroundImage({
-        backgroundImageUrl: initialSnapshotBgUrlRef.current,
-        imageFit: "shrinkBackgroundToCanvas"
-      });
-    } else if (authoredState.backgroundImageUrl) {
-      setBackgroundImage(authoredState);
-    }
-
     if (initialInteractiveStateRef.current) {
       drawingToolRef.current.load(initialInteractiveStateRef.current.drawingState, null, true);
     }
 
     drawingToolRef.current.on('drawing:changed', () => {
       if (readOnly) return;
-      const userState = drawingToolRef.current.save();
-      setInteractiveStateRef.current(userState);
+      setInteractiveStateRef.current({ drawingState: drawingToolRef.current.save() });
     });
-  }, [authoredState, report, readOnly, setBackgroundImage]);
+  }, [authoredState, report, readOnly]);
 
   useEffect(() => {
-    setBackgroundImage({
-      backgroundImageUrl: snapshotBackgroundUrl,
-      imageFit: "shrinkBackgroundToCanvas"
+    if (!drawingToolRef.current) {
+      return;
+    }
+    const imageOpts = {
+      src: interactiveState?.userBackgroundImageUrl || authoredState.backgroundImageUrl,
+      position: authoredState.imagePosition
+    };
+    if (authoredState.imageFit === "resizeCanvasToBackground") {
+      imageOpts.position = "center"; // anything else is an invalid combo
+    }
+    drawingToolRef.current.pauseHistory();
+    drawingToolRef.current.setBackgroundImage(imageOpts, authoredState.imageFit, () => {
+      drawingToolRef.current.unpauseHistory();
     });
-  }, [setBackgroundImage, snapshotBackgroundUrl]);
+  }, [interactiveState?.userBackgroundImageUrl, authoredState]);
+
+  const handleSnapshot = async () => {
+    if (authoredState.snapshotTarget) {
+      setSnapshotInProgress(true);
+      const response = await getInteractiveSnapshot({ interactiveItemId: authoredState.snapshotTarget });
+      setSnapshotInProgress(false);
+      if (response.success && response.snapshotUrl) {
+        handleSetInteractiveState({ userBackgroundImageUrl: response.snapshotUrl });
+      } else {
+        window.alert("Snapshot has failed. Please try again.");
+      }
+    }
+  };
+
+  const useSnapshot = authoredState?.backgroundSource === "snapshot";
 
   return (
     <div>
-      { authoredState.prompt && <div>{renderHTML(authoredState.prompt)}</div>}
+      {/* Drawing Tool UI: */}
+      { authoredState.prompt && <div>{renderHTML(authoredState.prompt)}</div> }
       <div className={css.drawingtoolWrapper}>
         { readOnly && <div className={css.clickShield} /> }
         <div id="drawing-tool-container" className={css.runtime} />
       </div>
+      {/* Snapshot UI: */}
+      {
+        useSnapshot && authoredState.snapshotTarget &&
+        <button className={cssHelpers.laraButton} onClick={handleSnapshot} disabled={snapshotInProgress} data-test="snapshot-btn">
+          <CameraIcon className={cssHelpers.smallIcon} /> { interactiveState?.userBackgroundImageUrl ? "Replace snapshot" : "Take a snapshot" }
+        </button>
+      }
+      { snapshotInProgress && <p>Please wait while the snapshot is being taken...</p> }
+      {
+        useSnapshot && authoredState.snapshotTarget === undefined &&
+        <p className={css.warn}>Snapshot won&apos;t work, as the target interactive is not selected</p>
+      }
     </div>
   );
 };

--- a/src/drawing-tool/components/runtime.tsx
+++ b/src/drawing-tool/components/runtime.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useRef, useState} from "react";
+import React, { useEffect, useRef, useState } from "react";
 import DrawingTool from "drawing-tool";
 import 'drawing-tool/dist/drawing-tool.css';
 import { IAuthoredState, IInteractiveState } from "./app";

--- a/src/image-question/components/app.tsx
+++ b/src/image-question/components/app.tsx
@@ -1,54 +1,30 @@
 import React from "react";
 import { JSONSchema6 } from "json-schema";
 import { BaseQuestionApp } from "../../shared/components/base-question-app";
-import { IRuntimeInteractiveMetadata, IAuthoringInteractiveMetadata } from "@concord-consortium/lara-interactive-api";
 import { Runtime } from "./runtime";
-import { StampCollection } from "../../drawing-tool/components/app";
-import { drawingToolAuthoringProps, stampCollectionDefinition, drawingToolAuthoringSchema } from "../../drawing-tool/components/app";
+import {
+  baseAuthoringProps as drawingToolBaseAuthoringProps, IAuthoredState as IDrawingToolAuthoredState,
+  IInteractiveState as IDrawingToolInteractiveState
+} from "../../drawing-tool/components/app";
+import deepmerge from "deepmerge";
 
-export interface IAuthoredState extends IAuthoringInteractiveMetadata {
-  version: number;
-  hint?: string;
-  backgroundImageUrl?: string;
-  imageFit: string;
-  imagePosition: string;
-  stampCollections: StampCollection[];
-  questionType: "iframe_interactive";
+export interface IAuthoredState extends IDrawingToolAuthoredState {
   answerPrompt?: string;
-  answerType: string;
-  defaultAnswer: string;
+  defaultAnswer?: string;
   modalSupported?: boolean;
-  useSnapshot?: boolean;
-  snapshotTarget?: string;
 }
 
-export interface IInteractiveState extends IRuntimeInteractiveMetadata {
-  drawingState: string;
-  answerType: "interactive_state";
+export interface IInteractiveState extends IDrawingToolInteractiveState {
   answerText?: string;
-  snapshotUrl?: string;
 }
 
-const baseAuthoringProps = {
+const baseAuthoringProps = deepmerge(drawingToolBaseAuthoringProps, {
   schema: {
-    type: "object",
-    definitions: {
-      stampCollection: stampCollectionDefinition,
-    },
     properties: {
       version: {
         type: "number",
         default: 1
       },
-      questionType: {
-        type: "string",
-        default: "image_question"
-      },
-      prompt: {
-        title: "Prompt",
-        type: "string"
-      },
-      ...drawingToolAuthoringProps,
       answerPrompt: {
         title: "Answer prompt",
         type: "string"
@@ -60,67 +36,23 @@ const baseAuthoringProps = {
       defaultAnswer: {
         type: "string",
         title: "Default answer"
-      },
-      useSnapshot: {
-        title: "Use snapshot button",
-        type: "boolean"
-      },
-      snapshotTarget: {
-        title: "Snapshot target",
-        type: "string",
-        enum: [],
-        enumNames: []
-      }
-    },
-    dependencies: {
-      required: {
-        oneOf: [
-          {
-            properties: {
-              required: {
-                enum: [
-                  false
-                ]
-              }
-            }
-          },
-          {
-            properties: {
-              required: {
-                enum: [
-                  true
-                ]
-              },
-              predictionFeedback: {
-                title: "Post-submission feedback (optional)",
-                type: "string"
-              }
-            }
-          }
-        ]
       }
     }
   } as JSONSchema6,
 
   uiSchema: {
-    prompt: {
-      "ui:widget": "richtext"
-    },
-    predictionFeedback: {
-      "ui:widget": "richtext"
-    },
+    "ui:order": [
+      "prompt", "required", "predictionFeedback", "hint", "backgroundSource", "snapshotTarget", "backgroundImageUrl",
+      "imageFit", "imagePosition",  "stampCollections", "answerPrompt", "defaultAnswer", "version", "questionType"
+    ],
     defaultAnswer: {
       "ui:widget": "textarea"
-    },
-    questionType: {
-      "ui:widget": "hidden"
-    },
-    version: {
-      "ui:widget": "hidden"
-    },
-    ...drawingToolAuthoringSchema
+    }
   }
-};
+}, {
+  // Just overwrite array, don't merge values.
+  arrayMerge: (destinationArray, sourceArray) => sourceArray
+});
 
 const isAnswered = (interactiveState: IInteractiveState | null) => !!interactiveState?.answerText;
 

--- a/src/image-question/components/runtime.test.tsx
+++ b/src/image-question/components/runtime.test.tsx
@@ -19,8 +19,7 @@ const authoredState: IAuthoredState = {
   defaultAnswer: "",
   imageFit: "center",
   imagePosition: "center",
-  stampCollections: [],
-  answerType: "image_question_answer"
+  stampCollections: []
 };
 
 const authoredRichState = {
@@ -46,14 +45,8 @@ describe("Runtime", () => {
 
   it("renders rich text prompt and textarea", () => {
     const wrapper = shallow(<Runtime authoredState={authoredRichState} />);
-    const prompt = wrapper.find("legend");
-    expect(prompt.html()).toEqual(expect.stringContaining(authoredRichState.prompt));
+    expect(wrapper.html()).toEqual(expect.stringContaining(authoredRichState.prompt));
     expect(wrapper.find("textarea").length).toEqual(1);
-  });
-
-  it("renders drawing tool", () => {
-    const wrapper = shallow(<Runtime authoredState={authoredRichState} />);
-    expect(wrapper.find("div").length).toEqual(1);
   });
 
   it("handles passed interactiveState", () => {
@@ -67,26 +60,6 @@ describe("Runtime", () => {
     wrapper.find("textarea").simulate("change", { target: { value: "new answer" } });
     const newState = setState.mock.calls[0][0](interactiveState);
     expect(newState).toEqual({answerType: "interactive_state", drawingState: "", answerText: "new answer"});
-  });
-
-  it("renders snapshot button when useSnapshot=true and snapshotTarget is set", () => {
-    const wrapperWithoutSnapshot = shallow(<Runtime authoredState={authoredState} interactiveState={interactiveState} />);
-    expect(wrapperWithoutSnapshot.find("[data-test='snapshot-btn']").length).toEqual(0);
-
-    const authoredStateWithSnapshot = {...authoredState, useSnapshot: true, snapshotTarget: "interactive_123"};
-    const wrapper = shallow(<Runtime authoredState={authoredStateWithSnapshot} interactiveState={interactiveState} />);
-
-    expect(wrapper.find("[data-test='snapshot-btn']").length).toEqual(1);
-    wrapper.find("[data-test='snapshot-btn']").simulate("click");
-    expect(getInteractiveSnapshotMock).toHaveBeenCalledWith({ interactiveItemId: "interactive_123" });
-  });
-
-  it("renders warning when useSnapshot=true and snapshotTarget is not set", () => {
-    const authoredStateWithoutSnapshotTarget = {...authoredState, useSnapshot: true };
-    const wrapper = shallow(<Runtime authoredState={authoredStateWithoutSnapshotTarget} interactiveState={interactiveState} />);
-
-    expect(wrapper.find("[data-test='snapshot-btn']").length).toEqual(0);
-    expect(wrapper.text()).toEqual(expect.stringContaining("Snapshot won't work, as the target interactive is not selected"));
   });
 
   describe("report mode", () => {

--- a/src/image-question/components/runtime.tsx
+++ b/src/image-question/components/runtime.tsx
@@ -37,6 +37,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
       <DrawingToolRuntime
         authoredState={authoredState}
         interactiveState={interactiveState}
+        setInteractiveState={setInteractiveState}
         report={report} />
       <div>
         {authoredState.answerPrompt && <div className={css.answerPrompt}>{authoredState.answerPrompt}</div>}

--- a/src/shared/components/base-authoring.tsx
+++ b/src/shared/components/base-authoring.tsx
@@ -46,6 +46,7 @@ export const BaseAuthoring = <IAuthoredState,>({ authoredState, setAuthoredState
 
   // This hook provides list of interactives on a given page and saving of the linked interactive IDs.
   const schemaWithInteractives = useLinkedInteractivesAuthoring({ linkedInteractiveProps, schema });
+  // const schemaWithInteractives = schema;
 
   return (
     <div className={css.authoring}>

--- a/src/shared/components/base-authoring.tsx
+++ b/src/shared/components/base-authoring.tsx
@@ -46,7 +46,6 @@ export const BaseAuthoring = <IAuthoredState,>({ authoredState, setAuthoredState
 
   // This hook provides list of interactives on a given page and saving of the linked interactive IDs.
   const schemaWithInteractives = useLinkedInteractivesAuthoring({ linkedInteractiveProps, schema });
-  // const schemaWithInteractives = schema;
 
   return (
     <div className={css.authoring}>


### PR DESCRIPTION
This PT story explains why it happened: https://www.pivotaltracker.com/story/show/175127634
We had some discussion yesterday about differences between Image Question and Drawing Tool.
It's a bit blurry, but after talking to Leslie I summarized all the differences in the linked PT story.

So, I've moved Snapshot from IQ to DT and tried to simplify IQ. It doesn't take pieces of DT anymore. It mostly extends it (especially authoring schema and interfaces should be more clear).


use-linked-interactives-authoring hook now supports properties that are nested too (e.g. in dependencies part).
