### PR TITLE
Add upload button to Drawing Tool

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,7 @@ module.exports = {
     "@typescript-eslint/interface-name-prefix": "off",
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-unused-vars": ["error", { "args": "none", "ignoreRestSiblings": true }],
+    "@typescript-eslint/no-unused-vars": ["warn", { "args": "none", "ignoreRestSiblings": true }],
     curly: ["error", "multi-line", "consistent"],
     eqeqeq: ["error", "smart"],
     "eslint-comments/no-unused-disable": "warn",

--- a/src/drawing-tool/components/runtime.scss
+++ b/src/drawing-tool/components/runtime.scss
@@ -20,3 +20,18 @@
   z-index: 1010;      // drawing-tool buttons are z-index 1000...
 }
 
+.dropArea {
+  padding: 10px;
+  width: 200px;
+  height: 200px;
+  display: flex;
+  align-content: center;
+  align-items: center;
+  justify-content: center;
+  background-color: #ddd;
+  margin: 10px 0 10px 0;
+}
+
+.uploadInfo {
+  margin: 10px 0 10px 0;
+}

--- a/src/drawing-tool/components/runtime.tsx
+++ b/src/drawing-tool/components/runtime.tsx
@@ -154,13 +154,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     // Always copy image to S3 using Shutterbug, so it works even when the image disappears from the external location.
     // Local image could be theoretically stored as dataSrc but it might be too big for Firestore storage that
     // is used by ActivityPlayer. So, copying to S3 is a safer option.
-    let uploadPromise;
-    if (typeof fileOrUrl === "string") {
-      uploadPromise = copyImageToS3(fileOrUrl);
-    } else {
-      uploadPromise = copyLocalImageToS3(fileOrUrl);
-    }
-    uploadPromise
+    (typeof fileOrUrl === "string" ? copyImageToS3(fileOrUrl) : copyLocalImageToS3(fileOrUrl))
       .then(url => {
         handleSetInteractiveState({ userBackgroundImageUrl: url });
       })

--- a/src/shared/utilities/copy-image-to-s3.ts
+++ b/src/shared/utilities/copy-image-to-s3.ts
@@ -1,0 +1,48 @@
+import Shutterbug from "shutterbug";
+
+export const copyImageToS3 = (imgSrc: string): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const img = document.createElement("img");
+    img.src = imgSrc;
+    img.onload = () => {
+      // Image needs to be in DOM tree just for a moment, so Shutterbug worker can process it correctly.
+      document.body.append(img);
+      Shutterbug.snapshot({
+        selector: img,
+        done: (url: string) => {
+          resolve(url);
+        },
+        fail: (jqXHR: any, textStatus: string, errorThrown: any) => {
+          reject(`Shutterbug request failed, ${textStatus}, error: ${errorThrown}`);
+        }
+      });
+      img.remove();
+    };
+  });
+};
+
+export const copyLocalImageToS3 = (file: File): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const [major] = file.type.split("/");
+    if (major !== "image") {
+      reject("Sorry, you can only upload images");
+    }
+    if (!window.FileReader) {
+      reject("Sorry, your browser does not support reading local files");
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataSrc = reader.result?.toString();
+      if (dataSrc) {
+        copyImageToS3(dataSrc)
+          .then(url => resolve(url))
+          .catch(error => reject(error));
+      }
+    };
+    reader.onerror = () => {
+      reject("FileReader error " + reader.error?.message);
+    };
+    reader.readAsDataURL(file);
+  });
+};
+


### PR DESCRIPTION
Old LARA implementation was keeping uploaded image as data-src within the drawing tool state. But this is not going to work well with Firestore and its 1MB limit. That's why the uploaded image is copied to S3 using Shutterbug (just by taking a snapshot of the image element with dataSrc).

Re ESLint update: changing unused vars to warning, as error breaks the compilation and it's pretty annoying when I work locally and move things around or comment out some parts of the code just for a few minutes. 