### PR TITLE
Add text decoration to fill in the blank and image question types

### DIFF
--- a/src/fill-in-the-blank/components/runtime.tsx
+++ b/src/fill-in-the-blank/components/runtime.tsx
@@ -3,6 +3,8 @@ import striptags from "striptags";
 import { IRuntimeQuestionComponentProps } from "../../shared/components/base-question-app";
 import { ParseHTMLReplacer, renderHTML } from "../../shared/utilities/render-html";
 import { blankRegexp, defaultBlankSize, IAuthoredState, IBlankDef, IFilledBlank, IInteractiveState } from "./types";
+import { DecorateChildren } from "@concord-consortium/text-decorator";
+import { useGlossaryDecoration } from "../../shared/hooks/use-glossary-decoration";
 import css from "./runtime.scss";
 
 interface IProps extends IRuntimeQuestionComponentProps<IAuthoredState, IInteractiveState> {
@@ -39,7 +41,7 @@ export const replaceBlanksWithInputs = (prompt: string) => {
 };
 
 export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, report }) => {
-
+  const decorateOptions = useGlossaryDecoration();
   const readOnly = !!(report || (authoredState.required && interactiveState?.submitted));
 
   const handleChange = useCallback((blankId: string, value: string) => {
@@ -91,7 +93,9 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   const htmlContents = replaceBlanksWithInputs(authoredState.prompt || "");
   return (
     <div className="fill-in-the-blank">
-      {renderHTML(htmlContents, replaceInputs)}
+      <DecorateChildren decorateOptions={decorateOptions}>
+        {renderHTML(htmlContents, replaceInputs)}
+      </DecorateChildren>
     </div>
   );
 };

--- a/src/image-question/components/runtime.test.tsx
+++ b/src/image-question/components/runtime.test.tsx
@@ -9,7 +9,8 @@ import Shutterbug  from "shutterbug";
 
 jest.mock("@concord-consortium/lara-interactive-api", () => ({
   getInteractiveSnapshot: jest.fn(() => new Promise(resolve => resolve({success: true, snapshotUrl: "http://snapshot/123" }))),
-  closeModal: jest.fn()
+  closeModal: jest.fn(),
+  useDecorateContent: jest.fn(),
 }));
 const getInteractiveSnapshotMock = getInteractiveSnapshot as jest.Mock;
 const closeModalMock = closeModal as jest.Mock;

--- a/src/image-question/components/runtime.tsx
+++ b/src/image-question/components/runtime.tsx
@@ -108,7 +108,11 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     const inlineImage = interactiveState?.answerImageUrl || interactiveState?.userBackgroundImageUrl || authoredBackgroundUrl;
     // Render answer prompt and answer text in inline mode to replicate LARA's Image Question UI
     return <div>
-      { authoredState.prompt && <DecorateChildren decorateOptions={decorateOptions}><div>{renderHTML(authoredState.prompt)}</div></DecorateChildren> }
+      { authoredState.prompt &&
+        <DecorateChildren decorateOptions={decorateOptions}>
+          <div>{renderHTML(authoredState.prompt)}</div>
+        </DecorateChildren>
+      }
       { inlineImage && <div><img src={inlineImage} className={css.inlineImg} alt="user work"/></div> }
       { authoredState.answerPrompt && <div>{renderHTML(authoredState.answerPrompt)}</div> }
       <div className={css.studentAnswerText}>{interactiveState?.answerText}</div>

--- a/src/image-question/components/runtime.tsx
+++ b/src/image-question/components/runtime.tsx
@@ -11,6 +11,8 @@ import { UpdateFunc } from "../../shared/components/base-app";
 import Shutterbug from "shutterbug";
 import PencilIcon from "../../shared/icons/pencil.svg";
 import { useCorsImageErrorCheck } from "../../shared/hooks/use-cors-image-error-check";
+import { DecorateChildren } from "@concord-consortium/text-decorator";
+import { useGlossaryDecoration } from "../../shared/hooks/use-glossary-decoration";
 import css from "./runtime.scss";
 import cssHelpers from "../../shared/styles/helpers.scss";
 
@@ -21,6 +23,7 @@ const kGlobalDefaultAnswer = "Please type your answer here.";
 const drawingToolDialogUrlParam = "drawingToolDialog";
 
 export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, report }) => {
+  const decorateOptions = useGlossaryDecoration();
   const readOnly = report || (authoredState.required && interactiveState?.submitted);
   const [ controlsHidden, setControlsHidden ] = useState(false);
   const [ drawingStateUpdated, setDrawingStateUpdated ] = useState(false);
@@ -105,7 +108,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     const inlineImage = interactiveState?.answerImageUrl || interactiveState?.userBackgroundImageUrl || authoredBackgroundUrl;
     // Render answer prompt and answer text in inline mode to replicate LARA's Image Question UI
     return <div>
-      { authoredState.prompt && <div>{renderHTML(authoredState.prompt)}</div> }
+      { authoredState.prompt && <DecorateChildren decorateOptions={decorateOptions}><div>{renderHTML(authoredState.prompt)}</div></DecorateChildren> }
       { inlineImage && <div><img src={inlineImage} className={css.inlineImg} alt="user work"/></div> }
       { authoredState.answerPrompt && <div>{renderHTML(authoredState.answerPrompt)}</div> }
       <div className={css.studentAnswerText}>{interactiveState?.answerText}</div>


### PR DESCRIPTION
This PR adds text decoration to the fill in the blank and image question types.  This was reported as a bug by @kevinsantos-cc when reviewing the glossary work.  Adding text decoration to these question types appears to simply have been an oversight when the initial glossary work was completed.  