### PR TITLE
Update graph interactive to better handle missing xAxisProp in datasets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1214,9 +1214,9 @@
       }
     },
     "@concord-consortium/lara-interactive-api": {
-      "version": "0.7.0-pre.3",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-0.7.0-pre.3.tgz",
-      "integrity": "sha512-oXWfrcaOY6weaXWWr22EvnJsOe0JiIbvhv+9x4A8HYcU4lP7pwP+2p2VV8obI2WfcDkubdSnCZYD43aw6SN9Ew==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-0.7.1.tgz",
+      "integrity": "sha512-rElnC5iTSE9wKgDzTMKXS73oJ0F2/wJgF+Ufsg7yvZb7D6hQJto01pXVi9PR+eXj4UsxGVnvuN0mUZVUYjOVwQ==",
       "requires": {
         "iframe-phone": "^1.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
-    "@concord-consortium/lara-interactive-api": "0.7.0-pre.3",
+    "@concord-consortium/lara-interactive-api": "0.7.1",
     "@concord-consortium/slate-editor": "^0.6.0",
     "chart.js": "^2.5.0",
     "deep-equal": "^2.0.3",

--- a/src/graph/components/app.tsx
+++ b/src/graph/components/app.tsx
@@ -18,6 +18,11 @@ const baseAuthoringProps = {
         enum: [1, 2, 3, 4],
         default: 3
       },
+      displayXAxisLabels: {
+        title: "Display X axis labels",
+        type: "boolean",
+        default: true
+      },
       dataSourceInteractive1: {
         title: "Data Source Interactive 1",
         type: "string",

--- a/src/graph/components/runtime.test.tsx
+++ b/src/graph/components/runtime.test.tsx
@@ -7,7 +7,6 @@ import { Runtime } from "./runtime";
 import { Bar } from "react-chartjs-2";
 import { IAuthoredState } from "./types";
 import { act } from "react-dom/test-utils";
-import { emptyChartData } from "../generate-chart-data";
 import css from "./runtime.scss";
 
 jest.mock("@concord-consortium/lara-interactive-api", () => ({
@@ -64,7 +63,6 @@ describe("Graph runtime", () => {
   it("renders empty graph when there's no data available yet", () => {
     const wrapper = mount(<Runtime authoredState={authoredState} />);
     expect(wrapper.find(Bar).length).toEqual(1);
-    expect(wrapper.find(Bar).at(0).prop("data")).toEqual(emptyChartData);
   });
 
   it("renders two separate graphs when datasets cannot be merged", () => {
@@ -121,8 +119,6 @@ describe("Graph runtime", () => {
     fakeDatasetUpdate(0, intStateWithWrongVersion as IInteractiveStateWithDataset);
     wrapper.update();
     expect(wrapper.find(Bar).length).toEqual(1);
-    // Still renders empty bar graph, wrong data is ignored.
-    expect(wrapper.find(Bar).at(0).prop("data")).toEqual(emptyChartData);
   });
 
   it("respects graphsPerRow setting", () => {

--- a/src/graph/components/runtime.tsx
+++ b/src/graph/components/runtime.tsx
@@ -12,25 +12,26 @@ export interface IProps {
   authoredState: IAuthoredState;
 }
 
-const defaultGraphOptions: ChartOptions = {
-  maintainAspectRatio: false,
-  scales: {
-    yAxes: [
-      {
+const getGraphOptions = (authoredState: IAuthoredState, { displayLegend }: { displayLegend: boolean }): ChartOptions => {
+  return {
+    legend: {
+      display: displayLegend // top legend with datasets and their colors
+    },
+    maintainAspectRatio: false,
+    scales: {
+      yAxes: [{
         ticks: {
           beginAtZero: true,
           maxTicksLimit: 5
-        },
-      },
-    ],
-  },
-};
-
-export const emptyGraphOptions = {
-  ...defaultGraphOptions,
-  legend: {
-    display: false
-  }
+        }
+      }],
+      xAxes: [{
+        ticks: {
+          display: authoredState.displayXAxisLabels // this will show/hide labels only
+        }
+      }]
+    }
+  };
 };
 
 export const Runtime: React.FC<IProps> = ({ authoredState }) => {
@@ -83,10 +84,11 @@ export const Runtime: React.FC<IProps> = ({ authoredState }) => {
         anyData ?
           generateChartData(datasets).map((chartData, idx: number) =>
             <div key={idx} className={graphContainerClassName}>
-              <Bar data={chartData} options={defaultGraphOptions} />
+              <Bar data={chartData} options={getGraphOptions(authoredState, { displayLegend: true })} />
             </div>
           ) :
-          <Bar data={emptyChartData} options={emptyGraphOptions} />
+          // Hide legend, as it'd show "undefined" (no data available yet).
+          <Bar data={emptyChartData} options={getGraphOptions(authoredState, { displayLegend: false })} />
       }
     </div>
   );

--- a/src/graph/components/types.ts
+++ b/src/graph/components/types.ts
@@ -1,6 +1,7 @@
 export interface IAuthoredState {
   version: number;
   graphsPerRow?: number;
+  displayXAxisLabels?: boolean;
   // Theoretically we could use dataSourceInteractive.type === "array", as react-jsonschema-forms handles that nicely.
   // But it would make handling of linked interactives difficult. Our hooks / helpers support only top-level
   // linked interactive properties in the authored state. That way authored state can remain "flat", having just:

--- a/src/graph/generate-chart-data.test.ts
+++ b/src/graph/generate-chart-data.test.ts
@@ -25,6 +25,13 @@ const dataset2: IDataset = {
   rows: [ [7, null], [8, 2000] ]
 };
 
+const datasetWithoutXProp: IDataset = {
+  type: "dataset",
+  version: 1,
+  properties: ["y"],
+  rows: [ [100], [200] ]
+};
+
 describe("generateChartData", () => {
   it("works for a single dataset", () => {
     const result = generateChartData([dataset1]);
@@ -59,6 +66,18 @@ describe("generateChartData", () => {
     });
   });
 
+  it("generates X axis labels (row indices) when xAxisProp is not specified", () => {
+    const result = generateChartData([datasetWithoutXProp]);
+    expect(result[0].labels).toEqual([1, 2]);
+    expect(result[0].datasets[0]).toMatchObject({
+      label: "y",
+      data: [100, 200],
+      backgroundColor: expect.any(String),
+      borderColor: expect.any(String),
+      borderWidth: expect.any(Number)
+    });
+  });
+
   it("merges multiple datasets when possible", () => {
     const result = generateChartData([dataset1, dataset1A]);
     expect(result[0].labels).toEqual([1, 2, 1.5, 3]);
@@ -76,17 +95,5 @@ describe("generateChartData", () => {
       borderColor: expect.any(String),
       borderWidth: expect.any(Number)
     });
-  });
-
-  it("detects incorrect xAxisProperty", () => {
-    expect(() => {
-      generateChartData([{
-        type: "dataset",
-        version: 1,
-        properties: ["x", "y"],
-        xAxisProp: "wrong",
-        rows: [ [1, 10], [2, 20] ]
-      }]);
-    }).toThrow("Incorrect dataset.xAxisProp value");
   });
 });

--- a/src/graph/generate-chart-data.ts
+++ b/src/graph/generate-chart-data.ts
@@ -57,11 +57,15 @@ export const generateChartData = (datasets: Array<IDataset | null | undefined>) 
     if (!dataset) {
       return;
     }
-    const xPropIdx = dataset.properties.indexOf(dataset.xAxisProp);
-    if (xPropIdx < 0) {
-      throw new Error("Incorrect dataset.xAxisProp value");
-    }
-    const labels = dataset.rows.map(row => row[xPropIdx] || "");
+    const xPropIdx = dataset.xAxisProp ? dataset.properties.indexOf(dataset.xAxisProp) : -1;
+    const labels: Label[] = dataset.rows.map((row, rowIdx) => {
+      if (xPropIdx === -1) {
+        // If x property isn't defined, use row index, but starting from 1.
+        return rowIdx + 1;
+      }
+      const val = row[xPropIdx];
+      return val !== null ? val : "";
+    });
 
     dataset.properties.forEach((prop, propIdx) => {
       if (propIdx === xPropIdx) {


### PR DESCRIPTION
[#175876890]

https://www.pivotaltracker.com/story/show/175876890

xAxisProp can be undefined now. Row indices will be displayed then. I've also added displayXAxisLabels as it might be useful to hide them in some cases (Vortex has datasets just with one row).