### PR TITLE
Drag and Drop question: allow drag and drop from drop containers

### DIFF
--- a/src/drag-and-drop/components/draggable-item-preview.scss
+++ b/src/drag-and-drop/components/draggable-item-preview.scss
@@ -5,6 +5,7 @@ $border-width: 4px;
   border: $border-width solid #ecb314;
   box-shadow: 0 0 12px rgba(0,0,0,0.25);
   transform: translate(-$border-width, -$border-width);
+  z-index: 99;
   .itemLabel {
     position: absolute;
     bottom: -25px;

--- a/src/drag-and-drop/components/drop-zone-wrapper.tsx
+++ b/src/drag-and-drop/components/drop-zone-wrapper.tsx
@@ -14,7 +14,7 @@ export interface IProps {
   position: IPosition;
   draggable: boolean;
   itemsInTarget: IDroppedItem[];
-  onItemDrop: (targetData: IDropZone, draggableItem: IDraggableItemWrapper) => void
+  onItemDrop: (targetData: IDropZone, targetPosition: IPosition, draggableItem: IDraggableItemWrapper) => void
 }
 
 // These types are used by react-dnd.
@@ -38,7 +38,7 @@ export const DropZoneWrapper: React.FC<IProps> = ({ target, position, draggable,
   const [{ isOver, canDrop, getItem }, drop] = useDrop({
     accept: DraggableItemWrapperType,
     drop: (droppedItem: any) => {
-      onItemDrop(target, getItem);
+      onItemDrop(target, position, getItem);
     },
     collect: (monitor: DropTargetMonitor) => ({
       isOver: monitor.isOver(),
@@ -52,24 +52,24 @@ export const DropZoneWrapper: React.FC<IProps> = ({ target, position, draggable,
   const highlightClassName = highlight ? css.highlight : "";
   const draggableClassName = draggable ? css.draggable : "";
   return (
-      isDragging
-        ? <DropZonePreview />
-        : <div
-            ref={draggable ? drag : drop}
-            className={`${css.dropZoneWrapper} ${css.background} ${draggableClassName}  ${highlightClassName}`}
-            style={zoneStyle}
-            data-cy="draggable-item-wrapper"
-          >
-            { itemsInTarget.map((item: any, idx: number) =>
-                <DraggableItemWrapper
-                  key={`draggable-item-${idx}`}
-                  item={item.droppedItem}
-                  position={{ top: kDropOffset * idx, left: kDropOffset * idx }}
-                  draggable={false}
-                />)
-            }
-            <DropZone target={target} highlight={highlight} />
-            <div className={css.targetLabel}>{target.targetLabel}</div>
-          </div>
+    isDragging
+    ? <DropZonePreview />
+    : <div
+        ref={draggable ? drag : drop}
+        className={`${css.dropZoneWrapper} ${css.background} ${draggableClassName}  ${highlightClassName}`}
+        style={zoneStyle}
+        data-cy="draggable-item-wrapper"
+      >
+        { itemsInTarget.map((item: any, idx: number) =>
+            <DraggableItemWrapper
+              key={`draggable-item-${idx}`}
+              item={item.droppedItem}
+              position={{ top: kDropOffset * idx, left: kDropOffset * idx }}
+              draggable={true}
+            />)
+        }
+        <DropZone target={target} highlight={highlight} />
+        <div className={css.targetLabel}>{target.targetLabel}</div>
+      </div>
   );
 };

--- a/src/drag-and-drop/components/types.ts
+++ b/src/drag-and-drop/components/types.ts
@@ -47,6 +47,7 @@ export interface IAuthoredState extends IAuthoringInteractiveMetadata {
 
 export interface IDroppedItem {
   targetId: string;
+  targetPosition: IPosition;
   droppedItem: IDraggableItem;
 }
 


### PR DESCRIPTION
This PR improves the drag and drop question so that a draggable item can be moved from one drop container to another and so a draggable item can be moved from a drop container back to the main canvas.  The implementation required storing the drop container position when the initial drop occurs.  This is required because our move code calculates the new position using a delta added to the current position.  Since the current position of an item in the drop containers is relative to the drop container, we need the drop container's position as well.  If we change the positioning or layout of items in the drop container in the future, this solution may also need to be updated.

![better-drag-n-drop](https://user-images.githubusercontent.com/5126913/122156869-b5d66700-ce1e-11eb-843a-1e4782241950.gif)
