### PR TITLE
Allow carousel and scaffolded question authoring to scroll to bottom of subquestion forms.

### DIFF
--- a/src/carousel/components/iframe-authoring.scss
+++ b/src/carousel/components/iframe-authoring.scss
@@ -4,6 +4,10 @@
     border: 1px solid #eee;
     border-radius: 5px;
     overflow: hidden;
+
+    &.open {
+      overflow: auto;
+    }
   }
 
   .iframeContainer {

--- a/src/carousel/components/iframe-authoring.tsx
+++ b/src/carousel/components/iframe-authoring.tsx
@@ -41,6 +41,7 @@ export const IframeAuthoring: React.FC<FieldProps> = props => {
   const { url, authoredState, id, navImageUrl } = formData;
   const [ iframeHeight, setIframeHeight ] = useState(300);
   const [ authoringOpened, setAuthoringOpened ] = useState(false);
+  const interactiveWrapperClass = authoringOpened ? `${css.iframeAuthoring} ${css.open}` : css.iframeAuthoring;
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const phoneRef = useRef<IframePhone>();
   // We need to keep track of the current iframe state and detect cases when update comes from the parent (e.g. when
@@ -107,7 +108,7 @@ export const IframeAuthoring: React.FC<FieldProps> = props => {
       </select>
       {
         url &&
-        <div className={css.iframeAuthoring}>
+        <div className={interactiveWrapperClass}>
           <h4 onClick={handleHeaderClick} className={css.link} data-cy="subquestion-authoring">{authoringOpened ? "▼" : "▶"} Subquestion Authoring</h4>
           <div className={css.iframeContainer} style={{maxHeight: authoringOpened ? iframeHeight : 0 }}>
             <div className={css.navButtonField}>

--- a/src/scaffolded-question/components/iframe-authoring.scss
+++ b/src/scaffolded-question/components/iframe-authoring.scss
@@ -4,6 +4,10 @@
     border: 1px solid #eee;
     border-radius: 5px;
     overflow: hidden;
+
+    &.open {
+      overflow: auto;
+    }
   }
 
   .iframeContainer {

--- a/src/scaffolded-question/components/iframe-authoring.tsx
+++ b/src/scaffolded-question/components/iframe-authoring.tsx
@@ -12,6 +12,7 @@ export const IframeAuthoring: React.FC<FieldProps> = props => {
   const { libraryInteractiveId, authoredState, id } = formData;
   const [ iframeHeight, setIframeHeight ] = useState(300);
   const [ authoringOpened, setAuthoringOpened ] = useState(false);
+  const interactiveWrapperClass = authoringOpened ? `${css.iframeAuthoring} ${css.open}` : css.iframeAuthoring;
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const phoneRef = useRef<IframePhone>();
   // We need to keep track of the current iframe state and detect cases when update comes from the parent (e.g. when
@@ -73,7 +74,7 @@ export const IframeAuthoring: React.FC<FieldProps> = props => {
       </select>
       {
         libraryInteractiveId &&
-        <div className={css.iframeAuthoring}>
+        <div className={interactiveWrapperClass}>
           <h4 onClick={handleHeaderClick} className={css.link} data-cy="subquestion-authoring">{authoringOpened ? "▼" : "▶"} Subquestion authoring</h4>
           <div className={css.iframeContainer} style={{maxHeight: authoringOpened ? iframeHeight : 0 }}>
             <iframe id={id} ref={iframeRef} width="100%" height={iframeHeight} frameBorder={0} />


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/176345663

[#176345663]

These changes fix a bug that in some cases prevented authors from scrolling to the bottom of the subquestion form in carousel and scaffolded questions.