### PR TITLE
Drag And Drop: add offset to dropped items

### DIFF
--- a/src/drag-and-drop/components/draggable-item-wrapper.tsx
+++ b/src/drag-and-drop/components/draggable-item-wrapper.tsx
@@ -9,7 +9,6 @@ export interface IProps {
   item: IDraggableItem;
   position: IPosition;
   draggable: boolean;
-  isDropped?: boolean;
 }
 
 // These types are used by react-dnd.
@@ -21,7 +20,7 @@ export interface IDraggableItemWrapper {
 }
 
 // Provides dragging logic and renders basic draggable item.
-export const DraggableItemWrapper: React.FC<IProps> = ({ item, position, draggable, isDropped }) => {
+export const DraggableItemWrapper: React.FC<IProps> = ({ item, position, draggable }) => {
   const [{ isDragging }, drag] = useDrag<IDraggableItemWrapper, any, any>({
     item: {type: "draggable-item-wrapper", item, position},
     collect: (monitor: DragSourceMonitor) => ({
@@ -31,18 +30,18 @@ export const DraggableItemWrapper: React.FC<IProps> = ({ item, position, draggab
 
   return (
     <>
-    { isDragging
-      ? <DraggableItemPreview />
-      : <div
-          ref={draggable ? drag : undefined}
-          className={`${css.draggableItemWrapper} ${draggable ? css.draggable : ""}`}
-          style={isDropped ? undefined : position}
-          data-cy="draggable-item-wrapper"
-        >
-          <DraggableItem item={item} />
-          <div className={css.itemLabel}>{item.label}</div>
-        </div>
-    }
+      { isDragging
+        ? <DraggableItemPreview />
+        : <div
+            ref={draggable ? drag : undefined}
+            className={`${css.draggableItemWrapper} ${draggable ? css.draggable : ""}`}
+            style={position}
+            data-cy="draggable-item-wrapper"
+          >
+            <DraggableItem item={item} />
+            <div className={css.itemLabel}>{item.label}</div>
+          </div>
+      }
     </>
   );
 };

--- a/src/drag-and-drop/components/drop-zone-wrapper.scss
+++ b/src/drag-and-drop/components/drop-zone-wrapper.scss
@@ -4,7 +4,6 @@
   box-sizing: border-box;
   border: $border-width dotted white;
   display: flex;
-  justify-content: center;
   flex-wrap: wrap;
   &.draggable {
     cursor: move;
@@ -33,6 +32,9 @@
   }
   .targetLabel {
     position: absolute;
+    display: flex;
+    width: 100%;
     bottom: -25px;
+    justify-content: center;
   }
 }

--- a/src/drag-and-drop/components/drop-zone-wrapper.tsx
+++ b/src/drag-and-drop/components/drop-zone-wrapper.tsx
@@ -7,6 +7,8 @@ import { DropZonePreview } from "./drop-zone-preview";
 import { DraggableItemWrapper, DraggableItemWrapperType, IDraggableItemWrapper } from "./draggable-item-wrapper";
 import css from "./drop-zone-wrapper.scss";
 
+const kDropOffset = 30;
+
 export interface IProps {
   target: IDropZone;
   position: IPosition;
@@ -58,9 +60,13 @@ export const DropZoneWrapper: React.FC<IProps> = ({ target, position, draggable,
             style={zoneStyle}
             data-cy="draggable-item-wrapper"
           >
-            { itemsInTarget.map((item: any, idx: number) => {
-                return <DraggableItemWrapper key={idx} item={item.droppedItem} position={position} draggable={false} isDropped={true}/>;
-              })
+            { itemsInTarget.map((item: any, idx: number) =>
+                <DraggableItemWrapper
+                  key={`draggable-item-${idx}`}
+                  item={item.droppedItem}
+                  position={{ top: kDropOffset * idx, left: kDropOffset * idx }}
+                  draggable={false}
+                />)
             }
             <DropZone target={target} highlight={highlight} />
             <div className={css.targetLabel}>{target.targetLabel}</div>


### PR DESCRIPTION
This PR adds an offset to draggable items when displayed in a drop target so that they do not overlap each other with the exact same position.  

![add-drop-offset](https://user-images.githubusercontent.com/5126913/121985753-39725400-cd4a-11eb-82a7-8331a293aaab.gif)
