### PR TITLE
Fix text decoration event listener set up

### DIFF
--- a/src/drawing-tool/components/runtime.tsx
+++ b/src/drawing-tool/components/runtime.tsx
@@ -18,7 +18,7 @@ export interface IProps {
 }
 
 export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, report }) => {
-  const [decorateOptions, decorateClassName] = useGlossaryDecoration();
+  const decorateOptions = useGlossaryDecoration();
   const readOnly = report || (authoredState.required && interactiveState?.submitted);
   const useSnapshot = authoredState?.backgroundSource === "snapshot";
   const useUpload = authoredState?.backgroundSource === "upload";
@@ -34,7 +34,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     <div>
       { authoredState.prompt &&
         <DecorateChildren decorateOptions={decorateOptions}>
-          <div className={decorateClassName}>{renderHTML(authoredState.prompt)}</div>
+          <div>{renderHTML(authoredState.prompt)}</div>
         </DecorateChildren> }
       <DrawingTool authoredState={authoredState} interactiveState={interactiveState} setInteractiveState={setInteractiveState} readOnly={readOnly} />
       {

--- a/src/image/components/runtime.tsx
+++ b/src/image/components/runtime.tsx
@@ -19,7 +19,7 @@ interface IImageSize {
 }
 
 export const Runtime: React.FC<IProps> = ({ authoredState }) => {
-  const [decorateOptions, decorateClassName] = useGlossaryDecoration();
+  const decorateOptions = useGlossaryDecoration();
   const { url, highResUrl, altText, caption, credit, creditLink, creditLinkDisplayText, scaling } = authoredState;
   const imageSize = useRef<IImageSize>();
 
@@ -80,7 +80,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState }) => {
       </div>
       {caption &&
         <DecorateChildren decorateOptions={decorateOptions}>
-          <div className={`${css.caption} ${decorateClassName}`}>{caption}</div>
+          <div className={css.caption}>{caption}</div>
         </DecorateChildren> }
       {credit && <div className={css.credit}>{credit}</div>}
       {getCreditLink()}

--- a/src/multiple-choice/components/runtime.tsx
+++ b/src/multiple-choice/components/runtime.tsx
@@ -24,7 +24,7 @@ interface IProps {
 const baseElementId = uuidv4();     // DOM id necessary to associate inputs and label-for
 
 export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, report }) => {
-  const [decorateOptions, decorateClassName] = useGlossaryDecoration();
+  const decorateOptions = useGlossaryDecoration();
   const [showAnswerFeedback, setShowAnswerFeedback] = useState(false);
 
   const type = authoredState.multipleAnswers ? "checkbox" : "radio";
@@ -190,7 +190,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
       <fieldset>
         { authoredState.prompt &&
           <DecorateChildren decorateOptions={decorateOptions}>
-            <legend className={css.prompt + " list-unstyled " + decorateClassName}>
+            <legend className={css.prompt + " list-unstyled "}>
               {renderHTML(authoredState.prompt)}
             </legend>
           </DecorateChildren> }

--- a/src/open-response/components/runtime.tsx
+++ b/src/open-response/components/runtime.tsx
@@ -14,12 +14,12 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     setInteractiveState?.(prevState => ({...prevState, answerType: "open_response_answer", answerText: event.target.value }));
   };
-  const [decorateOptions, decorateClassName] = useGlossaryDecoration();
+  const decorateOptions = useGlossaryDecoration();
   return (
     <fieldset>
       { authoredState.prompt &&
         <DecorateChildren decorateOptions={decorateOptions}>
-          <legend className={`${css.prompt} ${decorateClassName}`}>
+          <legend className={css.prompt}>
             {renderHTML(authoredState.prompt)}
           </legend>
         </DecorateChildren> }

--- a/src/scaffolded-question/components/runtime.tsx
+++ b/src/scaffolded-question/components/runtime.tsx
@@ -20,7 +20,7 @@ interface IProps {
 }
 
 export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, report }) => {
-  const [decorateOptions, decorateClassName] = useGlossaryDecoration();
+  const decorateOptions = useGlossaryDecoration();
   const studentSettings = useStudentSettings();
   // 1 means that student get to the easiest question variant. 5 means that user is limited to the most difficult
   // one (assuming there are 5 levels in total).
@@ -86,7 +86,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     <div className={css.runtime} tabIndex={1}>
       { authoredState.prompt &&
         <DecorateChildren decorateOptions={decorateOptions}>
-          <div className={decorateClassName}>{renderHTML(authoredState.prompt)}</div>
+          <div>{renderHTML(authoredState.prompt)}</div>
         </DecorateChildren> }
       <IframeRuntime
         key={currentInteractive.id}

--- a/src/shared/hooks/use-glossary-decoration.ts
+++ b/src/shared/hooks/use-glossary-decoration.ts
@@ -3,11 +3,10 @@ import { addEventListeners, removeEventListeners, IDecorateReactOptions } from "
 import { useEffect, useState } from "react";
 import { renderHTML } from "../utilities/render-html";
 
-const kClassName = "text-decorate";
-
-export const useGlossaryDecoration = (): [IDecorateReactOptions, string] => {
+export const useGlossaryDecoration = (): IDecorateReactOptions => {
   const [options, setOptions] = useState<IDecorateReactOptions>({ words: [], replace: "" });
   const [listeners, setListeners] = useState<any>(); // TODO: type should be IEventListeners
+  const [wordClass, setWordClass] = useState<string>("");
 
   useDecorateContent((msg: ITextDecorationHandlerInfo) => {
     const msgOptions = {
@@ -16,12 +15,13 @@ export const useGlossaryDecoration = (): [IDecorateReactOptions, string] => {
     };
     setOptions(msgOptions);
     setListeners(msg.eventListeners);
+    setWordClass(msg.wordClass);
   });
 
   useEffect(() => {
-    listeners && addEventListeners(kClassName, listeners);
-    return () => listeners && removeEventListeners(kClassName, listeners);
-  });
+    listeners && addEventListeners(wordClass, listeners);
+    return () => listeners && removeEventListeners(wordClass, listeners);
+  }, [wordClass, listeners]);
 
-  return [options, kClassName];
+  return options;
 };

--- a/src/shared/hooks/use-glossary-decoration.ts
+++ b/src/shared/hooks/use-glossary-decoration.ts
@@ -5,7 +5,7 @@ import { renderHTML } from "../utilities/render-html";
 
 export const useGlossaryDecoration = (): IDecorateReactOptions => {
   const [options, setOptions] = useState<IDecorateReactOptions>({ words: [], replace: "" });
-  const [msg, setMsg] = useState<ITextDecorationHandlerInfo>();
+  const [message, setMessage] = useState<ITextDecorationHandlerInfo>();
 
   useDecorateContent((msg: ITextDecorationHandlerInfo) => {
     const msgOptions = {
@@ -13,13 +13,13 @@ export const useGlossaryDecoration = (): IDecorateReactOptions => {
       replace: renderHTML(msg.replace) as string | React.ReactElement,
     };
     setOptions(msgOptions);
-    setMsg(msg);
+    setMessage(msg);
   });
 
   useEffect(() => {
-    msg && addEventListeners(msg.wordClass, msg.eventListeners);
-    return () => msg && removeEventListeners(msg.wordClass, msg.eventListeners);
-  }, [msg]);
+    message && addEventListeners(message.wordClass, message.eventListeners);
+    return () => message && removeEventListeners(message.wordClass, message.eventListeners);
+  }, [message]);
 
   return options;
 };

--- a/src/shared/hooks/use-glossary-decoration.ts
+++ b/src/shared/hooks/use-glossary-decoration.ts
@@ -5,8 +5,7 @@ import { renderHTML } from "../utilities/render-html";
 
 export const useGlossaryDecoration = (): IDecorateReactOptions => {
   const [options, setOptions] = useState<IDecorateReactOptions>({ words: [], replace: "" });
-  const [listeners, setListeners] = useState<any>(); // TODO: type should be IEventListeners
-  const [wordClass, setWordClass] = useState<string>("");
+  const [msg, setMsg] = useState<ITextDecorationHandlerInfo>();
 
   useDecorateContent((msg: ITextDecorationHandlerInfo) => {
     const msgOptions = {
@@ -14,14 +13,13 @@ export const useGlossaryDecoration = (): IDecorateReactOptions => {
       replace: renderHTML(msg.replace) as string | React.ReactElement,
     };
     setOptions(msgOptions);
-    setListeners(msg.eventListeners);
-    setWordClass(msg.wordClass);
+    setMsg(msg);
   });
 
   useEffect(() => {
-    listeners && addEventListeners(wordClass, listeners);
-    return () => listeners && removeEventListeners(wordClass, listeners);
-  }, [wordClass, listeners]);
+    msg && addEventListeners(msg.wordClass, msg.eventListeners);
+    return () => msg && removeEventListeners(msg.wordClass, msg.eventListeners);
+  }, [msg]);
 
   return options;
 };

--- a/src/video-player/components/runtime.tsx
+++ b/src/video-player/components/runtime.tsx
@@ -40,7 +40,7 @@ const captionsOnByDefault = true;
 // "https://models-resources.s3.amazonaws.com/question-interactives/test-captions.vtt";
 
 export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, report }) => {
-  const [decorateOptions, decorateClassName] = useGlossaryDecoration();
+  const decorateOptions = useGlossaryDecoration();
   const readOnly = report || (authoredState.required && interactiveState?.submitted);
   const viewedProgress = interactiveState?.percentageViewed || 0;
   const viewedTimestamp = interactiveState?.lastViewedTimestamp || 0;
@@ -177,7 +177,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     <div className={css.runtime}>
       { authoredState.prompt &&
         <DecorateChildren decorateOptions={decorateOptions}>
-          <div className={`${css.prompt} ${decorateClassName}`}>{ authoredState.prompt }</div>
+          <div className={css.prompt}>{ authoredState.prompt }</div>
         </DecorateChildren> }
       <div className={`${css.videoPlayerContainer} last-viewed${viewedTimestamp}`}>
         <div className="video-player" data-vjs-player={true}>


### PR DESCRIPTION
Modify event listener for text decoration so that it is attached to the actual decorated word element instead of the parent element (clicks were then occurring on ANY content in the parent element and being passed all the way to the glossary plugin before being rejected if a word/phrase wasn't in the glossary).