### PR TITLE
Question interactives need Activity Player styles

### DIFF
--- a/cypress/integration/multiple-choice.test.js
+++ b/cypress/integration/multiple-choice.test.js
@@ -82,7 +82,7 @@ context("Test multiple-choice interactive", () => {
       });
 
       cy.getIframeBody().find("[data-cy=check-answer-button]").should("be.visible");
-      cy.getIframeBody().find("[data-cy=check-answer-button]").should("include.text", "Check answer");
+      cy.getIframeBody().find("[data-cy=check-answer-button]").should("include.text", "Check Answer");
       cy.getIframeBody().find("[data-cy=check-answer-button]").should("have.attr", "disabled");
     });
 

--- a/src/carousel/components/runtime.scss
+++ b/src/carousel/components/runtime.scss
@@ -2,7 +2,7 @@
 
 .runtime {
   button {
-    @include lara-button;
+    @include ap-button;
     margin: 5px;
     svg {
       // icon

--- a/src/drawing-tool/components/take-snapshot.tsx
+++ b/src/drawing-tool/components/take-snapshot.tsx
@@ -41,8 +41,8 @@ export const TakeSnapshot: React.FC<IProps> = ({ authoredState, interactiveState
     <>
       {
         authoredState.snapshotTarget &&
-        <button className={cssHelpers.laraButton} onClick={handleSnapshot} disabled={snapshotInProgress} data-test="snapshot-btn">
-          <CameraIcon className={cssHelpers.smallIcon} /> { interactiveState?.userBackgroundImageUrl ? "Replace snapshot" : "Take a snapshot" }
+        <button className={cssHelpers.apButton} onClick={handleSnapshot} disabled={snapshotInProgress} data-test="snapshot-btn">
+          <CameraIcon className={cssHelpers.smallIcon} /> { interactiveState?.userBackgroundImageUrl ? "Replace Snapshot" : "Take a Snapshot" }
         </button>
       }
       { snapshotInProgress && <p>Please wait while the snapshot is being taken...</p> }

--- a/src/drawing-tool/components/upload-background.tsx
+++ b/src/drawing-tool/components/upload-background.tsx
@@ -80,8 +80,8 @@ export const UploadBackground: React.FC<IProps> = ({ authoredState, setInteracti
     <>
       {
         !uploadControlsVisible && !uploadInProgress &&
-        <button className={cssHelpers.laraButton} onClick={handleUploadBtnClick} data-test="upload-btn">
-          <UploadIcon className={cssHelpers.smallIcon} /> Upload image
+        <button className={cssHelpers.apButton} onClick={handleUploadBtnClick} data-test="upload-btn">
+          <UploadIcon className={cssHelpers.smallIcon} /> Upload Image
         </button>
       }
       {

--- a/src/image-question/components/runtime.tsx
+++ b/src/image-question/components/runtime.tsx
@@ -139,8 +139,8 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
           }
           {
             !controlsHidden && (renderMakeDrawing || previousAnswerAvailable) &&
-            <button className={cssHelpers.laraButton} onClick={openDrawingToolDialog} data-test="edit-btn">
-              { previousAnswerAvailable ? "Edit" : <span><PencilIcon className={cssHelpers.smallIcon}/> Make drawing</span> }
+            <button className={cssHelpers.apButton} onClick={openDrawingToolDialog} data-test="edit-btn">
+              { previousAnswerAvailable ? "Edit" : <span><PencilIcon className={cssHelpers.smallIcon}/> Make Drawing</span> }
             </button>
           }
         </div>
@@ -171,7 +171,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
       <div className={css.closeDialogSection}>
         { savingAnnotatedImage ?
           <div>Please wait while your drawing is being saved...</div> :
-          <button className={cssHelpers.laraButton} onClick={handleClose} data-test="close-dialog-btn">
+          <button className={cssHelpers.apButton} onClick={handleClose} data-test="close-dialog-btn">
             Close
           </button>
         }

--- a/src/multiple-choice-alerts/components/runtime.tsx
+++ b/src/multiple-choice-alerts/components/runtime.tsx
@@ -168,9 +168,9 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
         </div>
       </fieldset>
       { authoredState.enableCheckAnswer && !readOnly &&
-      <button className={buttonCss.laraButton} onClick={handleShowAnswerFeedback}
+      <button className={buttonCss.apButton} onClick={handleShowAnswerFeedback}
           disabled={!isAnswered} data-cy="check-answer-button">
-        Check answer
+        Check Answer
       </button>
       }
     </div>

--- a/src/multiple-choice/components/runtime.tsx
+++ b/src/multiple-choice/components/runtime.tsx
@@ -237,9 +237,9 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
         showAnswerFeedback && !readOnly && renderFeedback()
       }
       { authoredState.enableCheckAnswer && !readOnly &&
-      <button className={buttonCss.laraButton} onClick={handleShowAnswerFeedback}
+      <button className={buttonCss.apButton} onClick={handleShowAnswerFeedback}
           disabled={!isAnswered} data-cy="check-answer-button">
-        Check answer
+        Check Answer
       </button>
       }
     </div>

--- a/src/scaffolded-question/components/runtime.scss
+++ b/src/scaffolded-question/components/runtime.scss
@@ -2,7 +2,7 @@
 
 .runtime {
   button {
-    @include lara-button;
+    @include ap-button;
     margin: 5px;
     svg {
       // icon

--- a/src/shared/components/base-app.scss
+++ b/src/shared/components/base-app.scss
@@ -1,7 +1,7 @@
 @import "../styles/helpers";
 
 .runtime {
-  @include lara-styles;
+  @include ap-styles;
 
   textarea {
     border: 1px solid #ccc;

--- a/src/shared/components/locked-info.scss
+++ b/src/shared/components/locked-info.scss
@@ -3,13 +3,13 @@
 .locked {
 
   .header {
-    color: #525252;
-    font-weight: lighter;
     background-color: #ededed;
-    width: 100%;
-    padding: 4px;
-    font-size: 14pt;
+    color: #525252;
+    font-size: 16px;
+    font-weight: lighter;
     margin-top: 10px;
+    padding: 5px 10px;
+    width: 100%;
 
     // Icon.
     svg {

--- a/src/shared/components/submit-button.tsx
+++ b/src/shared/components/submit-button.tsx
@@ -24,7 +24,7 @@ export const SubmitButton: React.FC<IProps> = ({ isAnswered }) => {
   };
 
   return (
-    <button className={css.laraButton} onClick={handleSubmit} disabled={!isAnswered} data-cy="lock-answer-button">
+    <button className={css.apButton} onClick={handleSubmit} disabled={!isAnswered} data-cy="lock-answer-button">
       Submit <LockIcon className={css.smallIcon} />
     </button>
   );

--- a/src/shared/styles/helpers.scss
+++ b/src/shared/styles/helpers.scss
@@ -4,6 +4,19 @@ $incorrectColor: #930606;
 $themeColor1: #83cddd;
 $themeColor2: #34a5be;
 
+@mixin ap-styles {
+  // These values should match the Activity Player. In the future, we might extend interactive API so the Activity Player can provide them.
+  font-family: Lato, Arial, Helvetica, sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1.35 !important;
+  padding: 20px 20px 13px;
+
+  input[type=checkbox], input[type=radio] {
+    margin-right: 10px;
+  }
+}
+
 @mixin lara-styles {
   // These values should match LARA. In the future, we might extend interactive API so LARA can provide them.
   padding: 20px 20px 13px;
@@ -13,6 +26,43 @@ $themeColor2: #34a5be;
 
   input[type=checkbox], input[type=radio] {
     margin-right: 10px;
+  }
+}
+
+@mixin ap-button {
+  background-color: #ffa350;
+  border: solid 1.5px #979797;
+  border-radius: 4px;
+  color: #3f3f3f;
+  cursor: pointer;
+  flex-grow: 0;
+  flex-shrink: 0;
+  font: bold 20px Lato, Arial, Helvetica, sans-serif;
+  height: 44px;
+  min-width: 100px;
+  padding: 5px 10px 5px 10px;
+  white-space: nowrap;
+
+  &:hover {
+    background-color: #ff8415;
+  }
+  &:active {
+    color: white;
+
+    // Icon.
+    svg {
+      fill: white;
+    }
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.3;
+  }
+
+  // Icon.
+  svg {
+    fill: #3f3f3f;
   }
 }
 
@@ -60,6 +110,13 @@ $themeColor2: #34a5be;
 .error {
   font-weight: bold;
   color: darkred;
+}
+
+.apButton {
+  @include ap-button;
+  & + & {
+    margin-left: 10px;
+  }
 }
 
 .laraButton {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/176517471

[#176517471]

These changes make question interactives' fonts and button styles match the basic Activity Player specs by default. Previously, question interactives matched the base LARA runtime styles by default. (The LARA style rules are still available as mixins in src/shared/styles/helpers.scss in case we decide to make question interactives support multiple styles).