### PR TITLE
"Alt text" for carousel button images

### DIFF
--- a/cypress/integration/carousel.test.js
+++ b/cypress/integration/carousel.test.js
@@ -1,0 +1,392 @@
+import { phonePost, phoneListen, getAndClearLastPhoneMessage, getAndClearAllPhoneMessage } from "../support";
+
+context("Test carousel interactive", () => {
+  let i = 0;
+
+  beforeEach(() => {
+    if (i++ > 0) cy.wait(4000);
+    cy.visit("/wrapper.html?iframe=/carousel");
+  });
+
+  context("Runtime view", () => {
+    it("renders prompt, sends hint to parent and handles pre-existing interactive state (sending it to subquestions)", () => {
+      phonePost("initInteractive", {
+        mode: "runtime",
+        authoredState: {
+          version: 2,
+          prompt: "Test prompt",
+          hint: "Hint",
+          subinteractives: [
+            {
+              id: "int1",
+              url: "open-response",
+              authoredState: {
+                version: 1,
+                prompt: "Subquestion prompt",
+                hint: "Subquestion hint"
+              }
+            }
+          ]
+        },
+        interactiveState: {
+          currentSubinteractiveId: "int1",
+          subinteractiveStates: {
+            int1: {
+              answerType: "open_response_answer",
+              answerText: "Subquestion response"
+            }
+          }
+        }
+      });
+      phoneListen("hint");
+      getAndClearLastPhoneMessage(hint => {
+        expect(hint).eql({ text: "Hint" });
+      });
+
+      cy.getIframeBody().find("#app").should("include.text", "Test prompt");
+      cy.getIframeBody().find("#app").should("include.text", "Subquestion hint");
+
+      cy.getNestedIframeBody().find("#app").should("include.text", "Subquestion prompt");
+      cy.getNestedIframeBody().find("textarea").should("have.value", "Subquestion response");
+    });
+
+    // This is separate from previous test to check dealing with initial, empty state.
+    it("sends back interactive state to parent", () => {
+      phonePost("initInteractive", {
+        mode: "runtime",
+        authoredState: {
+          version: 2,
+          prompt: "Test prompt",
+          hint: "Hint",
+          subinteractives: [
+            {
+              id: "int1",
+              url: "open-response",
+              authoredState: {
+                version: 1,
+                prompt: "Subquestion prompt",
+                hint: "Subquestion hint"
+              }
+            }
+          ]
+        }
+      });
+      phoneListen("interactiveState");
+
+      cy.getNestedIframeBody().find("textarea").type("Test subquestion answer");
+      getAndClearLastPhoneMessage((state) => {
+        expect(state).eql({
+          answerType: "interactive_state",
+          subinteractiveStates: {
+            int1: {
+              answerType: "open_response_answer",
+              answerText: "Test subquestion answer"
+            }
+          },
+          answerText: "[Level: 1] Test subquestion answer"
+        });
+      });
+    });
+
+    it("logs events from subinteractives to parent", () => {
+      phonePost("initInteractive", {
+        mode: "runtime",
+        authoredState: {
+          version: 2,
+          prompt: "Test prompt",
+          hint: "Hint",
+          subinteractives: [
+            {
+              id: "int1",
+              url: "open-response",
+              authoredState: {
+                version: 1,
+                prompt: "Subquestion prompt",
+                hint: "Subquestion hint",
+                questionType: "open_response"
+              }
+            }
+          ]
+        }
+      });
+      phoneListen("log");
+
+      cy.getNestedIframeBody().find("textarea").type("Test subquestion answer");
+      cy.focused().blur();
+      cy.wait(200);
+
+      getAndClearAllPhoneMessage((messages) => {
+        expect(messages.length).eql(2);
+
+        expect(messages[0]).eql({
+          action: "focus in",
+          data: {
+            target_element: 'textarea',
+            target_type: 'textarea',
+            target_id: '',
+            target_name: '',
+            target_value: '',
+            scaffolded_question_level: 1,
+            subinteractive_url: "open-response",
+            subinteractive_type: "open_response",
+            subinteractive_sub_type: undefined,
+            subinteractive_id: 'int1'
+          }
+        });
+
+        expect(messages[1]).eql({
+          action: "focus out",
+          data: {
+            target_element: 'textarea',
+            target_type: 'textarea',
+            target_id: '',
+            target_name: '',
+            target_value: 'Test subquestion answer',
+            scaffolded_question_level: 1,
+            subinteractive_url: "open-response",
+            subinteractive_type: 'open_response',
+            subinteractive_sub_type: undefined,
+            subinteractive_id: 'int1',
+            answer_text: 'Test subquestion answer'
+          }
+        });
+      });
+    });
+
+    it("renders slides and nav buttons that move corresponding slides into view)", () => {
+      phonePost("initInteractive", {
+        mode: "runtime",
+        authoredState: {
+          version: 2,
+          prompt: "Test prompt",
+          hint: "Hint",
+          subinteractives: [
+            {
+              id: "int1",
+              url: "open-response",
+              authoredState: {
+                version: 1,
+                prompt: "Subquestion prompt #1",
+                hint: ""
+              }
+            },
+            {
+              id: "int2",
+              url: "open-response",
+              authoredState: {
+                version: 1,
+                prompt: "Subquestion prompt #2",
+                hint: ""
+              }
+            },
+            {
+              id: "int3",
+              url: "open-response",
+              authoredState: {
+                version: 1,
+                prompt: "Subquestion prompt #3",
+                hint: ""
+              }
+            }
+          ]
+        }
+      });
+
+      cy.getIframeBody().find(".slide").should('have.length', 3);
+      cy.getIframeBody().find(".slide").eq(0).find("iframe").its("0.contentDocument.body").should("include.text", "Subquestion prompt #1");
+      cy.getIframeBody().find(".slide").eq(1).find("iframe").its("0.contentDocument.body").should("include.text", "Subquestion prompt #2");
+      cy.getIframeBody().find(".slide").eq(2).find("iframe").its("0.contentDocument.body").should("include.text", "Subquestion prompt #3");
+      cy.getIframeBody().find(".slider").eq(0).should("have.attr", "style").should("contain", "translate3d(0px, 0px, 0px)");
+      cy.getIframeBody().find(".slide").eq(0).should("have.class", "selected");
+      // note: nav button index numbers don't match slide index numbers because of the previous and next buttons in navbar
+      cy.getIframeBody().find("[data-cy='carousel-nav']").children("button").eq(2).should("exist").click();
+      cy.getIframeBody().find(".slider").eq(0).should("have.attr", "style").should("contain", "translate3d(-100%, 0px, 0px)");
+      cy.getIframeBody().find(".slide").eq(0).should("not.have.class", "selected");
+      cy.getIframeBody().find(".slide").eq(1).should("have.class", "selected");
+      cy.getIframeBody().find("[data-cy='carousel-nav']").children("button").eq(3).should("exist").click();
+      cy.getIframeBody().find(".slider").eq(0).should("have.attr", "style").should("contain", "translate3d(-200%, 0px, 0px)");
+      cy.getIframeBody().find(".slide").eq(1).should("not.have.class", "selected");
+      cy.getIframeBody().find(".slide").eq(2).should("have.class", "selected");
+      cy.getIframeBody().find("[data-cy='carousel-nav']").children("button").eq(0).should("exist").click();
+      cy.getIframeBody().find(".slider").eq(0).should("have.attr", "style").should("contain", "translate3d(-100%, 0px, 0px)");
+      cy.getIframeBody().find(".slide").eq(2).should("not.have.class", "selected");
+      cy.getIframeBody().find(".slide").eq(1).should("have.class", "selected");
+      cy.getIframeBody().find("[data-cy='carousel-nav']").children("button").eq(4).should("exist").click();
+      cy.getIframeBody().find(".slider").eq(0).should("have.attr", "style").should("contain", "translate3d(-200%, 0px, 0px)");
+      cy.getIframeBody().find(".slide").eq(1).should("not.have.class", "selected");
+      cy.getIframeBody().find(".slide").eq(2).should("have.class", "selected");
+    });
+
+    it("renders nav buttons with custom images)", () => {
+      phonePost("initInteractive", {
+        mode: "runtime",
+        authoredState: {
+          version: 2,
+          prompt: "Test prompt",
+          hint: "Hint",
+          subinteractives: [
+            {
+              id: "int1",
+              url: "open-response",
+              authoredState: {
+                version: 1,
+                prompt: "Subquestion prompt #1",
+                hint: ""
+              },
+              navImageUrl: "http://fake.domain/path/to/image1.png",
+              navImageAltText: "Custom Image 1"
+            },
+            {
+              id: "int2",
+              url: "open-response",
+              authoredState: {
+                version: 1,
+                prompt: "Subquestion prompt #2",
+                hint: ""
+              },
+              navImageUrl: "http://fake.domain/path/to/image2.png",
+              navImageAltText: "Custom Image 2"
+            },
+            {
+              id: "int3",
+              url: "open-response",
+              authoredState: {
+                version: 1,
+                prompt: "Subquestion prompt #3",
+                hint: ""
+              },
+              navImageUrl: "http://fake.domain/path/to/image3.png",
+              navImageAltText: ""
+            }
+          ]
+        }
+      });
+
+      // note: nav button count should be two more than slide count because of previous and next buttons
+      cy.getIframeBody().find(".slide").should('have.length', 3);
+      cy.getIframeBody().find("[data-cy='carousel-nav']").children("button").should('have.length', 5);
+      cy.getIframeBody().find("[data-cy='carousel-nav']").children("button").eq(1).should("have.css", "backgroundImage", 'url("http://fake.domain/path/to/image1.png")');
+      cy.getIframeBody().find("[data-cy='carousel-nav']").children("button").eq(1).should("include.text", "Custom Image 1");
+      cy.getIframeBody().find("[data-cy='carousel-nav']").children("button").eq(2).should("have.css", "backgroundImage", 'url("http://fake.domain/path/to/image2.png")');
+      cy.getIframeBody().find("[data-cy='carousel-nav']").children("button").eq(2).should("include.text", "Custom Image 2");
+      cy.getIframeBody().find("[data-cy='carousel-nav']").children("button").eq(3).should("have.css", "backgroundImage", 'url("http://fake.domain/path/to/image3.png")');
+      cy.getIframeBody().find("[data-cy='carousel-nav']").children("button").eq(3).should("include.text", "Go to slide 3");
+    });
+  });
+
+  context("Authoring view", () => {
+    it("handles pre-existing authored state", () => {
+      phonePost("initInteractive", {
+        mode: "authoring",
+        authoredState: {
+          version: 2,
+          prompt: "Test prompt",
+          hint: "Hint",
+          subinteractives: [
+            {
+              id: "int1",
+              url: "open-response",
+              authoredState: {
+                version: 1,
+                prompt: "Subquestion prompt",
+                hint: "Subquestion hint"
+              }
+            }
+          ]
+        }
+      });
+
+      cy.getIframeBody().find("#app").should("include.text", "Prompt");
+      cy.getIframeBody().find("#app").should("include.text", "Hint");
+
+      cy.getIframeBody().find("#root_prompt").should("include.text", "Test prompt");
+      cy.getIframeBody().find("#root_hint").should("include.text", "Hint");
+
+      cy.getIframeBody().find("[data-cy=subquestion-authoring]").click();
+
+      cy.getNestedIframeBody().find("#root_prompt").should("include.text", "Subquestion prompt");
+      cy.getNestedIframeBody().find("#root_hint").should("include.text", "Subquestion hint");
+    });
+
+    it("renders authoring form and sends back authored state", () => {
+      phonePost("initInteractive", {
+        mode: "authoring"
+      });
+      phoneListen("authoredState");
+
+      cy.getIframeBody().find("#root_prompt").type("Test prompt");
+      getAndClearLastPhoneMessage(state => {
+        expect(state.version).eql(1);
+        expect(state.prompt).include("Test prompt");
+      }, 200);
+
+      cy.getIframeBody().find("#root_hint").type("Hint");
+      getAndClearLastPhoneMessage(state => {
+        expect(state.hint).include("Hint");
+      }, 200);
+
+      cy.getIframeBody().find(".btn-add").click();
+      cy.getIframeBody().find("[data-cy=select-subquestion]").select("Open response");
+      cy.getIframeBody().find("[data-cy=subquestion-authoring]").click();
+
+      cy.getNestedIframeBody().find("#root_prompt").type("Test subquestion prompt");
+      getAndClearLastPhoneMessage(state => {
+        expect(state.subinteractives[0].authoredState.prompt).include("Test subquestion prompt");
+      }, 200);
+    });
+
+    // This tests specifically a bug that was present and it's pretty subtle.
+    // https://www.pivotaltracker.com/story/show/173015286
+    it("handles reordering of subinteractives without any state loss", () => {
+      phonePost("initInteractive", {
+        mode: "authoring",
+        authoredState: {
+          version: 2,
+          prompt: "Test prompt",
+          hint: "Hint",
+          subinteractives: [
+            {
+              id: "int1",
+              url: "open-response",
+              authoredState: {
+                version: 1,
+                prompt: "1"
+              }
+            },
+            {
+              id: "int2",
+              url: "open-response",
+              authoredState: {
+                version: 1,
+                prompt: "2",
+              }
+            }
+          ]
+        }
+      });
+
+      // Lots of cy.wait as this test seems to fail sometimes.
+      // 1. Open subauthoring.
+      cy.wait(200);
+      cy.getIframeBody().find("[data-cy=subquestion-authoring]").eq(0).click();
+      cy.wait(200);
+      cy.getIframeBody().find("[data-cy=subquestion-authoring]").eq(1).click();
+
+      // 2. Edit second question.
+      cy.wait(1000);
+      cy.getNestedIframeBody("iframe", "#int2").find("#root_prompt").clear({ force: true });
+      cy.wait(200);
+      cy.getNestedIframeBody("iframe", "#int2").find("#root_prompt").type("x");
+
+      // 3. Move it up
+      cy.wait(200);
+      cy.getIframeBody().find(".array-item-move-up:not(:disabled)").click();
+
+      // 4. Move it down
+      cy.wait(200);
+      cy.getIframeBody().find(".array-item-move-down:not(:disabled)").click();
+      cy.wait(200);
+      cy.getNestedIframeBody("iframe", "#int2").find("#root_prompt").should("include.text", "x");
+    });
+  });
+});

--- a/src/carousel/components/iframe-authoring.tsx
+++ b/src/carousel/components/iframe-authoring.tsx
@@ -38,7 +38,7 @@ const availableInteractives = [
 
 export const IframeAuthoring: React.FC<FieldProps> = props => {
   const { onChange, formData } = props;
-  const { url, authoredState, id, navImageUrl } = formData;
+  const { url, authoredState, id, navImageUrl, navImageAltText } = formData;
   const [ iframeHeight, setIframeHeight ] = useState(300);
   const [ authoringOpened, setAuthoringOpened ] = useState(false);
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -55,12 +55,35 @@ export const IframeAuthoring: React.FC<FieldProps> = props => {
 
   const handleUrlChange = (event: ChangeEvent<HTMLSelectElement>) => {
     const newUrl = event.target.value;
-    onChange({ url: newUrl, authoredState: undefined, id: id || uuidv4(), navImageUrl: navImageUrl || "" });
+    onChange({ 
+      url: newUrl,
+      authoredState: undefined,
+      id: id || uuidv4(),
+      navImageUrl: navImageUrl || "",
+      navImageAltText: navImageAltText || ""
+    });
   };
 
   const handleNavImageUrlChange = (event: ChangeEvent<HTMLInputElement>) => {
     const newNavImageUrl = event.target.value;
-    onChange({ url: url, authoredState: authoredState, id: id, navImageUrl: newNavImageUrl || "" });
+    onChange({ 
+      url: url,
+      authoredState: authoredState,
+      id: id,
+      navImageUrl: newNavImageUrl || "",
+      navImageAltText: navImageAltText || ""
+    });
+  };
+
+  const handleNavImageAltTextChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const newNavImageAltText = event.target.value;
+    onChange({ 
+      url: url,
+      authoredState: undefined,
+      id: id,
+      navImageUrl: navImageUrl || "",
+      navImageAltText: newNavImageAltText || ""
+    });
   };
 
   const handleHeaderClick = () => {
@@ -75,7 +98,13 @@ export const IframeAuthoring: React.FC<FieldProps> = props => {
     phone.addListener("authoredState", (newAuthoredState: any) => {
       // Save current iframe authored state.
       iframeCurrentAuthoredState.current = newAuthoredState;
-      onChange({ url, authoredState: newAuthoredState, id: id || uuidv4(), navImageUrl: navImageUrl || ""  });
+      onChange({ 
+        url,
+        authoredState: newAuthoredState,
+        id: id || uuidv4(),
+        navImageUrl: navImageUrl || "",
+        navImageAltText: navImageAltText || ""
+      });
     });
     phone.addListener("height", (newHeight: number) => {
       setIframeHeight(newHeight);
@@ -84,7 +113,7 @@ export const IframeAuthoring: React.FC<FieldProps> = props => {
       mode: "authoring",
       authoredState
     });
-  }, [id, url, onChange, authoredState, navImageUrl]);
+  }, [id, url, onChange, authoredState, navImageUrl, navImageAltText]);
 
   useEffect(() => {
 
@@ -98,7 +127,7 @@ export const IframeAuthoring: React.FC<FieldProps> = props => {
       iframeRef.current.src = url;
       phoneRef.current = new iframePhone.ParentEndpoint(iframeRef.current, initInteractive);
     }
-  }, [url, authoredState, initInteractive, navImageUrl]);
+  }, [url, authoredState, initInteractive, navImageUrl, navImageAltText]);
 
   return (
     <div className={css.iframeAuthoring}>
@@ -113,7 +142,10 @@ export const IframeAuthoring: React.FC<FieldProps> = props => {
             <div className={css.navButtonField}>
               <label htmlFor={navImageUrl}>Custom Navigation Button Image URL</label>
               <input className="form-control" type="text" id={navImageUrl} defaultValue={navImageUrl} onChange={handleNavImageUrlChange} />
-              <p className="help-block">To customize the button for this slide, specify an image URL. Optimal image size: 150x100 pixels.</p>
+              <p className="help-block">To customize the button for this slide, enter an image URL. Optimal image size: 150x100 pixels.</p>
+              <label htmlFor={navImageAltText}>Custom Navigation Button Image Alt Text</label>
+              <input className="form-control" type="text" id={navImageAltText} defaultValue={navImageAltText} onChange={handleNavImageAltTextChange} />
+              <p className="help-block">To customize the alt text for a custom navigation button, enter your text.</p>
             </div>
             <iframe id={id} ref={iframeRef} width="100%" height={iframeHeight} frameBorder={0} />
           </div>

--- a/src/carousel/components/iframe-authoring.tsx
+++ b/src/carousel/components/iframe-authoring.tsx
@@ -140,11 +140,11 @@ export const IframeAuthoring: React.FC<FieldProps> = props => {
           <h4 onClick={handleHeaderClick} className={css.link} data-cy="subquestion-authoring">{authoringOpened ? "▼" : "▶"} Subquestion Authoring</h4>
           <div className={css.iframeContainer} style={{maxHeight: authoringOpened ? iframeHeight : 0 }}>
             <div className={css.navButtonField}>
-              <label htmlFor={navImageUrl}>Custom Navigation Button Image URL</label>
-              <input className="form-control" type="text" id={navImageUrl} defaultValue={navImageUrl} onChange={handleNavImageUrlChange} />
+              <label htmlFor="navImageUrl">Custom Navigation Button Image URL</label>
+              <input className="form-control" type="text" id="navImageUrl" defaultValue={navImageUrl} onChange={handleNavImageUrlChange} />
               <p className="help-block">To customize the button for this slide, enter an image URL. Optimal image size: 150x100 pixels.</p>
-              <label htmlFor={navImageAltText}>Custom Navigation Button Image Alt Text</label>
-              <input className="form-control" type="text" id={navImageAltText} defaultValue={navImageAltText} onChange={handleNavImageAltTextChange} />
+              <label htmlFor="navImageAltText">Custom Navigation Button Image Alt Text</label>
+              <input className="form-control" type="text" id="navImageAltText" defaultValue={navImageAltText} onChange={handleNavImageAltTextChange} />
               <p className="help-block">To customize the alt text for a custom navigation button, enter your text.</p>
             </div>
             <iframe id={id} ref={iframeRef} width="100%" height={iframeHeight} frameBorder={0} />

--- a/src/carousel/components/iframe-runtime.tsx
+++ b/src/carousel/components/iframe-runtime.tsx
@@ -22,10 +22,11 @@ interface IProps {
   scaffoldedQuestionLevel: number;
   report?: boolean;
   navImageUrl?: string;
+  navImageAltText?: string;
 }
 
 export const IframeRuntime: React.FC<IProps> =
-  ({ url, id, authoredState, interactiveState, setInteractiveState, report, scaffoldedQuestionLevel, navImageUrl }) => {
+  ({ url, id, authoredState, interactiveState, setInteractiveState, report, scaffoldedQuestionLevel, navImageUrl, navImageAltText }) => {
   const [ iframeHeight, setIframeHeight ] = useState(300);
   const [ hint, setHint ] = useState("");
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -102,7 +103,7 @@ export const IframeRuntime: React.FC<IProps> =
         phoneRef.current.disconnect();
       }
     };
-  }, [url, authoredState, report, id, scaffoldedQuestionLevel, navImageUrl]);
+  }, [url, authoredState, report, id, scaffoldedQuestionLevel, navImageUrl, navImageAltText]);
 
   return (
     <div>

--- a/src/carousel/components/runtime.tsx
+++ b/src/carousel/components/runtime.tsx
@@ -117,7 +117,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
           );
         })}
       </Carousel>
-      <nav>
+      <nav data-cy="carousel-nav">
         <button className={currentSlide === 0 ? css.disabled + " " + css.prevButton : css.prevButton} onClick={previousSlide}>Prev</button>
         {subinteractives.map(function(interactive, index) {
           let buttonStyle = {};

--- a/src/carousel/components/runtime.tsx
+++ b/src/carousel/components/runtime.tsx
@@ -126,8 +126,9 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
             buttonStyle = { backgroundImage: "url(" + interactive.navImageUrl + ")" };
             buttonClass += " " + css.customButton;
           }
+          const buttonText = interactive.navImageAltText ? interactive.navImageAltText : `Go to slide ${index + 1}`;
           return (
-            <button key={index} className={buttonClass} style={buttonStyle} onClick={() => updateCurrentSlide(index)}>{index}</button>
+            <button key={index} className={buttonClass} style={buttonStyle} title={buttonText} aria-label={buttonText} onClick={() => updateCurrentSlide(index)}>{buttonText}</button>
           );
         })}
         <button className={currentSlide === subinteractives.length - 1 ? css.disabled + " " + css.nextButton : css.nextButton} onClick={nextSlide}>Next</button>

--- a/src/carousel/components/types.ts
+++ b/src/carousel/components/types.ts
@@ -13,6 +13,7 @@ export interface IAuthoredState extends IAuthoringInteractiveMetadata {
     url: string;
     authoredState: any;
     navImageUrl?: string;
+    navImageAltText?: string;
   }[]
 }
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/176575201

[#176575201]

The carousel allows authors to specify images to be used as buttons in the carousel navbar. The images are displayed by making them a background image for the corresponding `button` elements. 

These changes add the option to customize text that appears to screen readers for these buttons, as well as on mouse over of the buttons. The original PT story calls for "alt text" but since the buttons aren't actually images, we add the text as button text and as `title` and `aria-label` attributes.

