### PR TITLE
Carousel subquestion response issues

### DIFF
--- a/cypress/integration/carousel.test.js
+++ b/cypress/integration/carousel.test.js
@@ -83,7 +83,7 @@ context("Test carousel interactive", () => {
               answerText: "Test subquestion answer"
             }
           },
-          answerText: "[Level: 1] Test subquestion answer"
+          answerText: "Test subquestion answer"
         });
       });
     });
@@ -126,7 +126,6 @@ context("Test carousel interactive", () => {
             target_id: '',
             target_name: '',
             target_value: '',
-            scaffolded_question_level: 1,
             subinteractive_url: "open-response",
             subinteractive_type: "open_response",
             subinteractive_sub_type: undefined,
@@ -142,7 +141,6 @@ context("Test carousel interactive", () => {
             target_id: '',
             target_name: '',
             target_value: 'Test subquestion answer',
-            scaffolded_question_level: 1,
             subinteractive_url: "open-response",
             subinteractive_type: 'open_response',
             subinteractive_sub_type: undefined,

--- a/src/carousel/components/iframe-runtime.tsx
+++ b/src/carousel/components/iframe-runtime.tsx
@@ -19,14 +19,13 @@ interface IProps {
   authoredState: any;
   interactiveState: any;
   setInteractiveState: (state: any) => void;
-  scaffoldedQuestionLevel: number;
   report?: boolean;
   navImageUrl?: string;
   navImageAltText?: string;
 }
 
 export const IframeRuntime: React.FC<IProps> =
-  ({ url, id, authoredState, interactiveState, setInteractiveState, report, scaffoldedQuestionLevel, navImageUrl, navImageAltText }) => {
+  ({ url, id, authoredState, interactiveState, setInteractiveState, report, navImageUrl, navImageAltText }) => {
   const [ iframeHeight, setIframeHeight ] = useState(300);
   const [ hint, setHint ] = useState("");
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -76,7 +75,6 @@ export const IframeRuntime: React.FC<IProps> =
       phone.addListener("log", (logData: ILogRequest) => {
         log(logData.action, {
           ...logData.data,
-          scaffolded_question_level: scaffoldedQuestionLevel,
           subinteractive_url: url,
           subinteractive_type: authoredState.questionType,
           subinteractive_sub_type: authoredState.questionSubType,
@@ -103,7 +101,7 @@ export const IframeRuntime: React.FC<IProps> =
         phoneRef.current.disconnect();
       }
     };
-  }, [url, authoredState, report, id, scaffoldedQuestionLevel, navImageUrl, navImageAltText]);
+  }, [url, authoredState, report, id, navImageUrl, navImageAltText]);
 
   return (
     <div>

--- a/src/carousel/components/runtime.tsx
+++ b/src/carousel/components/runtime.tsx
@@ -58,13 +58,10 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     currentInteractive = subinteractives[0];
   }
 
-  const currentSubintIndex = subinteractives.indexOf(currentInteractive);
-  const currentLevel = levelsCount - currentSubintIndex;
-
   const subStates = interactiveState?.subinteractiveStates;
-
-  const getAnswerText = (level: number, subinteractiveAnswerText: string | undefined) =>
-    `[Level: ${level}] ${subinteractiveAnswerText ? subinteractiveAnswerText : "no response"}`;
+  
+  const getAnswerText = (subinteractiveAnswerText: string | undefined) =>
+    `${subinteractiveAnswerText ? subinteractiveAnswerText : "no response"}`;
 
   const handleNewInteractiveState = (interactiveId: string, newInteractiveState: any) => {
     setInteractiveState?.((prevState: IInteractiveState) => {
@@ -73,7 +70,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
         ...prevState,
         answerType: "interactive_state",
         subinteractiveStates: updatedStates,
-        answerText: getAnswerText(currentLevel, newInteractiveState.answerText)
+        answerText: getAnswerText(newInteractiveState.answerText)
       };
     });
   };
@@ -111,7 +108,6 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
                   authoredState={interactive.authoredState}
                   interactiveState={subState}
                   setInteractiveState={handleNewInteractiveState.bind(null, interactive.id)}
-                  scaffoldedQuestionLevel={currentLevel}
                 />
             </div>
           );

--- a/src/carousel/components/runtime.tsx
+++ b/src/carousel/components/runtime.tsx
@@ -50,13 +50,6 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   if (subinteractives.length === 0) {
     return <div>No sub items available. Please add them using the authoring interface.</div>;
   }
-  const levelsCount = subinteractives.length;
-
-  const currentSubintId = interactiveState?.currentSubinteractiveId;
-  let currentInteractive = subinteractives.find(si => si.id === currentSubintId);
-  if (!currentInteractive) {
-    currentInteractive = subinteractives[0];
-  }
 
   const subStates = interactiveState?.subinteractiveStates;
   

--- a/src/carousel/components/runtime.tsx
+++ b/src/carousel/components/runtime.tsx
@@ -62,7 +62,6 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   const currentLevel = levelsCount - currentSubintIndex;
 
   const subStates = interactiveState?.subinteractiveStates;
-  const subState = subStates && subStates[currentInteractive.id];
 
   const getAnswerText = (level: number, subinteractiveAnswerText: string | undefined) =>
     `[Level: ${level}] ${subinteractiveAnswerText ? subinteractiveAnswerText : "no response"}`;
@@ -100,6 +99,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     <div>
       <Carousel selectedItem={currentSlide} onChange={updateCurrentSlide} showArrows={false} showIndicators={false} showStatus={false} showThumbs={false} autoPlay={false} dynamicHeight={false} transitionTime={300}>
         {subinteractives.map(function(interactive, index) {
+          const subState = subStates && subStates[interactive.id];
           return (
             <div key={index} className={css.runtime}>
               { authoredState.prompt &&


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/176001600

[#176001600]

In some cases, prompts for fill-in-the-blank questions in a carousel were appearing in the response area of other questions in the carousel. These changes set the `subState` value within the iteration through each subinteractive. That ensures the subState is correctly set and then used for each interactive's state.

I believe this change also fixed the bug described here: https://www.pivotaltracker.com/story/show/176013162