### PR TITLE
Drag and drop: refactor dataset and interactive state handling

### DIFF
--- a/src/drag-and-drop/components/types.ts
+++ b/src/drag-and-drop/components/types.ts
@@ -1,4 +1,4 @@
-import { IAuthoringInteractiveMetadata, IRuntimeInteractiveMetadata } from "@concord-consortium/lara-interactive-api";
+import { IAuthoringInteractiveMetadata, IDataset, IRuntimeInteractiveMetadata } from "@concord-consortium/lara-interactive-api";
 
 export type ItemId = string;
 
@@ -54,5 +54,5 @@ export interface IInteractiveState extends IRuntimeInteractiveMetadata {
   submitted?: boolean;
   itemPositions?: Record<ItemId, IPosition>;
   droppedItemData?: Record<ItemId, IDroppedItem>;
-  targetAggregateValues?: Record<TargetId, number>;
+  dataset?: IDataset;
 }

--- a/src/drag-and-drop/utils/generate-dataset.ts
+++ b/src/drag-and-drop/utils/generate-dataset.ts
@@ -1,21 +1,26 @@
 import { IDataset } from "@concord-consortium/lara-interactive-api";
-import { IDropZone, TargetId } from "../components/types";
+import { IDroppedItem, IDropZone, ItemId } from "../components/types";
 
-export const generateDataset = ( targets: IDropZone[], targetValues?: Record<TargetId, number>): IDataset | null => {
-
-  const rows = targets.map( target => {
-    const label = target.targetLabel || "Bin";
-    const value = targetValues ? targetValues[label] : 0;
+export const generateDataset = (targets?: IDropZone[], droppedItemsData?: Record<ItemId, IDroppedItem>): IDataset => {
+  const rows = targets?.map((target, idx) => {
+    const label = target.targetLabel || `Bin ${idx + 1}`;
+    let value = 0;
+    Object.values(droppedItemsData || {}).forEach(droppedItemData => {
+      if (target.id === droppedItemData.targetId) {
+        // In the future summing can be replaced with other function types.
+        value += droppedItemData.droppedItem.value;
+      }
+    });
     return [label, value];
   });
-  console.log(rows);
+
   return {
     type: "dataset",
     version: 1,
-    properties: ["x", "y"],
+    properties: ["Bin label", "Value"],
     // Always use first property as X axis. It might be necessary to customize that in the future, but it doesn't
     // seem useful now.
-    xAxisProp: "x",
-    rows: rows
+    xAxisProp: "Bin label",
+    rows: rows || [[]]
   };
 };


### PR DESCRIPTION
This PR refactors DnD interactive state.
I've removed `targetAggregateValue` as it was redundant (see my comments here: https://github.com/concord-consortium/question-interactives/pull/105). `dataset` is now automatically calculated on each update of dependant variable (`authoredState.dropZones`, `droppedItemData` only), so it should be more reliable. Also, it automatically adds support of removing items from dropzones that was recently added by @mklewandowski.

There are two issues that are probably not related to drag and drop interactive. I've tried to add comments that explain that as clear as possible. I've tried to debug them, but it seems it can be a bigger task:
- https://www.pivotaltracker.com/story/show/178556017
- https://www.pivotaltracker.com/story/show/178556075