### PR TITLE
Support authored state migrations, fix Scaffolded Question

### DIFF
--- a/cypress/integration/scaffolded-question.test.js
+++ b/cypress/integration/scaffolded-question.test.js
@@ -13,13 +13,13 @@ context("Test scaffolded question interactive", () => {
       phonePost("initInteractive", {
         mode: "runtime",
         authoredState: {
-          version: 1,
+          version: 2,
           prompt: "Test prompt",
           hint: "Hint",
           subinteractives: [
             {
               id: "int1",
-              url: "/open-response",
+              libraryInteractiveId: "open-response",
               authoredState: {
                 version: 1,
                 prompt: "Subquestion prompt",
@@ -55,13 +55,13 @@ context("Test scaffolded question interactive", () => {
       phonePost("initInteractive", {
         mode: "runtime",
         authoredState: {
-          version: 1,
+          version: 2,
           prompt: "Test prompt",
           hint: "Hint",
           subinteractives: [
             {
               id: "int1",
-              url: "/open-response",
+              libraryInteractiveId: "open-response",
               authoredState: {
                 version: 1,
                 prompt: "Subquestion prompt",
@@ -92,13 +92,13 @@ context("Test scaffolded question interactive", () => {
       phonePost("initInteractive", {
         mode: "runtime",
         authoredState: {
-          version: 1,
+          version: 2,
           prompt: "Test prompt",
           hint: "Hint",
           subinteractives: [
             {
               id: "int1",
-              url: "/open-response",
+              libraryInteractiveId: "open-response",
               authoredState: {
                 version: 1,
                 prompt: "Subquestion prompt",
@@ -118,6 +118,9 @@ context("Test scaffolded question interactive", () => {
       getAndClearAllPhoneMessage((messages) => {
         expect(messages.length).eql(2);
 
+        console.log("TAAK");
+        console.log(messages[0]);
+
         expect(messages[0]).eql({
           action: "focus in",
           data: {
@@ -127,7 +130,7 @@ context("Test scaffolded question interactive", () => {
             target_name: '',
             target_value: '',
             scaffolded_question_level: 1,
-            subinteractive_url: "/open-response",
+            subinteractive_url: "http://localhost:8080/open-response",
             subinteractive_type: "open_response",
             subinteractive_sub_type: undefined,
             subinteractive_id: 'int1'
@@ -143,7 +146,7 @@ context("Test scaffolded question interactive", () => {
             target_name: '',
             target_value: 'Test subquestion answer',
             scaffolded_question_level: 1,
-            subinteractive_url: '/open-response',
+            subinteractive_url: "http://localhost:8080/open-response",
             subinteractive_type: 'open_response',
             subinteractive_sub_type: undefined,
             subinteractive_id: 'int1',
@@ -159,13 +162,13 @@ context("Test scaffolded question interactive", () => {
       phonePost("initInteractive", {
         mode: "authoring",
         authoredState: {
-          version: 1,
+          version: 2,
           prompt: "Test prompt",
           hint: "Hint",
           subinteractives: [
             {
               id: "int1",
-              url: "/open-response",
+              libraryInteractiveId: "open-response",
               authoredState: {
                 version: 1,
                 prompt: "Subquestion prompt",
@@ -196,7 +199,7 @@ context("Test scaffolded question interactive", () => {
 
       cy.getIframeBody().find("#root_prompt").type("Test prompt");
       getAndClearLastPhoneMessage(state => {
-        expect(state.version).eql(1);
+        expect(state.version).eql(2);
         expect(state.prompt).include("Test prompt");
       }, 200);
 
@@ -221,13 +224,13 @@ context("Test scaffolded question interactive", () => {
       phonePost("initInteractive", {
         mode: "authoring",
         authoredState: {
-          version: 1,
+          version: 2,
           prompt: "Test prompt",
           hint: "Hint",
           subinteractives: [
             {
               id: "int1",
-              url: "/open-response",
+              libraryInteractiveId: "open-response",
               authoredState: {
                 version: 1,
                 prompt: "1"
@@ -235,7 +238,7 @@ context("Test scaffolded question interactive", () => {
             },
             {
               id: "int2",
-              url: "/open-response",
+              libraryInteractiveId: "open-response",
               authoredState: {
                 version: 1,
                 prompt: "2",
@@ -275,13 +278,13 @@ context("Test scaffolded question interactive", () => {
       phonePost("initInteractive", {
         mode: "report",
         authoredState: {
-          version: 1,
+          version: 2,
           prompt: "Test prompt",
           hint: "Hint",
           subinteractives: [
             {
               id: "int1",
-              url: "/open-response",
+              libraryInteractiveId: "open-response",
               authoredState: {
                 version: 1,
                 prompt: "Subquestion prompt",

--- a/src/scaffolded-question/components/app.tsx
+++ b/src/scaffolded-question/components/app.tsx
@@ -3,30 +3,8 @@ import { JSONSchema6 } from "json-schema";
 import { BaseQuestionApp } from "../../shared/components/base-question-app";
 import { Runtime } from "./runtime";
 import { IframeAuthoring } from "./iframe-authoring";
-import {
-  IAuthoringInteractiveMetadata, IRuntimeInteractiveMetadata
-} from "@concord-consortium/lara-interactive-api";
-
-// Note that TS interfaces should match JSON schema. Currently there's no way to generate one from the other.
-// TS interfaces are not available in runtime in contrast to JSON schema.
-
-export interface IAuthoredState extends IAuthoringInteractiveMetadata {
-  version: number;
-  hint?: string;
-  subinteractives?: {
-    id: string;
-    url: string;
-    authoredState: any;
-  }[]
-}
-
-export interface IInteractiveState extends IRuntimeInteractiveMetadata {
-  subinteractiveStates: {
-    [id: string]: any;
-  },
-  currentSubinteractiveId: string;
-  submitted: boolean;
-}
+import { IAuthoredState, IInteractiveState } from "./types";
+import { migrateAuthoredState } from "./state-migrations";
 
 const baseAuthoringProps = {
   schema: {
@@ -34,7 +12,7 @@ const baseAuthoringProps = {
     properties: {
       version: {
         type: "number",
-        default: 1
+        default: 2
       },
       questionType: {
         type: "string",
@@ -61,7 +39,7 @@ const baseAuthoringProps = {
             id: {
               type: "string"
             },
-            url: {
+            libraryInteractiveId: {
               type: "string"
             },
             authoredState: {
@@ -103,5 +81,6 @@ export const App = () => (
     Runtime={Runtime}
     baseAuthoringProps={baseAuthoringProps}
     disableSubmitBtnRendering={true}
+    migrateAuthoredState={migrateAuthoredState}
   />
 );

--- a/src/scaffolded-question/components/iframe-authoring.tsx
+++ b/src/scaffolded-question/components/iframe-authoring.tsx
@@ -3,34 +3,13 @@ import { FieldProps } from "react-jsonschema-form";
 import { IframePhone } from "../../shared/types";
 import iframePhone from "iframe-phone";
 import deepEqual from "deep-equal";
-
-import css from "./iframe-authoring.scss";
 import { v4 as uuidv4 } from "uuid";
-
-// This is only temporary list. It will be replaced by LARA Interactive API call that returns all the available managed interactives.
-const scaffoldedQuestionSegment = /scaffolded-question\/?$/;
-const availableInteractives = [
-  {
-    url: "",
-    name: "Select an interactive"
-  },
-  {
-    url: window.location.href.replace(scaffoldedQuestionSegment, "open-response"),
-    name: "Open response"
-  },
-  {
-    url: window.location.href.replace(scaffoldedQuestionSegment, "fill-in-the-blank"),
-    name: "Fill in the blank"
-  },
-  {
-    url: window.location.href.replace(scaffoldedQuestionSegment, "multiple-choice"),
-    name: "Multiple choice"
-  }
-];
+import { libraryInteractives, libraryInteractiveIdToUrl } from "./library-interactives";
+import css from "./iframe-authoring.scss";
 
 export const IframeAuthoring: React.FC<FieldProps> = props => {
   const { onChange, formData } = props;
-  const { url, authoredState, id } = formData;
+  const { libraryInteractiveId, authoredState, id } = formData;
   const [ iframeHeight, setIframeHeight ] = useState(300);
   const [ authoringOpened, setAuthoringOpened ] = useState(false);
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -45,9 +24,9 @@ export const IframeAuthoring: React.FC<FieldProps> = props => {
   // state outside `initInteractive` call. But this would require all the existing interactives to be updated.
   const iframeCurrentAuthoredState = useRef<any>();
 
-  const handleUrlChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    const newUrl = event.target.value;
-    onChange({ url: newUrl, authoredState: undefined, id: id || uuidv4() });
+  const handleLibraryInteractiveIdChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const newLibraryInteractiveId = event.target.value;
+    onChange({ libraryInteractiveId: newLibraryInteractiveId, authoredState: undefined, id: id || uuidv4() });
   };
 
   const handleHeaderClick = () => {
@@ -62,7 +41,7 @@ export const IframeAuthoring: React.FC<FieldProps> = props => {
     phone.addListener("authoredState", (newAuthoredState: any) => {
       // Save current iframe authored state.
       iframeCurrentAuthoredState.current = newAuthoredState;
-      onChange({ url, authoredState: newAuthoredState, id: id || uuidv4() });
+      onChange({ libraryInteractiveId, authoredState: newAuthoredState, id: id || uuidv4() });
     });
     phone.addListener("height", (newHeight: number) => {
       setIframeHeight(newHeight);
@@ -71,10 +50,10 @@ export const IframeAuthoring: React.FC<FieldProps> = props => {
       mode: "authoring",
       authoredState
     });
-  }, [id, url, onChange, authoredState]);
+  }, [id, libraryInteractiveId, onChange, authoredState]);
 
   useEffect(() => {
-
+    const url = libraryInteractiveIdToUrl(libraryInteractiveId);
     // Trigger reload ONLY if URL has changed or authored state is different than current iframe state.
     // This can happen when iframes are reordered using react-jsochschema-form array controls. More details in the
     // initial comment about `iframeCurrentAuthoredState`. `deepEqual` is used, as when `===` was used, sometimes iframe
@@ -85,15 +64,17 @@ export const IframeAuthoring: React.FC<FieldProps> = props => {
       iframeRef.current.src = url;
       phoneRef.current = new iframePhone.ParentEndpoint(iframeRef.current, initInteractive);
     }
-  }, [url, authoredState, initInteractive]);
+  }, [libraryInteractiveId, authoredState, initInteractive]);
+
+  console.log('lid', libraryInteractiveId);
 
   return (
     <div className={css.iframeAuthoring}>
-      Interactive: <select onChange={handleUrlChange} value={url} data-cy="select-subquestion">
-        { availableInteractives.map(o => <option key={o.url} value={o.url}>{o.name}</option>) }
+      Interactive: <select onChange={handleLibraryInteractiveIdChange} value={libraryInteractiveId} data-cy="select-subquestion">
+        { libraryInteractives.map(o => <option key={o.libraryInteractiveId} value={o.libraryInteractiveId}>{o.name}</option>) }
       </select>
       {
-        url &&
+        libraryInteractiveId &&
         <div className={css.iframeAuthoring}>
           <h4 onClick={handleHeaderClick} className={css.link} data-cy="subquestion-authoring">{authoringOpened ? "▼" : "▶"} Subquestion authoring</h4>
           <div className={css.iframeContainer} style={{maxHeight: authoringOpened ? iframeHeight : 0 }}>

--- a/src/scaffolded-question/components/library-interactives.test.ts
+++ b/src/scaffolded-question/components/library-interactives.test.ts
@@ -1,0 +1,14 @@
+import { libraryInteractiveIdToUrl } from "./library-interactives";
+
+describe("libraryInteractiveIdToUrl", () => {
+  beforeEach(() => {
+    delete (window as any).location;
+    (window as any).location = {
+      href: "http://question-interactives/version/0.5.0/scaffolded-question"
+    };
+  });
+
+  it("converts temporal ID (path segment) to full URL using the current URL", () => {
+    expect(libraryInteractiveIdToUrl("open-response")).toEqual("http://question-interactives/version/0.5.0/open-response");
+  });
+});

--- a/src/scaffolded-question/components/library-interactives.ts
+++ b/src/scaffolded-question/components/library-interactives.ts
@@ -1,0 +1,28 @@
+// This is only temporary list. It will be replaced by LARA Interactive API call that returns all the available library interactives.
+export const libraryInteractives = [
+  {
+    libraryInteractiveId: "",
+    name: "Select an interactive"
+  },
+  {
+    libraryInteractiveId: "open-response",
+    name: "Open response"
+  },
+  {
+    libraryInteractiveId: "fill-in-the-blank",
+    name: "Fill in the blank"
+  },
+  {
+    libraryInteractiveId: "multiple-choice",
+    name: "Multiple choice"
+  }
+];
+
+// This function will be in the future replaced by LARA Interactive API call.
+export const libraryInteractiveIdToUrl = (libraryInteractiveId: string) => {
+  // Note that currently libraryInteractiveId is just a last segment of the full interactive URL, for example
+  // "open-response", "fill-in-the-blank", and so on. The final URL is constructed here dynamically using
+  // scaffolded question URL that includes version number to keep subinteractives updated too.
+  const scaffoldedQuestionSegment = /scaffolded-question\/?$/;
+  return window.location.href.replace(scaffoldedQuestionSegment, libraryInteractiveId);
+};

--- a/src/scaffolded-question/components/runtime.tsx
+++ b/src/scaffolded-question/components/runtime.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { IframeRuntime } from "./iframe-runtime";
-import { IInteractiveState } from "./app";
-import { IAuthoredState } from "./app";
+import { IInteractiveState, IAuthoredState } from "./types";
 import { SubmitButton } from "../../shared/components/submit-button";
 import { LockedInfo } from "../../shared/components/locked-info";
 import { useStudentSettings } from "../../shared/hooks/use-student-settings";
 import { renderHTML } from "../../shared/utilities/render-html";
 import { log } from "@concord-consortium/lara-interactive-api";
+import { libraryInteractiveIdToUrl } from "./library-interactives";
 import css from "./runtime.scss";
 
 interface IProps {
@@ -86,7 +86,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
       <IframeRuntime
         key={currentInteractive.id}
         id={currentInteractive.id}
-        url={currentInteractive.url}
+        url={libraryInteractiveIdToUrl(currentInteractive.libraryInteractiveId)}
         authoredState={currentInteractive.authoredState}
         interactiveState={subState}
         setInteractiveState={readOnly ? undefined : handleNewInteractiveState.bind(null, currentInteractive.id)}

--- a/src/scaffolded-question/components/state-migrations.test.ts
+++ b/src/scaffolded-question/components/state-migrations.test.ts
@@ -1,0 +1,57 @@
+import { migrateAuthoredState } from "./state-migrations";
+import { IAuthoredState, IAuthoredStateV1 } from "./types";
+import deepmerge from "deepmerge";
+
+describe("authored state migration", () => {
+  it("leave the current version unaffected", () => {
+    const state: IAuthoredState = {
+      version: 2,
+      questionType: "iframe_interactive",
+      subinteractives: [
+        {
+          id: "uuid",
+          libraryInteractiveId: "open-response",
+          authoredState: {}
+        }
+      ]
+    };
+    const stateCopy = deepmerge({}, state);
+    expect(migrateAuthoredState(state)).toEqual(stateCopy);
+  });
+
+  it("should convert V1 to V2", () => {
+    const stateV1: IAuthoredStateV1 = {
+      version: 1,
+      questionType: "iframe_interactive",
+      subinteractives: [
+        {
+          id: "uuid",
+          url: "https://question-interactives.concord.org/version/0.5.0/open-response",
+          authoredState: {}
+        },
+        {
+          id: "uuid",
+          url: "https://question-interactives.concord.org/version/0.5.0/multiple-choice",
+          authoredState: {}
+        }
+      ]
+    };
+    const stateV2: IAuthoredState = {
+      version: 2,
+      questionType: "iframe_interactive",
+      subinteractives: [
+        {
+          id: "uuid",
+          libraryInteractiveId: "open-response",
+          authoredState: {}
+        },
+        {
+          id: "uuid",
+          libraryInteractiveId: "multiple-choice",
+          authoredState: {}
+        }
+      ]
+    };
+    expect(migrateAuthoredState(stateV1)).toEqual(stateV2);
+  });
+});

--- a/src/scaffolded-question/components/state-migrations.ts
+++ b/src/scaffolded-question/components/state-migrations.ts
@@ -1,0 +1,21 @@
+import { IAuthoredState, IAuthoredStateV1 } from "./types";
+
+export const migrateAuthoredState = (authoredState: IAuthoredStateV1 | IAuthoredState) => {
+  if (authoredState.version === 1) {
+    // Converts http://question-interactives.concord.org/version/0.5.0/open-response to open-response
+    const urlToIntName = (url: string) => {
+      while (url[url.length - 1] === "/") {
+        url = url.slice(0, -1);
+      }
+      return url.substr(url.lastIndexOf("/") + 1);
+    };
+    const newState: IAuthoredState = {...authoredState, version: 2, subinteractives: []};
+    newState.subinteractives = authoredState.subinteractives?.map(subint => ({
+      id: subint.id,
+      authoredState: subint.authoredState,
+      libraryInteractiveId: urlToIntName(subint.url)
+    }));
+    return newState;
+  }
+  return authoredState;
+};

--- a/src/scaffolded-question/components/types.ts
+++ b/src/scaffolded-question/components/types.ts
@@ -1,0 +1,32 @@
+import { IAuthoringInteractiveMetadata, IRuntimeInteractiveMetadata } from "@concord-consortium/lara-interactive-api";
+
+// Note that TS interfaces should match JSON schema. Currently there's no way to generate one from the other.
+// TS interfaces are not available in runtime in contrast to JSON schema.
+export interface IAuthoredState extends IAuthoringInteractiveMetadata {
+  version: 2;
+  hint?: string;
+  subinteractives?: {
+    id: string;
+    libraryInteractiveId: string;
+    authoredState: any;
+  }[]
+}
+
+export interface IInteractiveState extends IRuntimeInteractiveMetadata {
+  subinteractiveStates: {
+    [id: string]: any;
+  },
+  currentSubinteractiveId: string;
+  submitted: boolean;
+}
+
+// Old authored state versions:
+export interface IAuthoredStateV1 extends IAuthoringInteractiveMetadata {
+  version: 1;
+  hint?: string;
+  subinteractives?: {
+    id: string;
+    url: string;
+    authoredState: any;
+  }[]
+}

--- a/src/shared/components/base-app.test.tsx
+++ b/src/shared/components/base-app.test.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { mount } from "enzyme";
+import { BaseApp } from "./base-app";
+
+jest.mock("@concord-consortium/lara-interactive-api", () => ({
+  useInitMessage: jest.fn(() => initMessage),
+  useAuthoredState: jest.fn(() => useAuthoredStateResult),
+  useInteractiveState: jest.fn(() => ({})),
+  setSupportedFeatures: jest.fn()
+}));
+
+let initMessage = {};
+let useAuthoredStateResult = {};
+
+describe("BaseApp", () => {
+  beforeEach(() => {
+    initMessage = {};
+    useAuthoredStateResult = { authoredState: {}, setAuthoredState: jest.fn() };
+  });
+
+  it("applies authored state migrations in runtime mode", () => {
+    useAuthoredStateResult = { authoredState: {
+        version: 1,
+        foo: "bar"
+      }, setAuthoredState: jest.fn() };
+    initMessage = { mode: "runtime" };
+
+    const migrate = (oldState: any) => ({
+      ...oldState,
+      version: 2,
+      newProp: "123"
+    });
+
+    const Runtime = () => null;
+    const wrapper = mount(<BaseApp Runtime={Runtime} migrateAuthoredState={migrate} />);
+
+    expect(wrapper.find(Runtime).length).toEqual(1);
+    expect(wrapper.find(Runtime).prop("authoredState")).toEqual({
+      version: 2,
+      foo: "bar",
+      newProp: "123"
+    });
+  });
+});

--- a/src/shared/components/base-app.tsx
+++ b/src/shared/components/base-app.tsx
@@ -30,13 +30,17 @@ interface IProps<IAuthoredState> {
   Runtime: React.FC<IRuntimeComponentProps<IAuthoredState>>;
   disableAutoHeight?: boolean;
   linkedInteractiveProps?: ILinkedInteractiveProp[];
+  migrateAuthoredState?: (oldAuthoredState: any) => IAuthoredState;
 }
 
 // BaseApp for interactives that don't save interactive state and don't show up in the report. E.g. image, video.
 export const BaseApp = <IAuthoredState extends IBaseAuthoredState>(props: IProps<IAuthoredState>) => {
-  const { Authoring, baseAuthoringProps, Runtime, disableAutoHeight, linkedInteractiveProps } = props;
+  const { Authoring, baseAuthoringProps, Runtime, disableAutoHeight, linkedInteractiveProps, migrateAuthoredState } = props;
   const container = useRef<HTMLDivElement>(null);
-  const { authoredState, setAuthoredState } = useAuthoredState<IAuthoredState>();
+  const useAuthStateResult = useAuthoredState<IAuthoredState>();
+  const authoredState = migrateAuthoredState && useAuthStateResult.authoredState ?
+    migrateAuthoredState(useAuthStateResult.authoredState) : useAuthStateResult.authoredState;
+  const setAuthoredState = useAuthStateResult.setAuthoredState;
   const initMessage = useInitMessage();
   const isLoading = !initMessage;
   const isRuntimeView = initMessage?.mode === "runtime";

--- a/src/shared/components/base-question-app.test.tsx
+++ b/src/shared/components/base-question-app.test.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { mount } from "enzyme";
+import { BaseQuestionApp } from "./base-question-app";
+
+jest.mock("@concord-consortium/lara-interactive-api", () => ({
+  useInitMessage: jest.fn(() => initMessage),
+  useAuthoredState: jest.fn(() => useAuthoredStateResult),
+  useInteractiveState: jest.fn(() => ({})),
+  setSupportedFeatures: jest.fn()
+}));
+
+let initMessage = {};
+let useAuthoredStateResult = {};
+
+describe("BaseApp", () => {
+  beforeEach(() => {
+    initMessage = {};
+    useAuthoredStateResult = { authoredState: {}, setAuthoredState: jest.fn() };
+  });
+
+  it("applies authored state migrations in runtime mode", () => {
+    useAuthoredStateResult = { authoredState: {
+        version: 1,
+        foo: "bar"
+      }, setAuthoredState: jest.fn() };
+    initMessage = { mode: "runtime" };
+
+    const migrate = (oldState: any) => ({
+      ...oldState,
+      version: 2,
+      newProp: "123"
+    });
+
+    const Runtime = () => null;
+    const wrapper = mount(<BaseQuestionApp Runtime={Runtime} migrateAuthoredState={migrate} disableSubmitBtnRendering={true} />);
+
+    expect(wrapper.find(Runtime).length).toEqual(1);
+    expect(wrapper.find(Runtime).prop("authoredState")).toEqual({
+      version: 2,
+      foo: "bar",
+      newProp: "123"
+    });
+  });
+
+  it("applies authored state migrations in authoring mode", () => {
+    useAuthoredStateResult = { authoredState: {
+        version: 1,
+        foo: "bar"
+      }, setAuthoredState: jest.fn() };
+    initMessage = { mode: "authoring" };
+
+    const migrate = (oldState: any) => ({
+      ...oldState,
+      version: 2,
+      newProp: "123"
+    });
+
+    const Runtime = () => null;
+    const Authoring = () => null;
+    const wrapper = mount(<BaseQuestionApp Runtime={Runtime} Authoring={Authoring} migrateAuthoredState={migrate} disableSubmitBtnRendering={true} />);
+
+    expect(wrapper.find(Authoring).length).toEqual(1);
+    expect(wrapper.find(Authoring).prop("authoredState")).toEqual({
+      version: 2,
+      foo: "bar",
+      newProp: "123"
+    });
+  });
+});

--- a/src/shared/components/base-question-app.tsx
+++ b/src/shared/components/base-question-app.tsx
@@ -42,14 +42,19 @@ interface IProps<IAuthoredState, IInteractiveState> {
   // Note that isAnswered is required when `disableSubmitBtnRendering` is false.
   isAnswered?: (state: IInteractiveState | null) => boolean;
   linkedInteractiveProps?: ILinkedInteractiveProp[];
+  migrateAuthoredState?: (oldAuthoredState: any) => IAuthoredState;
 }
 
 // BaseApp for interactives that save interactive state and show in the report. E.g. open response, multiple choice.
 export const BaseQuestionApp = <IAuthoredState extends IAuthoringMetadata & IBaseQuestionAuthoredState,
   IInteractiveState extends IRuntimeMetadata & IBaseQuestionInteractiveState>(props: IProps<IAuthoredState, IInteractiveState>) => {
-  const { Authoring, baseAuthoringProps, Runtime, isAnswered, disableAutoHeight, disableSubmitBtnRendering, linkedInteractiveProps } = props;
+  const { Authoring, baseAuthoringProps, Runtime, isAnswered, disableAutoHeight, disableSubmitBtnRendering,
+    linkedInteractiveProps, migrateAuthoredState } = props;
   const container = useRef<HTMLDivElement>(null);
-  const { authoredState, setAuthoredState } = useAuthoredState<IAuthoredState>();
+  const useAuthStateResult = useAuthoredState<IAuthoredState>();
+  const authoredState = migrateAuthoredState && useAuthStateResult.authoredState ?
+    migrateAuthoredState(useAuthStateResult.authoredState) : useAuthStateResult.authoredState;
+  const setAuthoredState = useAuthStateResult.setAuthoredState;
   const { interactiveState, setInteractiveState } = useInteractiveState<IInteractiveState>();
   const initMessage = useInitMessage();
   const isLoading = !initMessage;


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/175502689

@scytacki, I'm marking you as a reviewer here, as we briefly discussed the issue and possible solutions before.

This fix became a bit lengthy, as I've decided to add a concept of authored state migration. I could kept using `url` property and just treat it as a path segment, but I've tried to make that a bit more clear and hopefully add a tool that can be used by other interactives later.

Re migrations - one issue with the current implementation is that when a random component decides to use `useAuthoredState`, it might get outdated state. So, it'd be its responsibility to call migrations first. It shouldn't be a problem right now as all interactive-specific components use authored state provided via props, but something to keep in mind. We could extend `lara-interactive-api` and register migration function there. Then, the client could apply migration globally, so we wouldn't have to care about it while using `useAuthoredState` hook. But I'm not yet sure if it's worth it yet.

Re Scaffolded Question issue - `libraryInteractiveId` name replaces old `url` property of the subinteractive. Currently, these IDs are hardcoded ("open-response", "multiple-choice", "fill-in-the-blank"), but in the future, we might use real IDs provided by LARA API. There's also a function that converts this ID to a real URL. The current implementation uses Scaffolded Question URL to generate subquestion URL, but in the future this could be replaced by LARA API too. I've decided to use this naming, so we don't have to make more migrations in the future here. And it kinda matches the current implementation too. 

If we ever decide to use LARA API and full interactive library, we wouldn't have to make another authoredState migration. We will need to migrate `libraryInteractiveId` values in LARA database though ("open-response" to open response library interactive ID etc.), but it seems this can't be avoided anyway.
