### PR TITLE
Removes image height and width in authoring

### DIFF
--- a/src/drag-and-drop/components/app.tsx
+++ b/src/drag-and-drop/components/app.tsx
@@ -67,14 +67,6 @@ export const baseAuthoringProps = {
               type: "string",
               format: "uri"
             },
-            imageWidth: {
-              title: "Image width",
-              type: "number"
-            },
-            imageHeight: {
-              title:"Image height",
-              type: "number"
-            },
           }
         }
       },


### PR DESCRIPTION
Takes out draggable item image width and height from authoring