### PR TITLE
Add graph interactive Jest and Cypress tests, update Cypress to 6.0

### DIFF
--- a/cypress/integration/graph.test.js
+++ b/cypress/integration/graph.test.js
@@ -1,0 +1,187 @@
+import {phonePost, phoneListen, getAndClearAllPhoneMessage, getAndClearLastPhoneMessage} from "../support";
+
+context("Test graph interactive", () => {
+  beforeEach(() => {
+    cy.visit("/wrapper.html?iframe=/graph");
+  });
+
+  context("Runtime view", () => {
+    it("renders empty graph if there's no data available", () => {
+      phonePost("initInteractive", {
+        mode: "runtime",
+        authoredState: {
+          version: 1,
+          dataSourceInteractive1: "testInt1"
+        },
+      });
+      cy.getIframeBody().find("canvas").should("have.length", 1);
+    });
+
+    it("renders multiple graphs when data cannot be merged", () => {
+      phoneListen("addLinkedInteractiveStateListener");
+
+      phonePost("initInteractive", {
+        mode: "runtime",
+        authoredState: {
+          version: 1,
+          graphsPerRow: 2,
+          dataSourceInteractive1: "testInt1",
+          dataSourceInteractive2: "testInt2"
+        },
+        // Note that this is necessary, see use-linked-interactives hook for implementation details.
+        // Generally, labels need to match authored state properties, and IDs become values in the authored state.
+        linkedInteractives: [ {id: "testInt1", label: "dataSourceInteractive1"}, {id: "testInt2", label: "dataSourceInteractive2"} ]
+      });
+
+      cy.wait(100);
+      getAndClearAllPhoneMessage(messages => {
+        // Two "addLinkedInteractiveStateListener" messages with listenerIds necessary to send back the response.
+        expect(messages.length).to.eql(2);
+        const listenerIds = messages.map(m => m.listenerId);
+
+        // Send the first linked state.
+        phonePost("linkedInteractiveState", {
+          listenerId: listenerIds[0],
+          interactiveState: {
+            dataset: {
+              type: "dataset",
+              version: 1,
+              properties: ["x", "y"],
+              xAxisProp: "x",
+              rows: [ [1, 1], [2, 2] ]
+            }
+          }
+        });
+        cy.getIframeBody().find("canvas").should("have.length", 1);
+
+        // Now send the second state.
+        phonePost("linkedInteractiveState", {
+          listenerId: listenerIds[1],
+          interactiveState: {
+            dataset: {
+              type: "dataset",
+              version: 1,
+              properties: ["x", "y2"], // note that y2 !== y, so two separate graphs are necessary.
+              xAxisProp: "x",
+              rows: [ [1, 1], [2, 2] ]
+            }
+          }
+        });
+        cy.getIframeBody().find("canvas").should("have.length", 2);
+      });
+    });
+
+    it("renders one graph when data can be merged", () => {
+      phoneListen("addLinkedInteractiveStateListener");
+
+      phonePost("initInteractive", {
+        mode: "runtime",
+        authoredState: {
+          version: 1,
+          graphsPerRow: 2,
+          dataSourceInteractive1: "testInt1",
+          dataSourceInteractive2: "testInt2"
+        },
+        // Note that this is necessary, see use-linked-interactives hook for implementation details.
+        // Generally, labels need to match authored state properties, and IDs become values in the authored state.
+        linkedInteractives: [ {id: "testInt1", label: "dataSourceInteractive1"}, {id: "testInt2", label: "dataSourceInteractive2"} ]
+      });
+
+      cy.wait(100);
+      getAndClearAllPhoneMessage(messages => {
+        // Two "addLinkedInteractiveStateListener" messages with listenerIds necessary to send back the response.
+        expect(messages.length).to.eql(2);
+        const listenerIds = messages.map(m => m.listenerId);
+
+        const interactiveState = {
+          dataset: {
+            type: "dataset",
+              version: 1,
+              properties: ["x", "y"],
+              xAxisProp: "x",
+              rows: [ [1, 1], [2, 2] ]
+          }
+        };
+
+        // Send the first linked state.
+        phonePost("linkedInteractiveState", {
+          listenerId: listenerIds[0],
+          interactiveState
+        });
+        cy.getIframeBody().find("canvas").should("have.length", 1);
+
+        // Now send the second state.
+        phonePost("linkedInteractiveState", {
+          listenerId: listenerIds[1],
+          interactiveState
+        });
+        // Still one graph but with two bars.
+        cy.getIframeBody().find("canvas").should("have.length", 1);
+      });
+    });
+  });
+
+  context("Authoring view", () => {
+    it("handles pre-existing authored state", () => {
+      phonePost("initInteractive", {
+        mode: "authoring",
+        authoredState: {
+          version: 1,
+          graphsPerRow: 2,
+          dataSourceInteractive1: "testInt1",
+          dataSourceInteractive2: "testInt2"
+        },
+        // Note that this is necessary, see use-linked-interactives hook for implementation details.
+        // Generally, labels need to match authored state properties, and IDs become values in the authored state.
+        linkedInteractives: [ {id: "testInt1", label: "dataSourceInteractive1"}, {id: "testInt2", label: "dataSourceInteractive2"} ]
+      });
+
+      cy.getIframeBody().find("#app").should("include.text", "Number of graphs per row");
+      cy.getIframeBody().find("#app").should("include.text", "Data Source Interactive 1");
+      cy.getIframeBody().find("#app").should("include.text", "Data Source Interactive 2");
+      cy.getIframeBody().find("#app").should("include.text", "Data Source Interactive 3");
+
+      cy.getIframeBody().find("#root_graphsPerRow input[checked]").should("have.value", "2");
+      cy.getIframeBody().find("#root_dataSourceInteractive1").should("have.value", "testInt1");
+      cy.getIframeBody().find("#root_dataSourceInteractive2").should("have.value", "testInt2");
+    });
+
+    it("renders authoring form and sends back authored state", () => {
+      phonePost("initInteractive", {
+        mode: "authoring",
+        authoredState: {
+          version: 1,
+          graphsPerRow: 2,
+          dataSourceInteractive1: "testInt1",
+          dataSourceInteractive2: "testInt2"
+        },
+        // Note that this is necessary, see use-linked-interactives hook for implementation details.
+        // Generally, labels need to match authored state properties, and IDs become values in the authored state.
+        linkedInteractives: [ {id: "testInt1", label: "dataSourceInteractive1"}, {id: "testInt2", label: "dataSourceInteractive2"} ]
+      });
+      phoneListen("getInteractiveList");
+      phoneListen("authoredState");
+
+      getAndClearAllPhoneMessage(messages => {
+        console.log(messages);
+        messages.forEach(msg => {
+          phonePost("interactiveList", {
+            requestId: msg.requestId,
+            interactives: [
+              { id: "testInt1", name: "Test Interactive 1" },
+              { id: "testInt2", name: "Test Interactive 2" },
+              { id: "testInt3", name: "Test Interactive 3" },
+              { id: "testInt4", name: "Test Interactive 4" },
+            ]
+          });
+        });
+      });
+
+      cy.getIframeBody().find("select#root_dataSourceInteractive1").select("testInt4 (Test Interactive 4)");
+      getAndClearLastPhoneMessage(state => {
+        expect(state.version).eql(1);
+        expect(state.dataSourceInteractive1).eql("testInt4");
+      }, 300);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1355,22 +1355,14 @@
       }
     },
     "@cypress/webpack-preprocessor": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/@cypress/webpack-preprocessor/-/webpack-preprocessor-5.4.5.tgz",
-      "integrity": "sha512-KH9B//f5DanvnO4RxyEq9RRGqeFqbzsk/wvINWhJAZcyCSZ9iD/J5E1picHt7UZxw9iXw3hzJWcuKNxdR4nk5w==",
+      "version": "5.4.11",
+      "resolved": "https://registry.npmjs.org/@cypress/webpack-preprocessor/-/webpack-preprocessor-5.4.11.tgz",
+      "integrity": "sha512-6kj0HsaWf1s0UT4qkABuwl676sW8S8lSTai3NUcF3BWj9BqhN4JPd2DdGcHNkNmYRkjpklPeGUHqAOyqMDj5+A==",
       "dev": true,
       "requires": {
         "bluebird": "^3.7.1",
         "debug": "^4.1.1",
         "lodash": "^4.17.20"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-          "dev": true
-        }
       }
     },
     "@cypress/xvfb": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1384,9 +1384,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -3425,9 +3425,9 @@
       }
     },
     "@types/sinonjs__fake-timers": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz",
-      "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
+      "integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==",
       "dev": true
     },
     "@types/sizzle": {
@@ -4133,9 +4133,9 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "arch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.2.tgz",
-      "integrity": "sha512-NTBIIbAfkJeIletyABbVtdPgeKfDafR+1mZV/AyyfC1UkVkp9iUjV+wwmqtUgphHYajbI86jejBJp5e+jkGTiQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
       "dev": true
     },
     "are-we-there-yet": {
@@ -6733,9 +6733,9 @@
       }
     },
     "commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
       "dev": true
     },
     "common-tags": {
@@ -7294,9 +7294,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-5.0.0.tgz",
-      "integrity": "sha512-jhPd0PMO1dPSBNpx6pHVLkmnnaTfMy3wCoacHAKJ9LJG06y16zqUNSFri64N4BjuGe8y6mNMt8TdgKnmy9muCg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.0.0.tgz",
+      "integrity": "sha512-A/w9S15xGxX5UVeAQZacKBqaA0Uqlae9e5WMrehehAdFiLOZj08IgSVZOV8YqA9OH9Z0iBOnmsEkK3NNj43VrA==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "^0.4.1",
@@ -7311,7 +7311,7 @@
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
         "cli-table3": "~0.6.0",
-        "commander": "^4.1.1",
+        "commander": "^5.1.0",
         "common-tags": "^1.8.0",
         "debug": "^4.1.1",
         "eventemitter2": "^6.4.2",
@@ -7329,10 +7329,10 @@
         "minimist": "^1.2.5",
         "moment": "^2.27.0",
         "ospath": "^1.2.2",
-        "pretty-bytes": "^5.3.0",
+        "pretty-bytes": "^5.4.1",
         "ramda": "~0.26.1",
         "request-progress": "^3.0.0",
-        "supports-color": "^7.1.0",
+        "supports-color": "^7.2.0",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
         "url": "^0.11.0",
@@ -7367,9 +7367,9 @@
           }
         },
         "execa": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
-          "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
           "dev": true,
           "requires": {
             "cross-spawn": "^7.0.0",
@@ -7411,20 +7411,22 @@
           "dev": true
         },
         "jsonfile": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6",
-            "universalify": "^1.0.0"
+            "universalify": "^2.0.0"
+          },
+          "dependencies": {
+            "universalify": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+              "dev": true
+            }
           }
-        },
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-          "dev": true
         },
         "npm-run-path": {
           "version": "4.0.1",
@@ -7464,6 +7466,15 @@
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
           "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         },
         "universalify": {
           "version": "1.0.0",
@@ -16048,9 +16059,9 @@
       "dev": true
     },
     "pretty-bytes": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
-      "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.4.1.tgz",
+      "integrity": "sha512-s1Iam6Gwz3JI5Hweaz4GoCD1WUNUIyzePFy5+Js2hjwGVt2Z79wNN+ZKOZ2vB6C+Xs6njyB84Z1IthQg8d9LxA==",
       "dev": true
     },
     "pretty-error": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "homepage": "https://github.com/concord-consortium/question-interactives#readme",
   "devDependencies": {
-    "@cypress/webpack-preprocessor": "^5.4.5",
+    "@cypress/webpack-preprocessor": "^5.4.11",
     "@svgr/webpack": "^5.4.0",
     "@testing-library/react": "^10.4.9",
     "@testing-library/react-hooks": "^3.4.1",
@@ -90,7 +90,7 @@
     "babel-jest": "^26.3.0",
     "babel-loader": "^8.1.0",
     "css-loader": "^4.2.2",
-    "cypress": "^5.0.0",
+    "cypress": "^6.0.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.3",
     "eslint": "^7.7.0",

--- a/src/graph/components/runtime.test.tsx
+++ b/src/graph/components/runtime.test.tsx
@@ -1,0 +1,145 @@
+import React from "react";
+import {
+  addLinkedInteractiveStateListener, IInteractiveStateWithDataset, removeLinkedInteractiveStateListener
+} from "@concord-consortium/lara-interactive-api";
+import { mount } from "enzyme";
+import { Runtime } from "./runtime";
+import { Bar } from "react-chartjs-2";
+import { IAuthoredState } from "./types";
+import { act } from "react-dom/test-utils";
+import { emptyChartData } from "../generate-chart-data";
+import css from "./runtime.scss";
+
+jest.mock("@concord-consortium/lara-interactive-api", () => ({
+  addLinkedInteractiveStateListener: jest.fn(),
+  removeLinkedInteractiveStateListener: jest.fn()
+}));
+
+const addLinkedInteractiveStateListenerMock = addLinkedInteractiveStateListener as jest.Mock;
+const removeLinkedInteractiveStateListenerMock = removeLinkedInteractiveStateListener as jest.Mock;
+
+const authoredState: IAuthoredState = {
+  version: 1,
+  dataSourceInteractive1: "linkedInt1",
+  dataSourceInteractive2: "linkedInt2"
+};
+
+const defaultLinkedState: IInteractiveStateWithDataset = {
+  dataset: {
+    type: "dataset",
+    version: 1,
+    properties: ["x", "y"],
+    xAxisProp: "x",
+    rows: [ [1, 1], [2, 2] ]
+  }
+};
+
+const fakeDatasetUpdate = (index: number, intState: IInteractiveStateWithDataset) => {
+  const listener1 = addLinkedInteractiveStateListenerMock.mock.calls[index][0];
+  act(() => {
+    listener1(intState);
+  });
+};
+
+describe("Graph runtime", () => {
+  beforeEach(() => {
+    addLinkedInteractiveStateListenerMock.mockClear();
+    removeLinkedInteractiveStateListenerMock.mockClear();
+  });
+
+  it("calls addLinkedInteractiveStateListener on mount and removeLinkedInteractiveStateListener for each observed source interactive", () => {
+    const wrapper = mount(<Runtime authoredState={authoredState} />);
+    expect(addLinkedInteractiveStateListenerMock).toHaveBeenCalledTimes(2);
+    expect(addLinkedInteractiveStateListenerMock.mock.calls[0][1]).toEqual({interactiveItemId: "linkedInt1"});
+    expect(addLinkedInteractiveStateListenerMock.mock.calls[1][1]).toEqual({interactiveItemId: "linkedInt2"});
+    expect(removeLinkedInteractiveStateListener).toHaveBeenCalledTimes(0);
+    wrapper.unmount();
+    expect(removeLinkedInteractiveStateListenerMock).toHaveBeenCalledTimes(2);
+    const listener1 = addLinkedInteractiveStateListenerMock.mock.calls[0][0];
+    expect(removeLinkedInteractiveStateListenerMock).toHaveBeenCalledWith(listener1);
+    const listener2 = addLinkedInteractiveStateListenerMock.mock.calls[1][0];
+    expect(removeLinkedInteractiveStateListenerMock).toHaveBeenCalledWith(listener2);
+  });
+
+  it("renders empty graph when there's no data available yet", () => {
+    const wrapper = mount(<Runtime authoredState={authoredState} />);
+    expect(wrapper.find(Bar).length).toEqual(1);
+    expect(wrapper.find(Bar).at(0).prop("data")).toEqual(emptyChartData);
+  });
+
+  it("renders two separate graphs when datasets cannot be merged", () => {
+    const wrapper = mount(<Runtime authoredState={authoredState} />);
+    const intState1: IInteractiveStateWithDataset = {
+      dataset: {
+        type: "dataset",
+        version: 1,
+        properties: ["x", "y"],
+        xAxisProp: "x",
+        rows: [ [1, 1], [2, 2] ]
+      }
+    };
+    fakeDatasetUpdate(0, intState1);
+    wrapper.update();
+    expect(wrapper.find(Bar).length).toEqual(1);
+    expect((wrapper.find(Bar).at(0).prop("data") as any).datasets.length).toEqual(1);
+
+    const intState2: IInteractiveStateWithDataset = {
+      dataset: {
+        type: "dataset",
+        version: 1,
+        properties: ["x1", "y1"],
+        xAxisProp: "x1",
+        rows: [ [1, 1], [2, 2] ]
+      }
+    };
+    fakeDatasetUpdate(1, intState2);
+    wrapper.update();
+    expect(wrapper.find(Bar).length).toEqual(2);
+    expect((wrapper.find(Bar).at(1).prop("data") as any).datasets.length).toEqual(1);
+  });
+
+  it("renders one graph when two datasets can be merged", () => {
+    const wrapper = mount(<Runtime authoredState={authoredState} />);
+    fakeDatasetUpdate(0, defaultLinkedState);
+    fakeDatasetUpdate(1, defaultLinkedState);
+    wrapper.update();
+    expect(wrapper.find(Bar).length).toEqual(1);
+    expect((wrapper.find(Bar).at(0).prop("data") as any).datasets.length).toEqual(2);
+  });
+
+  it("ignores incompatible datasets", () => {
+    const wrapper = mount(<Runtime authoredState={authoredState} />);
+    const intStateWithWrongVersion = {
+      dataset: {
+        type: "dataset",
+        version: 123,
+        properties: ["x", "y"],
+        xAxisProp: "x",
+        rows: [ [1, 1], [2, 2] ]
+      }
+    };
+    fakeDatasetUpdate(0, intStateWithWrongVersion as IInteractiveStateWithDataset);
+    wrapper.update();
+    expect(wrapper.find(Bar).length).toEqual(1);
+    // Still renders empty bar graph, wrong data is ignored.
+    expect(wrapper.find(Bar).at(0).prop("data")).toEqual(emptyChartData);
+  });
+
+  it("respects graphsPerRow setting", () => {
+    const graphsPerRow = 2;
+    const customAuthoredState = {...authoredState, graphsPerRow};
+    const wrapper = mount(<Runtime authoredState={customAuthoredState} />);
+    fakeDatasetUpdate(0, defaultLinkedState);
+    fakeDatasetUpdate(1, {
+      dataset: {
+        type: "dataset",
+        version: 1,
+        properties: ["x", "y1"], // make sure 2 graphs are rendered
+        xAxisProp: "x",
+        rows: [ [1, 1], [2, 2] ]
+      }
+    });
+    wrapper.update();
+    expect(wrapper.find(`.${css["graphLayout" + graphsPerRow]}`).length).toEqual(graphsPerRow);
+  });
+});

--- a/src/graph/components/runtime.tsx
+++ b/src/graph/components/runtime.tsx
@@ -26,7 +26,7 @@ const defaultGraphOptions: ChartOptions = {
   },
 };
 
-const emptyGraphOptions = {
+export const emptyGraphOptions = {
   ...defaultGraphOptions,
   legend: {
     display: false

--- a/src/graph/generate-chart-data.test.ts
+++ b/src/graph/generate-chart-data.test.ts
@@ -1,0 +1,92 @@
+import { generateChartData } from "./generate-chart-data";
+import { IDataset } from "@concord-consortium/lara-interactive-api";
+
+const dataset1: IDataset = {
+  type: "dataset",
+  version: 1,
+  properties: ["x", "y"],
+  xAxisProp: "x",
+  rows: [ [1, 10], [2, 20] ]
+};
+
+const dataset1A: IDataset = {
+  type: "dataset",
+  version: 1,
+  properties: ["x", "y"],
+  xAxisProp: "x",
+  rows: [ [1.5, 100], [2, 200], [3, 300] ]
+};
+
+const dataset2: IDataset = {
+  type: "dataset",
+  version: 1,
+  properties: ["x", "y2"],
+  xAxisProp: "x",
+  rows: [ [7, null], [8, 2000] ]
+};
+
+describe("generateChartData", () => {
+  it("works for a single dataset", () => {
+    const result = generateChartData([dataset1]);
+    expect(result[0].labels).toEqual([1, 2]);
+    expect(result[0].datasets[0]).toMatchObject({
+      label: "y",
+      data: [10, 20],
+      backgroundColor: expect.any(String),
+      borderColor: expect.any(String),
+      borderWidth: expect.any(Number)
+    });
+  });
+
+  it("works for multiple datasets", () => {
+    const result = generateChartData([dataset1, dataset2]);
+    expect(result[0].labels).toEqual([1, 2]);
+    expect(result[0].datasets[0]).toMatchObject({
+      label: "y",
+      data: [10, 20],
+      backgroundColor: expect.any(String),
+      borderColor: expect.any(String),
+      borderWidth: expect.any(Number)
+    });
+
+    expect(result[1].labels).toEqual([7, 8]);
+    expect(result[1].datasets[0]).toMatchObject({
+      label: "y2",
+      data: [null, 2000],
+      backgroundColor: expect.any(String),
+      borderColor: expect.any(String),
+      borderWidth: expect.any(Number)
+    });
+  });
+
+  it("merges multiple datasets when possible", () => {
+    const result = generateChartData([dataset1, dataset1A]);
+    expect(result[0].labels).toEqual([1, 2, 1.5, 3]);
+    expect(result[0].datasets[0]).toMatchObject({
+      label: "y",
+      data: [10, 20],
+      backgroundColor: expect.any(String),
+      borderColor: expect.any(String),
+      borderWidth: expect.any(Number)
+    });
+    expect(result[0].datasets[1]).toMatchObject({
+      label: "y #2",
+      data: [null, 200, 100, 300],
+      backgroundColor: expect.any(String),
+      borderColor: expect.any(String),
+      borderWidth: expect.any(Number)
+    });
+  });
+
+  it("detects incorrect xAxisProperty", () => {
+    expect(() => {
+      generateChartData([{
+        type: "dataset",
+        version: 1,
+        properties: ["x", "y"],
+        xAxisProp: "wrong",
+        rows: [ [1, 10], [2, 20] ]
+      }]);
+    }).toThrow("Incorrect dataset.xAxisProp value");
+  });
+});

--- a/src/graph/generate-chart-data.ts
+++ b/src/graph/generate-chart-data.ts
@@ -47,6 +47,7 @@ export const emptyChartData = {
   }]
 };
 
+// It accepts array of IDataset and returns array of Chart.JS ChartData objects.
 export const generateChartData = (datasets: Array<IDataset | null | undefined>) => {
   const result: CustomChartData[] = [];
   const chartDataForProp: {[key: string]: CustomChartData} = {};


### PR DESCRIPTION
[#173954114]

This PR adds missing tests. 

Cypress tests might not be super intuitive, as they include implementation details related to linked interactives handling, listenerIds, interactive list etc., but the benefit is that we have these functionalities covered now too.

I've updated Cypress to 6.0.0 as it didn't cause any issues.