### PR TITLE
Fix conversion doesn't update runtime for converted sequence activities

### DIFF
--- a/src/convert-old-lara/convert.ts
+++ b/src/convert-old-lara/convert.ts
@@ -256,6 +256,7 @@ const convert = async (laraResource: string, laraRoot: string, libraryInteractiv
     newResourceName = "Activity Player Copy of " + resource.title;
     resource.title = newResourceName;
     resource.activities.forEach((activity: Record<string, any>) => {
+      activity.runtime = "Activity Player";
       activity.pages.forEach((page: Record<string, any>) => {
         updateEmbeddables(page.embeddables, libraryInteractives);
       });


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/177916895

[#177916895]

This change ensures that activities within a sequence that is converted to run in the Activity Player have their runtime set to "Activity Player."