### PR TITLE
Send data to graph

### DIFF
--- a/cypress/integration/graph.test.js
+++ b/cypress/integration/graph.test.js
@@ -175,7 +175,7 @@ context("Test graph interactive", () => {
           });
         });
       });
-
+      cy.wait(1000);
       cy.getIframeBody().find("select#root_dataSourceInteractive1").select("testInt4 (Test Interactive 4)");
       getAndClearLastPhoneMessage(state => {
         expect(state.version).eql(1);

--- a/cypress/integration/graph.test.js
+++ b/cypress/integration/graph.test.js
@@ -175,7 +175,6 @@ context("Test graph interactive", () => {
           });
         });
       });
-      cy.wait(1000);
       cy.getIframeBody().find("select#root_dataSourceInteractive1").select("testInt4 (Test Interactive 4)");
       getAndClearLastPhoneMessage(state => {
         expect(state.version).eql(1);

--- a/src/drag-and-drop/components/container.tsx
+++ b/src/drag-and-drop/components/container.tsx
@@ -6,6 +6,7 @@ import { useDrop } from "react-dnd";
 import { DraggableItemWrapper, DraggableItemWrapperType, IDraggableItemWrapper } from "./draggable-item-wrapper";
 import { DropZoneWrapper, DropZoneWrapperType, IDropZoneWrapper } from "./drop-zone-wrapper";
 import css from "./container.scss";
+import { generateDataset } from "../utils/generate-dataset";
 
 export interface IProps extends IRuntimeQuestionComponentProps<IAuthoredState, IInteractiveState> {
   // Used only for authoring (initial state is part of the authored state).
@@ -133,9 +134,11 @@ export const Container: React.FC<IProps> = ({ authoredState, interactiveState, s
           ...prevState?.droppedItemData,
           [droppedItem.id]: targetDroppedItem
         },
+        dataset: generateDataset(targetData, draggableItem)
       }));
     }
   }, [setInteractiveState]);
+
   const [, drop] = useDrop({
     accept: [DraggableItemWrapperType, DropZoneWrapperType],
     drop(wrapper: IDraggableItemWrapper | IDropZoneWrapper, monitor) {

--- a/src/drag-and-drop/components/container.tsx
+++ b/src/drag-and-drop/components/container.tsx
@@ -116,7 +116,6 @@ export const Container: React.FC<IProps> = ({ authoredState, interactiveState, s
           ...prevState?.itemPositions,
           [id]: {left, top}
         },
-
       }));
     }
   }, [authoredState.initialState?.itemPositions, authoredState.initialState?.targetPositions, setInitialState, setInteractiveState]);
@@ -125,19 +124,30 @@ export const Container: React.FC<IProps> = ({ authoredState, interactiveState, s
     const droppedItem = draggableItem.item;
     const targetId = targetData.id;
     const targetDroppedItem = {targetId, droppedItem};
+    const targets = authoredState.dropZones || [];
+    const targetLabel = targetData.targetLabel || "Bin";
+
     if (setInteractiveState) {
       // Runtime mode.
-      setInteractiveState(prevState => ({
-        ...prevState,
-        answerType: "interactive_state",
-        droppedItemData: {
-          ...prevState?.droppedItemData,
-          [droppedItem.id]: targetDroppedItem
-        },
-        dataset: generateDataset(targetData, draggableItem)
-      }));
+      setInteractiveState(prevState => {
+        const newTargetAggregateValues = {
+          ...prevState?.targetAggregateValues,
+          [targetLabel]: (prevState?.targetAggregateValues?.[targetLabel] || 0) + droppedItem.value
+        };
+
+        return {
+          ...prevState,
+          answerType: "interactive_state",
+          droppedItemData: {
+            ...prevState?.droppedItemData,
+            [droppedItem.id]: targetDroppedItem
+          },
+          targetAggregateValues: newTargetAggregateValues,
+          dataset: generateDataset(targets, newTargetAggregateValues)
+        };
+      });
     }
-  }, [setInteractiveState]);
+  }, [authoredState.dropZones, setInteractiveState]);
 
   const [, drop] = useDrop({
     accept: [DraggableItemWrapperType, DropZoneWrapperType],

--- a/src/drag-and-drop/components/types.ts
+++ b/src/drag-and-drop/components/types.ts
@@ -18,7 +18,6 @@ export interface IPosition {
 export interface IInitialState {
   itemPositions?: Record<ItemId, IPosition>;
   targetPositions?: Record<TargetId, IPosition>;
-  itemTargetIds?: Record<ItemId, TargetId>;
 }
 
 export type TargetId = string;
@@ -54,4 +53,5 @@ export interface IInteractiveState extends IRuntimeInteractiveMetadata {
   submitted?: boolean;
   itemPositions?: Record<ItemId, IPosition>;
   droppedItemData?: Record<ItemId, IDroppedItem>;
+  targetAggregateValue?: Record<TargetId, number>;
 }

--- a/src/drag-and-drop/components/types.ts
+++ b/src/drag-and-drop/components/types.ts
@@ -53,5 +53,5 @@ export interface IInteractiveState extends IRuntimeInteractiveMetadata {
   submitted?: boolean;
   itemPositions?: Record<ItemId, IPosition>;
   droppedItemData?: Record<ItemId, IDroppedItem>;
-  targetAggregateValue?: Record<TargetId, number>;
+  targetAggregateValues?: Record<TargetId, number>;
 }

--- a/src/drag-and-drop/utils/generate-dataset.ts
+++ b/src/drag-and-drop/utils/generate-dataset.ts
@@ -12,10 +12,10 @@ export const generateDataset = ( targets: IDropZone[], targetValues?: Record<Tar
   return {
     type: "dataset",
     version: 1,
-    properties: ["body of water", "area"],
+    properties: ["x", "y"],
     // Always use first property as X axis. It might be necessary to customize that in the future, but it doesn't
     // seem useful now.
-    xAxisProp: "body of water",
+    xAxisProp: "x",
     rows: rows
   };
 };

--- a/src/drag-and-drop/utils/generate-dataset.ts
+++ b/src/drag-and-drop/utils/generate-dataset.ts
@@ -1,10 +1,14 @@
 import { IDataset } from "@concord-consortium/lara-interactive-api";
-import { IDraggableItemWrapper } from "../components/draggable-item-wrapper";
-import { IDropZone } from "../components/types";
+import { IDropZone, TargetId } from "../components/types";
 
-export const generateDataset = (target: IDropZone, draggableItem: IDraggableItemWrapper): IDataset | null => {
-  const value = draggableItem.item.value;
-  const label = target.targetLabel || "Bin 1";
+export const generateDataset = ( targets: IDropZone[], targetValues?: Record<TargetId, number>): IDataset | null => {
+
+  const rows = targets.map( target => {
+    const label = target.targetLabel || "Bin";
+    const value = targetValues ? targetValues[label] : 0;
+    return [label, value];
+  });
+
   return {
     type: "dataset",
     version: 1,
@@ -12,6 +16,6 @@ export const generateDataset = (target: IDropZone, draggableItem: IDraggableItem
     // Always use first property as X axis. It might be necessary to customize that in the future, but it doesn't
     // seem useful now.
     xAxisProp: "body of water",
-    rows: [[label,value]]
+    rows: rows
   };
 };

--- a/src/drag-and-drop/utils/generate-dataset.ts
+++ b/src/drag-and-drop/utils/generate-dataset.ts
@@ -8,7 +8,7 @@ export const generateDataset = ( targets: IDropZone[], targetValues?: Record<Tar
     const value = targetValues ? targetValues[label] : 0;
     return [label, value];
   });
-
+  console.log(rows);
   return {
     type: "dataset",
     version: 1,

--- a/src/drag-and-drop/utils/generate-dataset.ts
+++ b/src/drag-and-drop/utils/generate-dataset.ts
@@ -1,0 +1,17 @@
+import { IDataset } from "@concord-consortium/lara-interactive-api";
+import { IDraggableItemWrapper } from "../components/draggable-item-wrapper";
+import { IDropZone } from "../components/types";
+
+export const generateDataset = (target: IDropZone, draggableItem: IDraggableItemWrapper): IDataset | null => {
+  const value = draggableItem.item.value;
+  const label = target.targetLabel || "Bin 1";
+  return {
+    type: "dataset",
+    version: 1,
+    properties: ["body of water", "area"],
+    // Always use first property as X axis. It might be necessary to customize that in the future, but it doesn't
+    // seem useful now.
+    xAxisProp: "body of water",
+    rows: [[label,value]]
+  };
+};


### PR DESCRIPTION
Currently only shows the sum of the values dropped onto a target.
Graph only comes up once a draggable item has been dropped.
We tried to get it to pre-load with a useEffect but it didn't work unless we put the setInteractiveState in s setTimeOut > 1000.