### PR TITLE
Added image uploading in authoring mode [#178284894]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ npm-error.log
 .DS_Store
 .yalc
 yalc.lock
+/temp
 
 # Editors
 .idea

--- a/cypress/integration/image.test.js
+++ b/cypress/integration/image.test.js
@@ -59,9 +59,21 @@ context("Test Image interactive", () => {
 
   context("Authoring view", () => {
     it("handles pre-existing authored state", () => {
+
+      // fake token-service JWT so that image upload control is displayed above url
+      phoneListen("getFirebaseJWT", (data, phone) => {
+        phone.post("firebaseJWT", {
+          requestId: 1,
+          token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        });
+      });
+
       phonePost("initInteractive", {
         mode: "authoring",
-        authoredState: authoredStateSample
+        authoredState: authoredStateSample,
+        hostFeatures: {
+          getFirebaseJwt: {version: "1.0.0"}
+        }
       });
 
       const app = cy.getIframeBody().find("#app");
@@ -74,6 +86,7 @@ context("Test Image interactive", () => {
       app.should("include.text", "Credit Link Display Text");
       app.should("include.text", "Allow lightbox");
       app.should("include.text", "Choose a scaling style for the image");
+      app.should("include.text", "Drop an image here, or click to select a file to upload. Only popular image formats are supported (e.g. png, jpeg, gif, svg, webp).");
 
       cy.getIframeBody().find("#root_url").should("have.value", authoredStateSample.url);
       cy.getIframeBody().find("#root_highResUrl").should("have.value", authoredStateSample.highResUrl);

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -38,7 +38,7 @@ export const phonePost = (type, message) => {
   );
 };
 
-export const phoneListen = (type) => {
+export const phoneListen = (type, callback) => {
   useIframePhone(phone => {
     cy.window().then(window => {
       phone.addListener(type, newState => {
@@ -47,6 +47,10 @@ export const phoneListen = (type) => {
           window.receivedMessages = [];
         }
         window.receivedMessages.push(newState);
+
+        if (callback) {
+          callback(newState, phone);
+        }
       });
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2517,9 +2517,9 @@
       }
     },
     "@concord-consortium/lara-interactive-api": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.0.2.tgz",
-      "integrity": "sha512-CqmDUL77rHTiTa5gWshJQgXHzHFasRzEHOT1+kkgU7zPIWu8IUivdCK0lyYfxyNuguES5eDr9LJAWdI86xEp8g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.1.0.tgz",
+      "integrity": "sha512-skNR306/b7ScP6+7SfSmjeTMgtRFetMsnutnFj4imvwUIpKc3yFVMxRXIreGwP5jeCUK0c+Utvy99/foa7Mynw==",
       "requires": {
         "iframe-phone": "^1.3.1"
       }
@@ -2598,9 +2598,9 @@
       }
     },
     "@concord-consortium/token-service": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/token-service/-/token-service-1.2.0.tgz",
-      "integrity": "sha512-zQVl83djUtm6RFl6n7EAnZKrvsbtrRYtLeZQgcBZrMZL0ZZj6G3sV3W77uuh/VS1iJOGfeT8/7jiRdSRxuLE1Q=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/token-service/-/token-service-2.0.0.tgz",
+      "integrity": "sha512-S85e8ZMtgazhzW7pFHDUbeG9hMUkDJqbxcGOS4jKbYMG1HfnVYqvCpxUr8xywTXwYpep8Wo+KTqnwKbiWIFPZQ=="
     },
     "@cypress/listr-verbose-renderer": {
       "version": "0.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,1309 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@aws-crypto/crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-1.0.0.tgz",
+      "integrity": "sha512-wr4EyCv3ZfLH3Sg7FErV6e/cLhpk9rUP/l5322y8PRgpQsItdieaLbtE4aDOR+dxl8U7BG9FIwWXH4TleTDZ9A==",
+      "requires": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/ie11-detection": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
+      "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
+      "requires": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.1.0.tgz",
+      "integrity": "sha512-VIpuLRDonMAHgomrsm/zKbeXTnxpr4aHDQmS4pF+NcpvBp64l675yjGA9hyUYs/QJwBjUl8WqMjh9tIRgi85Sg==",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.1.0",
+        "@aws-crypto/supports-web-crypto": "^1.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
+      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "requires": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
+      "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
+      "requires": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.18.0.tgz",
+      "integrity": "sha512-AxDm2QLq2Z+PjzMESB+lPD5XL73MzC4CtUAajPn09ocWj7p9poVN0dd8NVFhBDfQMVPWTQaQBZk7h5TDvZrsBg==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/chunked-blob-reader": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.18.0.tgz",
+      "integrity": "sha512-Xl4Dw67OgYEEqmPvcjcC4vvnZ7esAFKW32WRxhccfR0cqRhsM1RsDFHPfD8o5wJRiB3amc4Ui8ZbYBUy8a/2Fw==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/chunked-blob-reader-native": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.18.0.tgz",
+      "integrity": "sha512-1ogm6vVt8qtRUOzExURHVspDPaLCOtahD5edsJeqPWUPNv5tGGaRi5LyZcXUTGky34Z4cVoy69FwxUBpkaJ6SA==",
+      "requires": {
+        "@aws-sdk/util-base64-browser": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/client-s3": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.19.0.tgz",
+      "integrity": "sha512-in342ONWtXUNsh2H7Pe8jnB8ebEKQZTGQgCM5/V6Ue+f6wzgBqmb8blPMoFw+uFPJnxPfMugz6FvJzaOsB/sxA==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/client-sts": "3.19.0",
+        "@aws-sdk/config-resolver": "3.19.0",
+        "@aws-sdk/credential-provider-node": "3.19.0",
+        "@aws-sdk/eventstream-serde-browser": "3.18.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.18.0",
+        "@aws-sdk/eventstream-serde-node": "3.18.0",
+        "@aws-sdk/fetch-http-handler": "3.18.0",
+        "@aws-sdk/hash-blob-browser": "3.18.0",
+        "@aws-sdk/hash-node": "3.18.0",
+        "@aws-sdk/hash-stream-node": "3.18.0",
+        "@aws-sdk/invalid-dependency": "3.18.0",
+        "@aws-sdk/md5-js": "3.18.0",
+        "@aws-sdk/middleware-apply-body-checksum": "3.18.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.19.0",
+        "@aws-sdk/middleware-content-length": "3.18.0",
+        "@aws-sdk/middleware-expect-continue": "3.18.0",
+        "@aws-sdk/middleware-host-header": "3.18.0",
+        "@aws-sdk/middleware-location-constraint": "3.18.0",
+        "@aws-sdk/middleware-logger": "3.18.0",
+        "@aws-sdk/middleware-retry": "3.19.0",
+        "@aws-sdk/middleware-sdk-s3": "3.18.0",
+        "@aws-sdk/middleware-serde": "3.18.0",
+        "@aws-sdk/middleware-signing": "3.19.0",
+        "@aws-sdk/middleware-ssec": "3.18.0",
+        "@aws-sdk/middleware-stack": "3.18.0",
+        "@aws-sdk/middleware-user-agent": "3.18.0",
+        "@aws-sdk/node-config-provider": "3.19.0",
+        "@aws-sdk/node-http-handler": "3.18.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/smithy-client": "3.19.0",
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/url-parser": "3.18.0",
+        "@aws-sdk/util-base64-browser": "3.18.0",
+        "@aws-sdk/util-base64-node": "3.18.0",
+        "@aws-sdk/util-body-length-browser": "3.18.0",
+        "@aws-sdk/util-body-length-node": "3.18.0",
+        "@aws-sdk/util-user-agent-browser": "3.18.0",
+        "@aws-sdk/util-user-agent-node": "3.19.0",
+        "@aws-sdk/util-utf8-browser": "3.18.0",
+        "@aws-sdk/util-utf8-node": "3.18.0",
+        "@aws-sdk/util-waiter": "3.18.0",
+        "@aws-sdk/xml-builder": "3.18.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+        },
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.19.0.tgz",
+      "integrity": "sha512-u1aRHx0HNpO2JdPlcsKHbmI5D0aJM5ryso2rWJEMPfW1qKGRc4BY/QDuD03nXkHIBXX+okkkqAhZyR8HZzZsXQ==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.19.0",
+        "@aws-sdk/fetch-http-handler": "3.18.0",
+        "@aws-sdk/hash-node": "3.18.0",
+        "@aws-sdk/invalid-dependency": "3.18.0",
+        "@aws-sdk/middleware-content-length": "3.18.0",
+        "@aws-sdk/middleware-host-header": "3.18.0",
+        "@aws-sdk/middleware-logger": "3.18.0",
+        "@aws-sdk/middleware-retry": "3.19.0",
+        "@aws-sdk/middleware-serde": "3.18.0",
+        "@aws-sdk/middleware-stack": "3.18.0",
+        "@aws-sdk/middleware-user-agent": "3.18.0",
+        "@aws-sdk/node-config-provider": "3.19.0",
+        "@aws-sdk/node-http-handler": "3.18.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/smithy-client": "3.19.0",
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/url-parser": "3.18.0",
+        "@aws-sdk/util-base64-browser": "3.18.0",
+        "@aws-sdk/util-base64-node": "3.18.0",
+        "@aws-sdk/util-body-length-browser": "3.18.0",
+        "@aws-sdk/util-body-length-node": "3.18.0",
+        "@aws-sdk/util-user-agent-browser": "3.18.0",
+        "@aws-sdk/util-user-agent-node": "3.19.0",
+        "@aws-sdk/util-utf8-browser": "3.18.0",
+        "@aws-sdk/util-utf8-node": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.19.0.tgz",
+      "integrity": "sha512-hp8Cpua29NeECn5fzUec8OLWnJf/VvLURIYUcaHBcP5qXMeAG+0LGbHa2acZ+dKAh3XPwS+CClJU4ZWwLsgiSw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.19.0",
+        "@aws-sdk/credential-provider-node": "3.19.0",
+        "@aws-sdk/fetch-http-handler": "3.18.0",
+        "@aws-sdk/hash-node": "3.18.0",
+        "@aws-sdk/invalid-dependency": "3.18.0",
+        "@aws-sdk/middleware-content-length": "3.18.0",
+        "@aws-sdk/middleware-host-header": "3.18.0",
+        "@aws-sdk/middleware-logger": "3.18.0",
+        "@aws-sdk/middleware-retry": "3.19.0",
+        "@aws-sdk/middleware-sdk-sts": "3.19.0",
+        "@aws-sdk/middleware-serde": "3.18.0",
+        "@aws-sdk/middleware-signing": "3.19.0",
+        "@aws-sdk/middleware-stack": "3.18.0",
+        "@aws-sdk/middleware-user-agent": "3.18.0",
+        "@aws-sdk/node-config-provider": "3.19.0",
+        "@aws-sdk/node-http-handler": "3.18.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/smithy-client": "3.19.0",
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/url-parser": "3.18.0",
+        "@aws-sdk/util-base64-browser": "3.18.0",
+        "@aws-sdk/util-base64-node": "3.18.0",
+        "@aws-sdk/util-body-length-browser": "3.18.0",
+        "@aws-sdk/util-body-length-node": "3.18.0",
+        "@aws-sdk/util-user-agent-browser": "3.18.0",
+        "@aws-sdk/util-user-agent-node": "3.19.0",
+        "@aws-sdk/util-utf8-browser": "3.18.0",
+        "@aws-sdk/util-utf8-node": "3.18.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+        },
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.19.0.tgz",
+      "integrity": "sha512-ErB8H6iUkpw5301vIUt+I85AYBKHLLZIZFKsV8L+3z4Nnd5heQF1hV5qpaRqICUZvbDeo7ObfUCIbBiPH9dSWg==",
+      "requires": {
+        "@aws-sdk/signature-v4": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.19.0.tgz",
+      "integrity": "sha512-ujE+Y1/SIGSN/JA1Ze/a1/qXREAWI3Xut3LQ8hKFpRE0hsQVn8HuyFlD9bQ0v7dvUmx6V66eJdksDFW9innqqQ==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.19.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.19.0.tgz",
+      "integrity": "sha512-z8TXzzQjqzcMAHdcyGwJPpbt2cvXMWygPB5ZImA/IDnT6zMdXWTLTzHtkBpZG6Dulo2DBe1hCnY+Bb7IZqoKNQ==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.19.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.19.0.tgz",
+      "integrity": "sha512-FMeHZyDB1GmQB/cbkaJIrlGKjiZyMjURdiEpTaDhtIzcQfbRxLotes067DcAtbHuu2BnX7IFIbLws3juNJANiQ==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.19.0",
+        "@aws-sdk/credential-provider-imds": "3.19.0",
+        "@aws-sdk/credential-provider-web-identity": "3.19.0",
+        "@aws-sdk/property-provider": "3.19.0",
+        "@aws-sdk/shared-ini-file-loader": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.19.0.tgz",
+      "integrity": "sha512-G7VsQ/BUhhSMSdbD2hODCnwnJtcAg/S/5fbfrn3jPGPDdA0o8AsI5jVht+7ablv6mbCpyOktSPXSCQKeXokh5Q==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.19.0",
+        "@aws-sdk/credential-provider-imds": "3.19.0",
+        "@aws-sdk/credential-provider-ini": "3.19.0",
+        "@aws-sdk/credential-provider-process": "3.19.0",
+        "@aws-sdk/credential-provider-sso": "3.19.0",
+        "@aws-sdk/credential-provider-web-identity": "3.19.0",
+        "@aws-sdk/property-provider": "3.19.0",
+        "@aws-sdk/shared-ini-file-loader": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.19.0.tgz",
+      "integrity": "sha512-ZwrBY4u8n2Wv+TQ3QgNa3b1R3TCp30tQ7WSrHqniUwxE7LgBKbhoDuLEYA/zQ54WB/QdeJB6bliYBL681ENAFw==",
+      "requires": {
+        "@aws-sdk/credential-provider-ini": "3.19.0",
+        "@aws-sdk/property-provider": "3.19.0",
+        "@aws-sdk/shared-ini-file-loader": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.19.0.tgz",
+      "integrity": "sha512-MCfNPGyMmalFkIGC9VUXnP8y0TMa476N8fObhNhrx9EUXmv6GjAn7Pf/dOM5R+SRAHVZ6ivrwMVyi6dF1eIyUg==",
+      "requires": {
+        "@aws-sdk/client-sso": "3.19.0",
+        "@aws-sdk/credential-provider-ini": "3.19.0",
+        "@aws-sdk/property-provider": "3.19.0",
+        "@aws-sdk/shared-ini-file-loader": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.19.0.tgz",
+      "integrity": "sha512-dLOezn47d3usRD4oPmATigjIu3q5q950F4Li64euUMZGcJOYZEZIlriQUHPfIMmC3RweVpbhN+eSO8ypNO3+IQ==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.19.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/eventstream-marshaller": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.18.0.tgz",
+      "integrity": "sha512-DbvQfpBHolEanxjaJ3uJdfTdZdyE7Js7v2fvvYT/r59/zNYNNwUtjdciL25Dg2H4OfJtMp10r2neB23U5IKLVQ==",
+      "requires": {
+        "@aws-crypto/crc32": "^1.0.0",
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/util-hex-encoding": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/eventstream-serde-browser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.18.0.tgz",
+      "integrity": "sha512-RDaRPyfXnabcLlci/PZAY7rqd7x2408kLiRNzpj824+yVgnjRlKG45YYkYggxZo2F4ZKVeU2rJE9zhxP9XT6AA==",
+      "requires": {
+        "@aws-sdk/eventstream-marshaller": "3.18.0",
+        "@aws-sdk/eventstream-serde-universal": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/eventstream-serde-config-resolver": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.18.0.tgz",
+      "integrity": "sha512-CDPwXQUiQbzFqGnn2QQSloRLZ6KogbGPqcAxVADdHiFw8+UdA+bjBbfQmmv0tTWvasrvPOLomHw42DZ1v+DvEw==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/eventstream-serde-node": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.18.0.tgz",
+      "integrity": "sha512-EPg7QUxIAVHO5Zmp+9D8KYV3gcPvsz1v6nmw3ZFOGStgJM37j6KYbu84gFPradkEgTzE+bxb3OgB/mMC2j3XSg==",
+      "requires": {
+        "@aws-sdk/eventstream-marshaller": "3.18.0",
+        "@aws-sdk/eventstream-serde-universal": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/eventstream-serde-universal": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.18.0.tgz",
+      "integrity": "sha512-pqQEFY4U16oV25vXAfaDnnTSe78ZDaqAEkVZxSt1gyfLBjin9AmFa4JpBx0TGbm5ZjwEk8KDwGa4+HPMTTQjxw==",
+      "requires": {
+        "@aws-sdk/eventstream-marshaller": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.18.0.tgz",
+      "integrity": "sha512-jJS34wJzv+5wumVpQ7fGOmTxkJlu1tmGkbCt13xuSjYpt2M/by+WAShxcxEhrsBJlMNMHTHF+v2Tew6JwEP00w==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/querystring-builder": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/util-base64-browser": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/hash-blob-browser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.18.0.tgz",
+      "integrity": "sha512-4+c/AoMLt50EeetoDhVKRq3CNnpHgrbQomQI4LjDZeSnlNuTZ/fQ6MvRnWPOoZgTwK2xtI31LrAt95G/54oa0Q==",
+      "requires": {
+        "@aws-sdk/chunked-blob-reader": "3.18.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.18.0.tgz",
+      "integrity": "sha512-rmjpJl4oG4JxHydnb9F3GzHu5wDJAQswgnBV0NszHfDndJm34f0Dta6OTmreK5nZ8ns/g6ZAjLjiTuKJoxjVmg==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/util-buffer-from": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/hash-stream-node": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.18.0.tgz",
+      "integrity": "sha512-dW8nMYy4Wz5wjkID9z8e6cNdTVralDXfilgaPas7D+Q3RfnCm5PgDFHXFhDcY51rLwuuWCHmxi2QLqx9tGngmg==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.18.0.tgz",
+      "integrity": "sha512-+VlXE8G22+H7d6K0EafpmihodOiF8I957J/euWIAGTSYYhLuAXPgCyPoKk1Qmxqfb3oAoG/cuoehCuPfFWwTPA==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.18.0.tgz",
+      "integrity": "sha512-HvPRgESVQt0UbzRQZVKhf8SpGGc5Jrln3AtTzkVu6PBHO04Dh2EHsrsxiu7X3oB453Mnp8+LYBVIgsmM/RyJzA==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/md5-js": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.18.0.tgz",
+      "integrity": "sha512-EYYOdfl5i4o1XeaJYqQDk/3ETzLdzhR2JwqPxPGJfTC7E44yFJYV0fLFEmS46WXgN5Dtz4DXkw0GZdf/jJecyA==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/util-utf8-browser": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-apply-body-checksum": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.18.0.tgz",
+      "integrity": "sha512-ODM+Lb89Zpuzmo/36O+PxfQb82Y1U8QG+BoLULdCYKGW0yqB6zywuHXhfJaTzSjZYufckVKPFaoKYUvE3GmPMw==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.18.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.19.0.tgz",
+      "integrity": "sha512-I3MwtIMnp9LrUjvd/j6WZVOTkzxZSKHfTBe9oFg7DQvxRiEnJHQL9/icDz4xwrzzKjY76WsGOAFNa98rrx67SA==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/util-arn-parser": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.18.0.tgz",
+      "integrity": "sha512-N1qTzkn+vNjMXBRybW9/S9WtCFiJp2B8agr+41zja4hnZVA07kClvI76jM6KUwQHADB2q79FWT+i6PeyCHHh1Q==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-expect-continue": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.18.0.tgz",
+      "integrity": "sha512-JiTx+22XRdC1MHp7wLdIuAIzgBVp/3EoAbSRdg4Qhs88yFwUZM7G3vNRtnq4l8He2T/VExVZjTLMcGBCKpu/pA==",
+      "requires": {
+        "@aws-sdk/middleware-header-default": "3.18.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-header-default": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.18.0.tgz",
+      "integrity": "sha512-mWT/p2gVVB3us5Otf0g66zTIUaZXPMamatzmqEUVWC40VQxIcC0HeuXKBJrBQz63TqgFEUuFIPe5fdyaWgsjLQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.18.0.tgz",
+      "integrity": "sha512-MPX9GJk3Wl3OjRJ3ti+ptkG+7dTpXGtEjIPF0MsCSlfTKH01lsNGDpSZpeUyhYFrvl3fXoMrPeJHUuFeXA3bIA==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-location-constraint": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.18.0.tgz",
+      "integrity": "sha512-VjMFFE7FXfmuwtFDnNLeqVM4/Q9rXC2a0YkYjXoGSzF4CuMarkyu3dPb590ubdSsYhYpKQDaoRFgJNzCRjmssA==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.18.0.tgz",
+      "integrity": "sha512-GGiT4w8R7GOvlp4Q1w8JmBaBSsxNUL+ebEcs8ahJBrm9brYZG7tN8ncLXfF7d3oLd5XMoSbBkTn8+dQ973pkEQ==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.19.0.tgz",
+      "integrity": "sha512-2IPCBH8jYy0A1MQUx0o3JZ51eY1AesZaZduiqHmuzgCw5FEtKd60jmSh91CD+iex9CPs854ajw7/+4ICVu6SLg==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/service-error-classification": "3.19.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-sdk-s3": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.18.0.tgz",
+      "integrity": "sha512-JQ0UGyixH3QTnLd27eG2rpgMswhe2T7e0h9iI9YLGDiYQLRAULYIagR6XZep1vKJljyY8VNmnII89aMb132I1w==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/util-arn-parser": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.19.0.tgz",
+      "integrity": "sha512-hdmPiNUQp3RsLteDFOyD1bB3hoW7QmfQM7uxFMA5cg3RQMuCxLlQWb+srPKXx0bJ8C3aRk5aa2KRMUnVJ6/7EQ==",
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.19.0",
+        "@aws-sdk/property-provider": "3.19.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/signature-v4": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.18.0.tgz",
+      "integrity": "sha512-46PtAvnGONN/v5OcNE4/3UywadCJunITwXDK/AGs6SMijkOPtoGMjP7fme9XlB6wg4QTSfeF3eKsieOF47RlPg==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.19.0.tgz",
+      "integrity": "sha512-nCSGbSnZNw3CCl7K43+Xv0qT95ijP31EpmfAWDL6Xqtjt0J4K43VDFr1lWq2q8TQaqQ62dRakbe9UxtxdwAP6g==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.19.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/signature-v4": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-ssec": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.18.0.tgz",
+      "integrity": "sha512-j4WdgNLrHH5w5Nn3JbnMFFvTPTNU6a9FvLT08tfWYT93UOgRBe+d8c8BZzTY+OYkoA77EgEYuI5TYetratXiIw==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.18.0.tgz",
+      "integrity": "sha512-+FDsKMRq3Gsd6ddVt1P+7ltSiRRcEj6KpRccMHkFkFqWWqn9OcPh+Et076ivSBXCW8q9Ib4qJi04hiCD/md2EQ==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.18.0.tgz",
+      "integrity": "sha512-BGm+buvq0wHtIylYGmyLhuRUvb2MsKx2mBhEx9m5Vs4M8I8GnTgrWtblOzwqZ+Q7dl+GQCL0/tLYTw50BTeLGQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.19.0.tgz",
+      "integrity": "sha512-HI+oP/sAuAW3kZ5TwSRGV2rNmVq04wLCuuwhMXX2/SXw2EpHRtZRWhIVQ+0d4sIlFzKWhcnmvp0qL52jHguUzA==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.19.0",
+        "@aws-sdk/shared-ini-file-loader": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.18.0.tgz",
+      "integrity": "sha512-87ZxGlq3dnlPjAIN0yhawiF+n3oQQihxYaSeysltsuz13X/beYTDyGTEBZXWKwB06O/XHbfBV6iYUR7XgMP20w==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.18.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/querystring-builder": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.19.0.tgz",
+      "integrity": "sha512-Sqqggthui4qczlOa91SRg8r9VziB9wrrJCd1XJmtBoJK45DiR7LCO10fii+VUCjHrJ+rU6cxKMVAghkMX06yiQ==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.18.0.tgz",
+      "integrity": "sha512-GIKvZBEnm87/mRaVYHnsQDYBSvU6qyKjyVdHDpQHhF+MZ+MKafygmpdBjsrRRstWr7h5WepnUVImYgvmaW6vyw==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.18.0.tgz",
+      "integrity": "sha512-1DrzflLp80RG674XfhZsl4jehIe0mdSPqXqMH6vOMDcmF/lLEsfwPs307G+Go3kwWXSUup52bcMmfi8Ef4xLBg==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/util-uri-escape": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.18.0.tgz",
+      "integrity": "sha512-7pkgPCeTtsgcgBwYSK2QN9Kij88Adi4bKMBxCqpanloTng2KrZ3DfyyD7c0H70mt21Zqfwr2M1HrPSs1SZKBkw==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.19.0.tgz",
+      "integrity": "sha512-01lXj5QnJamSx/Sg6Q5ymgk1MJLOOIUsCMctasWZWURqDLqEsGp2F4SSguMSkNAYnA2wB8nc+U66m3UCPxPm1A=="
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.18.0.tgz",
+      "integrity": "sha512-YpBCZWRvJhnPHbdFLzRvLIfx7Zxre8/5YsWrrNNBWRJ90z/6czzPdOn9jab/AVfLPpC/VSSubf4v4b8Cjeb4eA==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.18.0.tgz",
+      "integrity": "sha512-md52+v+aIDfhwtaN+xIJ+7XgSqtRmreGkSCnJziGINRSnUSdycoR/ZJhT5d9TbMpYHdoT0Rm9RXNXImlfKCNGw==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/util-hex-encoding": "3.18.0",
+        "@aws-sdk/util-uri-escape": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.19.0.tgz",
+      "integrity": "sha512-vd1hIs2IxIuEdaiinx6gICVSlkFMe7peGgmlMQtY4CT29cI5DT1Uip8i6PnlSJHS+/qPQUetIsnc5Nc9eFDGmQ==",
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.18.0.tgz",
+      "integrity": "sha512-fyk6HXK1wk83n4fDvsG+ewV+yS4uegepeMNrmLr7iBKjzc/bLckTWk7GKFM5ZaF/9jWyk7o2eKW3C3BltgDrfQ=="
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.18.0.tgz",
+      "integrity": "sha512-ye3sSF8R6kp1r98MRNk9UDj6P0luQfSZ5N2EZjF8AUG0y4PTVc4L/PlSsH3/sMOjG831al+khNo+cZNO9wZeiQ==",
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-arn-parser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.18.0.tgz",
+      "integrity": "sha512-zqzkRwxbt73/SLZAmmLLqTavSF0BucButJQ5m9uIGgobPi7kZBjOwh4sY6WQw3E80MFc6EExiVyry3rSHiWMBg==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-base64-browser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.18.0.tgz",
+      "integrity": "sha512-XG7ls/9utSgCGzD0hgnNAQWLWU9Nnc/IqjQCZ6td84Y1/kTBBafSN3RTPeQ3fLzJ063sTDOy/DPEh21IPZCF6A==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-base64-node": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.18.0.tgz",
+      "integrity": "sha512-NzkHCynFU2wfqU/15IkI5H0ukafu//LSUTFp9w4MzFNYpfbXAjcAK4S53VQe46bvciRRk8pyHc4wixiYsxFbpA==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.18.0.tgz",
+      "integrity": "sha512-+x0yrV9Z/gGGRVoWmx7t+skwG110vngkq5Clu7z+k/DtuZrkrspYKOVzidaH80pGJwJi+0JzxbIhA5JblBAf7Q==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.18.0.tgz",
+      "integrity": "sha512-r/m+TP9O1G8k9V51LvDCjkoc53Parn7BjP81cBplDrA6Uc2iezVRcjuXzRU+4X8EBIlUtCNhDYryl5xN8cohKw==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.18.0.tgz",
+      "integrity": "sha512-4Pp4owEfjNdmqH9cByJnN0GbfM2II3I4FnRN5d9BysJ6mG+rLhc6WYxBgr4sEFtsJGYCgFzLU5MfUMx9OuDdPA==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.18.0.tgz",
+      "integrity": "sha512-tayCN0+jLJRyM7W059ybwaEojjI4ylP4UyyG+LDc4m62PskmsCWTWOJzudjtx4d765e0I/F1w1ELrE+VhUdOpQ==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.18.0.tgz",
+      "integrity": "sha512-Lj2O9KaXCn+gPW23l3ydcSWe4HK0jH6teeSymbaFTwTjKtr4oLfDDKAOFoG5YyppQstEPqsL/RidVey4kOFfcg==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.18.0.tgz",
+      "integrity": "sha512-Ui+uydvhzQALj/Q8sat4cVnCedwB/8iBPoMzcm1hr1r7ttWfmBKKElFZFl6ljCUtKaCE3rTb3JrZ2sKy9wT09A==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.18.0.tgz",
+      "integrity": "sha512-qBfyQJqN3RFyeY6nr03RZQ6uT6t5BIdthqwSPZ99K2gvf75TdhPA3PJsaIZfluNHEPQrgrNd32OED8jnd+GXwA==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.19.0.tgz",
+      "integrity": "sha512-Fv4Vof09Xu9QMBhqopiQwTp7jAhRw1VqKFQN9hsdbJOj1DoDcSpiAyFb1QfvV6QymGDhH28kLoSaBMucrFW8YQ==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.19.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.18.0.tgz",
+      "integrity": "sha512-JwcdTb6AAMtnlt2Sg0I18DBK1sWlsfDR/23CkDQ52niXvCSRdHeNkh5b7SdEPVUKI76hyce9nEshzI1OasTv7w==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.18.0.tgz",
+      "integrity": "sha512-yQtKkW5V6ycT6DlJkYgeMjj6HJc+jj50LUUx2ukW6IfRmCeAGWdUu82NgIzlzvlsqH1jvmQ/kaeqZ7ruOtmA6Q==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-waiter": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.18.0.tgz",
+      "integrity": "sha512-ba67ZEn96RR7Nm0xXGtxD1ISWsG6ePpnOEi2p6hhP1/zJth70mCgxfMPHbxBmfQuadCtP3lhMGpRIptdAlXnDA==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/xml-builder": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.18.0.tgz",
+      "integrity": "sha512-w8cx5Dx1njWjks+AH9tnQy6yvPbZUQrfJupvMFEY3wmXHnUGWCQrZC8GUOgcaLUbS27SykQAv+COxwNuZZMicQ==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -1214,9 +2517,9 @@
       }
     },
     "@concord-consortium/lara-interactive-api": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.0.1.tgz",
-      "integrity": "sha512-838j9BB6EaY+KSaBPAoLphTIx2Ak9iysDpyaByxvmeCj7V3BlntDs04luCC3J+w/QL0n/Vj0OCpuo0OoLVAWuQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.0.2.tgz",
+      "integrity": "sha512-CqmDUL77rHTiTa5gWshJQgXHzHFasRzEHOT1+kkgU7zPIWu8IUivdCK0lyYfxyNuguES5eDr9LJAWdI86xEp8g==",
       "requires": {
         "iframe-phone": "^1.3.1"
       }
@@ -1293,6 +2596,11 @@
           "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
         }
       }
+    },
+    "@concord-consortium/token-service": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/token-service/-/token-service-1.2.0.tgz",
+      "integrity": "sha512-zQVl83djUtm6RFl6n7EAnZKrvsbtrRYtLeZQgcBZrMZL0ZZj6G3sV3W77uuh/VS1iJOGfeT8/7jiRdSRxuLE1Q=="
     },
     "@cypress/listr-verbose-renderer": {
       "version": "0.4.1",
@@ -4439,6 +5747,11 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "attr-accept": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
+      "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg=="
+    },
     "autoprefixer": {
       "version": "9.8.6",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
@@ -5240,6 +6553,11 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
+    },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -9222,6 +10540,11 @@
       "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
       "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
     },
+    "fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
+    },
     "faye-websocket": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
@@ -9313,6 +10636,21 @@
             "ajv": "^6.12.0",
             "ajv-keywords": "^3.4.1"
           }
+        }
+      }
+    },
+    "file-selector": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.2.4.tgz",
+      "integrity": "sha512-ZDsQNbrv6qRi1YTDOEWzf5J2KjZ9KMI1Q2SGeTkCJmNNW25Jg4TW4UMcmoqcg4WrAyKRcpBXdbWRxkfrOzVRbA==",
+      "requires": {
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
         }
       }
     },
@@ -16509,6 +17847,16 @@
         "scheduler": "^0.19.1"
       }
     },
+    "react-dropzone": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-11.3.4.tgz",
+      "integrity": "sha512-B1nzNRZ4F1cnrfEC0T6KXeBN1mCPinu4JCoTrp7NjB+442KSPxqfDrw41QIA2kAwlYs1+wj/0BTedeM5hc2+xw==",
+      "requires": {
+        "attr-accept": "^2.2.1",
+        "file-selector": "^0.2.2",
+        "prop-types": "^15.7.2"
+      }
+    },
     "react-easy-swipe": {
       "version": "0.0.21",
       "resolved": "https://registry.npmjs.org/react-easy-swipe/-/react-easy-swipe-0.0.21.tgz",
@@ -19793,9 +21141,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-      "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "start": "webpack-dev-server --inline --hot --content-base dist/",
-    "start:secure": "webpack-dev-server --https --inline --hot --content-base dist/ --cert ./LocalhostCertificates/localhost.pem --key ./LocalhostCertificates/localhost.key",
+    "start:secure": "webpack-dev-server --https --inline --hot --content-base dist/ --cert ~/.localhost-ssl/localhost.pem --key ~/.localhost-ssl/localhost.key",
     "start:secure:no-certs": "webpack-dev-server --https --inline --hot --content-base dist/",
     "build": "npm-run-all lint:build clean build:webpack",
     "build:webpack": "webpack --mode production --devtool false",

--- a/package.json
+++ b/package.json
@@ -122,9 +122,11 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.19.0",
     "@concord-consortium/lara-interactive-api": "^1.0.1",
     "@concord-consortium/slate-editor": "^0.6.0",
     "@concord-consortium/text-decorator": "^1.0.2",
+    "@concord-consortium/token-service": "^1.2.0",
     "chart.js": "^2.5.0",
     "deep-equal": "^2.0.3",
     "deepmerge": "^4.2.2",
@@ -142,6 +144,7 @@
     "react-dnd-preview": "^6.0.2",
     "react-dnd-touch-backend": "^11.1.3",
     "react-dom": "^16.13.1",
+    "react-dropzone": "^11.3.4",
     "react-hooks-use-previous": "^1.1.1",
     "react-jsonschema-form": "^1.8.1",
     "react-responsive-carousel": "^3.2.10",

--- a/package.json
+++ b/package.json
@@ -123,10 +123,10 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.19.0",
-    "@concord-consortium/lara-interactive-api": "^1.0.1",
+    "@concord-consortium/lara-interactive-api": "^1.1.0",
     "@concord-consortium/slate-editor": "^0.6.0",
     "@concord-consortium/text-decorator": "^1.0.2",
-    "@concord-consortium/token-service": "^1.2.0",
+    "@concord-consortium/token-service": "^2.0.0",
     "chart.js": "^2.5.0",
     "deep-equal": "^2.0.3",
     "deepmerge": "^4.2.2",

--- a/src/carousel/components/iframe-authoring.tsx
+++ b/src/carousel/components/iframe-authoring.tsx
@@ -7,6 +7,7 @@ import { libraryInteractives, libraryInteractiveIdToUrl } from "../../shared/uti
 import { v4 as uuidv4 } from "uuid";
 import { ImageUploadComponent } from "../../shared/widgets/image-upload/image-upload-widget";
 import { IFormContext } from "../../shared/components/base-authoring";
+import { getFirebaseJwt } from "@concord-consortium/lara-interactive-api";
 
 import css from "./iframe-authoring.scss";
 
@@ -80,9 +81,18 @@ export const IframeAuthoring: React.FC<FieldProps> = props => {
     phone.addListener("height", (newHeight: number) => {
       setIframeHeight(newHeight);
     });
+    phone.addListener("getFirebaseJWT", async (request) => {
+      const {requestId, firebase_app} = request;
+      const jwt = await getFirebaseJwt(firebase_app);
+      const response = {requestId, ...jwt};
+      phone.post("firebaseJWT", response);
+    });
     phone.post("initInteractive", {
       mode: "authoring",
-      authoredState
+      authoredState,
+      hostFeatures: {
+        getFirebaseJwt: {version: "1.0.0"}
+      }
     });
   }, [id, libraryInteractiveId, onChange, authoredState, navImageUrl, navImageAltText]);
 

--- a/src/carousel/components/iframe-authoring.tsx
+++ b/src/carousel/components/iframe-authoring.tsx
@@ -4,14 +4,18 @@ import { IframePhone } from "../../shared/types";
 import iframePhone from "iframe-phone";
 import deepEqual from "deep-equal";
 import { libraryInteractives, libraryInteractiveIdToUrl } from "../../shared/utilities/library-interactives";
-import css from "./iframe-authoring.scss";
 import { v4 as uuidv4 } from "uuid";
+import { ImageUploadComponent } from "../../shared/widgets/image-upload/image-upload-widget";
+import { IFormContext } from "../../shared/components/base-authoring";
+
+import css from "./iframe-authoring.scss";
 
 // This is only temporary list. In the future, it will be replaced by LARA Interactive API call that returns all the available managed interactives.
 const availableInteractives = libraryInteractives;
 
 export const IframeAuthoring: React.FC<FieldProps> = props => {
   const { onChange, formData } = props;
+  const { tokenServiceClient } = props.formContext as IFormContext<unknown>;
   const { libraryInteractiveId, authoredState, id, navImageUrl, navImageAltText } = formData;
   const [ iframeHeight, setIframeHeight ] = useState(300);
   const [ authoringOpened, setAuthoringOpened ] = useState(false);
@@ -30,7 +34,7 @@ export const IframeAuthoring: React.FC<FieldProps> = props => {
 
   const handleLibraryInteractiveIdChange = (event: ChangeEvent<HTMLSelectElement>) => {
     const newLibraryInteractiveId = event.target.value;
-    onChange({ 
+    onChange({
       libraryInteractiveId: newLibraryInteractiveId,
       authoredState: undefined,
       id: id || uuidv4(),
@@ -39,16 +43,14 @@ export const IframeAuthoring: React.FC<FieldProps> = props => {
     });
   };
 
-  const handleNavImageUrlChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const newNavImageUrl = event.target.value;
+  const handleNavImageUrlChange = (newNavImageUrl: string) => {
     onChange({libraryInteractiveId, authoredState, id,
       navImageUrl: newNavImageUrl || "",
       navImageAltText: navImageAltText || ""
     });
   };
 
-  const handleNavImageAltTextChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const newNavImageAltText = event.target.value;
+  const handleNavImageAltTextChange = (newNavImageAltText: string) => {
     onChange({libraryInteractiveId, id,
       authoredState: undefined,
       navImageUrl: navImageUrl || "",
@@ -110,10 +112,10 @@ export const IframeAuthoring: React.FC<FieldProps> = props => {
           <div className={css.iframeContainer} style={{maxHeight: authoringOpened ? iframeHeight : 0 }}>
             <div className={css.navButtonField}>
               <label htmlFor="navImageUrl">Custom Navigation Button Image URL</label>
-              <input className="form-control" type="text" id="navImageUrl" defaultValue={navImageUrl} onChange={handleNavImageUrlChange} />
+              <ImageUploadComponent className="form-control" id="navImageUrl" defaultValue={navImageUrl} onChange={handleNavImageUrlChange} tokenServiceClient={tokenServiceClient} />
               <p className="help-block">To customize the button for this slide, enter an image URL. Optimal image size: 150x100 pixels.</p>
               <label htmlFor="navImageAltText">Custom Navigation Button Image Alt Text</label>
-              <input className="form-control" type="text" id="navImageAltText" defaultValue={navImageAltText} onChange={handleNavImageAltTextChange} />
+              <ImageUploadComponent className="form-control" id="navImageAltText" defaultValue={navImageAltText} onChange={handleNavImageAltTextChange} tokenServiceClient={tokenServiceClient} />
               <p className="help-block">To customize the alt text for a custom navigation button, enter your text.</p>
             </div>
             <iframe id={id} ref={iframeRef} width="100%" height={iframeHeight} frameBorder={0} />

--- a/src/drag-and-drop/components/app.tsx
+++ b/src/drag-and-drop/components/app.tsx
@@ -142,10 +142,16 @@ export const baseAuthoringProps = {
     hint: {
       "ui:widget": "richtext"
     },
+    backgroundImageUrl: {
+      "ui:widget": "imageUpload"
+    },
     draggableItems: {
       items: {
         id: {
           "ui:widget": "hidden"
+        },
+        imageUrl: {
+          "ui:widget": "imageUpload"
         }
       }
     },

--- a/src/drawing-tool/components/app.tsx
+++ b/src/drawing-tool/components/app.tsx
@@ -251,7 +251,8 @@ export const baseAuthoringProps = {
       "ui:widget": "richtext"
     },
     backgroundImageUrl: {
-      "ui:help": "Path to hosted image file (jpg, png, gif, etc)"
+      "ui:help": "Path to hosted image file (jpg, png, gif, etc)",
+      "ui:widget": "imageUpload"
     },
     imageFit: {
       "ui:widget": "radio"

--- a/src/image-question/components/app.test.tsx
+++ b/src/image-question/components/app.test.tsx
@@ -11,7 +11,8 @@ jest.mock("@concord-consortium/lara-interactive-api", () => ({
   useAuthoredState: jest.fn(),
   useInteractiveState: jest.fn(),
   setSupportedFeatures: jest.fn(),
-  getInteractiveList: jest.fn(() => new Promise(() => { /* never resolve */ }))
+  getInteractiveList: jest.fn(() => new Promise(() => { /* never resolve */ })),
+  getFirebaseJwt: jest.fn().mockReturnValue({token: "test"}),
 }));
 
 const useInitMessageMock = useInitMessage as jest.Mock;

--- a/src/image/components/app.tsx
+++ b/src/image/components/app.tsx
@@ -75,11 +75,11 @@ const baseAuthoringProps = {
       "ui:widget": "hidden"
     },
     url: {
-      "ui:widget": "textarea",
+      "ui:widget": "imageUpload",
       "ui:help": "Path to hosted image file (jpg, png, gif, etc)"
     },
     highResUrl: {
-      "ui:widget": "textarea",
+      "ui:widget": "imageUpload",
       "ui:help": "Path to high-resolution hosted image file (jpg, png, gif, etc) for zoomed-in view (optional)"
     },
     altText: {

--- a/src/open-response/components/app.test.tsx
+++ b/src/open-response/components/app.test.tsx
@@ -11,7 +11,8 @@ jest.mock("@concord-consortium/lara-interactive-api", () => ({
   useInitMessage: jest.fn(),
   useAuthoredState: jest.fn(),
   useInteractiveState: jest.fn(),
-  setSupportedFeatures: jest.fn()
+  setSupportedFeatures: jest.fn(),
+  getFirebaseJwt: jest.fn().mockReturnValue({token: "test"}),
 }));
 
 const useInitMessageMock = useInitMessage as jest.Mock;

--- a/src/scaffolded-question/components/iframe-authoring.tsx
+++ b/src/scaffolded-question/components/iframe-authoring.tsx
@@ -5,6 +5,8 @@ import iframePhone from "iframe-phone";
 import deepEqual from "deep-equal";
 import { v4 as uuidv4 } from "uuid";
 import { libraryInteractives, libraryInteractiveIdToUrl } from "../../shared/utilities/library-interactives";
+import { getFirebaseJwt } from "@concord-consortium/lara-interactive-api";
+
 import css from "./iframe-authoring.scss";
 
 export const IframeAuthoring: React.FC<FieldProps> = props => {
@@ -47,9 +49,18 @@ export const IframeAuthoring: React.FC<FieldProps> = props => {
     phone.addListener("height", (newHeight: number) => {
       setIframeHeight(newHeight);
     });
+    phone.addListener("getFirebaseJWT", async (request) => {
+      const {requestId, firebase_app} = request;
+      const jwt = await getFirebaseJwt(firebase_app);
+      const response = {requestId, ...jwt};
+      phone.post("firebaseJWT", response);
+    });
     phone.post("initInteractive", {
       mode: "authoring",
-      authoredState
+      authoredState,
+      hostFeatures: {
+        getFirebaseJwt: {version: "1.0.0"}
+      }
     });
   }, [id, libraryInteractiveId, onChange, authoredState]);
 

--- a/src/shared/components/base-authoring.test.tsx
+++ b/src/shared/components/base-authoring.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { mount, shallow } from "enzyme";
-import { BaseAuthoring } from "./base-authoring";
+import { BaseAuthoring, getTokenServiceEnv } from "./base-authoring";
 import { JSONSchema6 } from "json-schema";
 import Form from "react-jsonschema-form";
 import { useLinkedInteractivesAuthoring } from "../hooks/use-linked-interactives-authoring";
@@ -97,5 +97,14 @@ describe("BaseAuthoring", () => {
         schema={schema}
     />);
     expect(useLinkedInteractivesAuthoringMock).toHaveBeenCalled();
+  });
+});
+
+describe("getTokenServiceEnv", () => {
+  it("returns production only for learn.concord.org", () => {
+    expect(getTokenServiceEnv({platform_id: "https://learn.concord.org"})).toEqual("production");
+
+    expect(getTokenServiceEnv({platform_id: "https://example.com"})).toEqual("staging");
+    expect(getTokenServiceEnv({platform_id: "https://learn.staging.concord.org"})).toEqual("staging");
   });
 });

--- a/src/shared/components/base-authoring.tsx
+++ b/src/shared/components/base-authoring.tsx
@@ -37,18 +37,17 @@ const widgets = {
 
 export const getTokenServiceEnv = () => {
   // use either the portal url param for standalone authoring or the Lara page url for inline authoring
-  const host = window.location.hostname;
-  if (host.match(/staging\./)) {
-    return "staging";
-  }
-  if (host.match(/concord\.org/)) {
-    return "production";
-  }
   // Note that when local Portal is being used, we'll still return "staging" token service env, so developers don't
   // have to setup local instance of token service. When local token service client should be used, you need to use
   // `token-service-url=dev` URL param. It's handled by TokenServiceClient directly, and the `env` param passed to its
   // constructor will be ignored.
-  return "staging";
+  let env = "staging";
+  const host = window.location.hostname;
+  if (!host.match(/staging\./) && host.match(/concord\.org/)) {
+    env = "production";
+  }
+  console.log("getTokenServiceEnv", {host, env});
+  return env;
 };
 
 export const BaseAuthoring = <IAuthoredState,>({ authoredState, setAuthoredState, preprocessFormData, schema, uiSchema, fields, validate, linkedInteractiveProps }: IBaseAuthoringProps<IAuthoredState>) => {

--- a/src/shared/components/base-authoring.tsx
+++ b/src/shared/components/base-authoring.tsx
@@ -46,7 +46,9 @@ export const getTokenServiceEnv = () => {
   if (!host.match(/staging\./) && host.match(/concord\.org/)) {
     env = "production";
   }
-  console.log("getTokenServiceEnv", {host, env});
+  // force staging for demo
+  env = "staging";
+  console.log("getTokenServiceEnv!", {host, env});
   return env;
 };
 

--- a/src/shared/components/base-authoring.tsx
+++ b/src/shared/components/base-authoring.tsx
@@ -35,21 +35,9 @@ const widgets = {
   imageUpload: ImageUploadWidget
 };
 
-export const getTokenServiceEnv = () => {
-  // use either the portal url param for standalone authoring or the Lara page url for inline authoring
-  // Note that when local Portal is being used, we'll still return "staging" token service env, so developers don't
-  // have to setup local instance of token service. When local token service client should be used, you need to use
-  // `token-service-url=dev` URL param. It's handled by TokenServiceClient directly, and the `env` param passed to its
-  // constructor will be ignored.
-  let env: "staging" | "production" = "staging";
-  const host = window.location.hostname;
-  if (!host.match(/staging\./) && host.match(/concord\.org/)) {
-    env = "production";
-  }
-  // force staging for demo
-  env = "staging";
-  console.log("getTokenServiceEnv!", {host, env});
-  return env;
+export const getTokenServiceEnv = (claims: any) => {
+  const host = claims?.platform_id || "";
+  return host.match(/learn\.concord\.org/) ? "production" : "staging";
 };
 
 export const BaseAuthoring = <IAuthoredState,>({ authoredState, setAuthoredState, preprocessFormData, schema, uiSchema, fields, validate, linkedInteractiveProps }: IBaseAuthoringProps<IAuthoredState>) => {
@@ -76,7 +64,7 @@ export const BaseAuthoring = <IAuthoredState,>({ authoredState, setAuthoredState
   useEffect(() => {
     const getJWT = async () => {
       const jwt = await getFirebaseJwt(TokenServiceClient.FirebaseAppName);
-      setTokenServiceClient(new TokenServiceClient({ jwt: jwt.token, env: getTokenServiceEnv() }));
+      setTokenServiceClient(new TokenServiceClient({ jwt: jwt.token, env: getTokenServiceEnv(jwt.claims) }));
     };
     getJWT();
   }, [setTokenServiceClient]);

--- a/src/shared/components/base-authoring.tsx
+++ b/src/shared/components/base-authoring.tsx
@@ -41,7 +41,7 @@ export const getTokenServiceEnv = () => {
   // have to setup local instance of token service. When local token service client should be used, you need to use
   // `token-service-url=dev` URL param. It's handled by TokenServiceClient directly, and the `env` param passed to its
   // constructor will be ignored.
-  let env = "staging";
+  let env: "staging" | "production" = "staging";
   const host = window.location.hostname;
   if (!host.match(/staging\./) && host.match(/concord\.org/)) {
     env = "production";

--- a/src/shared/components/base-authoring.tsx
+++ b/src/shared/components/base-authoring.tsx
@@ -1,10 +1,14 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import Form, { Field, FormValidation, IChangeEvent, UiSchema } from "react-jsonschema-form";
 import { JSONSchema6 } from "json-schema";
 import { useDelayedValidation } from "../hooks/use-delayed-validation";
 import { RichTextWidget } from "../widgets/rich-text/rich-text-widget";
+import { ImageUploadWidget } from "../widgets/image-upload/image-upload-widget";
 import { ILinkedInteractiveProp, useLinkedInteractivesAuthoring } from "../hooks/use-linked-interactives-authoring";
 import "../../shared/styles/boostrap-3.3.7.css"; // necessary to style react-jsonschema-form
+import { getFirebaseJwt } from "@concord-consortium/lara-interactive-api";
+import { TokenServiceClient } from "@concord-consortium/token-service";
+
 import css from "../../shared/styles/authoring.scss";
 
 export interface IBaseAuthoringProps<IAuthoredState> {
@@ -22,16 +26,35 @@ export interface IBaseAuthoringProps<IAuthoredState> {
 
 export interface IFormContext<IAuthoredState> {
   authoredState: IAuthoredState;
+  tokenServiceClient: TokenServiceClient;
 }
 
 // custom widgets
 const widgets = {
-  richtext: RichTextWidget
+  richtext: RichTextWidget,
+  imageUpload: ImageUploadWidget
+};
+
+export const getTokenServiceEnv = () => {
+  // use either the portal url param for standalone authoring or the Lara page url for inline authoring
+  const host = window.location.hostname;
+  if (host.match(/staging\./)) {
+    return "staging";
+  }
+  if (host.match(/concord\.org/)) {
+    return "production";
+  }
+  // Note that when local Portal is being used, we'll still return "staging" token service env, so developers don't
+  // have to setup local instance of token service. When local token service client should be used, you need to use
+  // `token-service-url=dev` URL param. It's handled by TokenServiceClient directly, and the `env` param passed to its
+  // constructor will be ignored.
+  return "staging";
 };
 
 export const BaseAuthoring = <IAuthoredState,>({ authoredState, setAuthoredState, preprocessFormData, schema, uiSchema, fields, validate, linkedInteractiveProps }: IBaseAuthoringProps<IAuthoredState>) => {
   const formRef = useRef<Form<IAuthoredState>>(null);
   const triggerDelayedValidation = useDelayedValidation({ formRef });
+  const [tokenServiceClient, setTokenServiceClient] = useState<TokenServiceClient>();
 
   const onChange = (event: IChangeEvent) => {
     let formData = event.formData;
@@ -47,6 +70,15 @@ export const BaseAuthoring = <IAuthoredState,>({ authoredState, setAuthoredState
     // Initial validation (if necessary).
     validate && triggerDelayedValidation();
   }, [validate, triggerDelayedValidation]);
+
+  // create token service client
+  useEffect(() => {
+    const getJWT = async () => {
+      const jwt = await getFirebaseJwt(TokenServiceClient.FirebaseAppName);
+      setTokenServiceClient(new TokenServiceClient({ jwt: jwt.token, env: getTokenServiceEnv() }));
+    };
+    getJWT();
+  }, [setTokenServiceClient]);
 
   // This hook provides list of interactives on a given page and saving of the linked interactive IDs.
   const schemaWithInteractives = useLinkedInteractivesAuthoring({ linkedInteractiveProps, schema });
@@ -66,7 +98,8 @@ export const BaseAuthoring = <IAuthoredState,>({ authoredState, setAuthoredState
           // Pass authored state in context, so custom field can access the complete authored state.
           // It's useful quite often, e.g. when field rendering is based on previous form inputs.
           // Currently used by drag and drop - `initialState` field is using list of draggable items.
-          authoredState: authoredState || {}
+          authoredState: authoredState || {},
+          tokenServiceClient
         }}
       >
         {/* Children are used to render custom action buttons. We don't want any, */}

--- a/src/shared/utilities/s3-upload.test.ts
+++ b/src/shared/utilities/s3-upload.test.ts
@@ -1,0 +1,68 @@
+import { TokenServiceClient, S3Resource, Credentials } from "@concord-consortium/token-service";
+import { IS3UploadParams, s3Upload, uniqueFilename } from "./s3-upload";
+
+const putObject = jest.fn().mockImplementation(() => {
+  return Promise.resolve()
+});
+
+jest.mock("@aws-sdk/client-s3", () => {
+  return {
+    S3: jest.fn().mockImplementation(() => {
+      return { putObject };
+    }),
+  };
+});
+
+describe("s3Upload", () => {
+  it("should call AWS.S3.upload with correct arguments and return Cloudfront URL", async () => {
+    const client = new TokenServiceClient({jwt: "test"});
+    const resource: S3Resource = {
+      id: "test",
+      name: "image upload",
+      description: "test image upload",
+      type: "s3Folder",
+      tool: "author-image-upload",
+      accessRules: [],
+      bucket: "test-bucket",
+      folder: "test-folder",
+      region: "test-region",
+      publicPath: "test-folder/test/",
+      publicUrl: "https://test-bucket.s3.amazonaws.com/test-folder/test/"
+    };
+    const credentials: Credentials = {
+      accessKeyId: "test",
+      expiration: new Date(),
+      secretAccessKey: "test",
+      sessionToken: "test"
+    };
+    const params: IS3UploadParams = {
+      client,
+      credentials,
+      filename: "test.png",
+      resource,
+      body: "test",
+      cacheControl: "max-age=123",
+      contentType: "application/test"
+    };
+    const url = await s3Upload(params);
+    expect(putObject).toHaveBeenCalledTimes(1);
+    const expectedKey = `test-folder/test/test.png`;
+    expect(putObject).toHaveBeenCalledWith({
+      Bucket: "test-bucket",
+      Key: expectedKey,
+      Body: params.body,
+      ContentEncoding: "UTF-8",
+      ContentType: params.contentType,
+      CacheControl: params.cacheControl
+    });
+    expect(url).toEqual(`https://test-bucket.s3.amazonaws.com/${expectedKey}`);
+  });
+});
+
+describe("uniqueFilename", () => {
+  it("prefixes the filename with a uuid", () => {
+    const [prefix, filename, ...rest] = uniqueFilename("test.png").split("-");
+    expect(prefix.length).toEqual(32);
+    expect(filename).toEqual("test.png");
+  });
+});

--- a/src/shared/utilities/s3-upload.test.ts
+++ b/src/shared/utilities/s3-upload.test.ts
@@ -2,7 +2,7 @@ import { TokenServiceClient, S3Resource, Credentials } from "@concord-consortium
 import { IS3UploadParams, s3Upload, uniqueFilename } from "./s3-upload";
 
 const putObject = jest.fn().mockImplementation(() => {
-  return Promise.resolve()
+  return Promise.resolve();
 });
 
 jest.mock("@aws-sdk/client-s3", () => {
@@ -61,7 +61,7 @@ describe("s3Upload", () => {
 
 describe("uniqueFilename", () => {
   it("prefixes the filename with a uuid", () => {
-    const [prefix, filename, ...rest] = uniqueFilename("test.png").split("-");
+    const [prefix, filename] = uniqueFilename("test.png").split("-");
     expect(prefix.length).toEqual(32);
     expect(filename).toEqual("test.png");
   });

--- a/src/shared/utilities/s3-upload.ts
+++ b/src/shared/utilities/s3-upload.ts
@@ -1,0 +1,31 @@
+import * as AWS from "@aws-sdk/client-s3";
+import {v4 as uuid} from "uuid";
+
+import { TokenServiceClient, S3Resource, Credentials } from "@concord-consortium/token-service";
+
+export interface IS3UploadParams {
+  client: TokenServiceClient;
+  credentials: Credentials;
+  filename: string;
+  resource: S3Resource;
+  body: any;
+  contentType?: string;
+  cacheControl?: string;
+}
+
+export const s3Upload = async ({client, credentials, filename, resource, body, contentType = "", cacheControl = ""}: IS3UploadParams): Promise<string> => {
+  const {bucket, region} = resource;
+  const s3 = new AWS.S3({region, credentials});
+  const key = client.getPublicS3Path(resource, filename);
+  await s3.putObject({
+    Bucket: bucket,
+    Key: key,
+    Body: body,
+    ContentType: contentType,
+    ContentEncoding: "UTF-8",
+    CacheControl: cacheControl
+  });
+  return client.getPublicS3Url(resource, filename);
+};
+
+export const uniqueFilename = (filename: string) => `${uuid().replace(/-/g, "")}-${filename}`;

--- a/src/shared/utilities/token-service.test.ts
+++ b/src/shared/utilities/token-service.test.ts
@@ -1,0 +1,34 @@
+import { TokenServiceClient } from "@concord-consortium/token-service";
+import { AUTHOR_IMAGE_UPLOAD_TOOL_ID, getOrCreateUserImageUploadResource } from "./token-service";
+
+describe("constants", () => {
+  expect(AUTHOR_IMAGE_UPLOAD_TOOL_ID).toEqual("author-image-upload");
+});
+
+describe("getOrCreateUserImageUploadResource", () => {
+  it("returns the first author-image-upload resource for the user", async () => {
+    const listResources = jest.fn().mockImplementation(() => {
+      return Promise.resolve(["first-resource"]);
+    });
+    const client = { listResources };
+
+    const resource = await getOrCreateUserImageUploadResource(client as unknown as TokenServiceClient);
+    expect(listResources).toHaveBeenCalledTimes(1);
+    expect(resource).toEqual("first-resource");
+  });
+
+  it("calls createResource when there is no existing author-image-upload resource for the user", async () => {
+    const listResources = jest.fn().mockImplementation(() => {
+      return Promise.resolve([]);
+    });
+    const createResource = jest.fn().mockImplementation(() => {
+      return Promise.resolve("created-resource");
+    });
+    const client = { listResources, createResource };
+
+    const resource = await getOrCreateUserImageUploadResource(client as unknown as TokenServiceClient);
+    expect(listResources).toHaveBeenCalledTimes(1);
+    expect(createResource).toHaveBeenCalledTimes(1);
+    expect(resource).toEqual("created-resource");
+  });
+});

--- a/src/shared/utilities/token-service.ts
+++ b/src/shared/utilities/token-service.ts
@@ -1,6 +1,6 @@
 import { S3Resource, TokenServiceClient } from "@concord-consortium/token-service";
 
-const AUTHOR_IMAGE_UPLOAD_TOOL_ID = "author-image-upload";
+export const AUTHOR_IMAGE_UPLOAD_TOOL_ID = "author-image-upload";
 
 export const getOrCreateUserImageUploadResource = async (client: TokenServiceClient): Promise<S3Resource> => {
   const resources = await client.listResources({type: "s3Folder", tool: AUTHOR_IMAGE_UPLOAD_TOOL_ID, amOwner: "true"});

--- a/src/shared/utilities/token-service.ts
+++ b/src/shared/utilities/token-service.ts
@@ -1,0 +1,17 @@
+import { S3Resource, TokenServiceClient } from "@concord-consortium/token-service";
+
+const AUTHOR_IMAGE_UPLOAD_TOOL_ID = "author-image-upload";
+
+export const getOrCreateUserImageUploadResource = async (client: TokenServiceClient): Promise<S3Resource> => {
+  const resources = await client.listResources({type: "s3Folder", tool: AUTHOR_IMAGE_UPLOAD_TOOL_ID, amOwner: "true"});
+  if (resources.length > 0) {
+    return resources[0] as S3Resource;
+  }
+  return await client.createResource({
+    name: "Author Image Upload Folder",
+    description: "Image uploads for authors",
+    type: "s3Folder",
+    tool: AUTHOR_IMAGE_UPLOAD_TOOL_ID,
+    accessRuleType: "user"
+  }) as S3Resource;
+};

--- a/src/shared/widgets/image-upload/image-upload-widget.scss
+++ b/src/shared/widgets/image-upload/image-upload-widget.scss
@@ -4,6 +4,7 @@
     padding: 10px;
     margin-bottom: 10px;
     border: 1px dashed #000;
+    cursor: pointer;
   }
 
   .uploadProgress {

--- a/src/shared/widgets/image-upload/image-upload-widget.scss
+++ b/src/shared/widgets/image-upload/image-upload-widget.scss
@@ -1,0 +1,17 @@
+.customImageUploadWidget {
+
+  .dropzone {
+    padding: 10px;
+    margin-bottom: 10px;
+    border: 1px dashed #000;
+  }
+
+  .uploadProgress {
+    margin: 10px 0;
+  }
+
+  .uploadError {
+    margin: 10px 0;
+    color: #f00;
+  }
+}

--- a/src/shared/widgets/image-upload/image-upload-widget.tsx
+++ b/src/shared/widgets/image-upload/image-upload-widget.tsx
@@ -1,0 +1,105 @@
+import { TokenServiceClient } from "@concord-consortium/token-service";
+import React, { ChangeEvent, useCallback, useState } from "react";
+import { WidgetProps } from "react-jsonschema-form";
+import { IFormContext } from "../../components/base-authoring";
+import { useDropzone } from "react-dropzone";
+import { s3Upload, uniqueFilename } from "../../utilities/s3-upload";
+import { getOrCreateUserImageUploadResource } from "../../utilities/token-service";
+
+import css from "./image-upload-widget.scss";
+
+export const ImageUploadDropzone = ({onDrop}: {onDrop: (file: File) => void}) => {
+  const handleDrop = useCallback((files) => {
+    if (files.length > 0) {
+      onDrop(files[0]);
+    }
+  }, [onDrop]);
+
+  const {getRootProps, getInputProps, fileRejections} = useDropzone({
+    onDrop: handleDrop,
+    accept: "image/png, image/jpeg, image/gif, image/svg+xml, image/webp"
+  });
+
+  const rejectedFileMessage = fileRejections.length > 0 ? <p>{`Sorry, ${fileRejections[0].file.name} can't be uploaded. Please use one of the supported file types.`}</p> : undefined;
+
+  return (
+    <div className={css.dropzone} {...getRootProps()}>
+      <input {...getInputProps()} />
+      Drop an image here, or click to select a file to upload. Only popular image formats are supported (e.g. png, jpeg, gif, svg, webp).
+      {rejectedFileMessage}
+    </div>
+  );
+};
+
+type UploadStatusState = "waiting" | "uploading" | "uploaded" | "error";
+
+interface ImageUploadComponentProps {
+  id?: string
+  className?: string
+  defaultValue?: string
+  onChange: (value: string) => void
+  tokenServiceClient: TokenServiceClient;
+}
+
+// used in carousel iframe-authoring directly as a React component and by widget
+export const ImageUploadComponent = ({id, defaultValue, onChange, tokenServiceClient}: ImageUploadComponentProps) => {
+  const [value, setValue] = useState(defaultValue || "");
+  const [uploadStatus, setUploadStatus] = useState<UploadStatusState>("waiting");
+  const [error, setError] = useState<string|undefined>();
+  const [filename, setFilename] = useState<string|undefined>();
+
+  const updateValue = useCallback((newValue: string) => {
+    setValue(newValue);
+    onChange?.(newValue);
+  }, [setValue, onChange]);
+
+  const handleInputChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    updateValue(event.target.value);
+  }, [updateValue]);
+
+  const handleDrop = useCallback(async (file: File) => {
+    setError(undefined);
+    setUploadStatus("uploading");
+    setFilename(file.name);
+
+    try {
+      const s3Resource = await getOrCreateUserImageUploadResource(tokenServiceClient);
+      const credentials = await tokenServiceClient.getCredentials(s3Resource.id);
+      const url = await s3Upload({
+        client: tokenServiceClient,
+        resource: s3Resource,
+        credentials,
+        filename: uniqueFilename(file.name),
+        body: file,
+        contentType: file.type,
+        cacheControl: "max-age=31536000" // 1 year
+      });
+      setUploadStatus("uploaded");
+      updateValue(url);
+    } catch (e) {
+      console.error("Error uploading file", e);
+      setUploadStatus("error");
+      setError(e.toString());
+    }
+  }, [setUploadStatus, updateValue, tokenServiceClient]);
+
+  return (
+    <div className={css.customImageUploadWidget}>
+      {tokenServiceClient && <ImageUploadDropzone onDrop={handleDrop} />}
+      {uploadStatus === "uploading" && <div className={css.uploadProgress}>Uploading {filename}...</div>}
+      {uploadStatus === "uploaded" && <div className={css.uploadProgress}>Uploaded {filename}!</div>}
+      {uploadStatus === "error" && <div className={css.uploadError}>Error uploading {filename}! {error}</div>}
+      <p>
+        <input className="form-control" type="text" id={id} value={value} onChange={handleInputChange} />
+      </p>
+    </div>
+  );
+};
+
+// used in json ui-schema in multiple question interactives
+export const ImageUploadWidget = (props: WidgetProps) => {
+  const { onChange } = props;
+  const { tokenServiceClient } = props.formContext as IFormContext<unknown>;
+
+  return <ImageUploadComponent onChange={onChange} defaultValue={props.value} tokenServiceClient={tokenServiceClient} />;
+};

--- a/src/shared/widgets/image-upload/image-upload-widget.tsx
+++ b/src/shared/widgets/image-upload/image-upload-widget.tsx
@@ -101,5 +101,5 @@ export const ImageUploadWidget = (props: WidgetProps) => {
   const { onChange } = props;
   const { tokenServiceClient } = props.formContext as IFormContext<unknown>;
 
-  return <ImageUploadComponent onChange={onChange} defaultValue={props.value} tokenServiceClient={tokenServiceClient} />;
+  return <ImageUploadComponent id={props.id} onChange={onChange} defaultValue={props.value} tokenServiceClient={tokenServiceClient} />;
 };

--- a/src/video-player/components/app.tsx
+++ b/src/video-player/components/app.tsx
@@ -71,6 +71,7 @@ export const baseAuthoringProps = {
       "ui:help": "Path to subtitles or captions, if available"
     },
     poster: {
+      "ui:widget": "imageUpload",
       "ui:help": "Path to a static image to display before video playback begins"
     },
     prompt: {


### PR DESCRIPTION
The new `authoring-image-upload` tool has been added to both the staging and production token-service resource list so this should work both on local Docker containers (defaults to staging), staging and production.

The final design I landed on was 1 upload folder per user.  This was we don't need to store resource ids anywhere - we just use the first `author-image-upload` resource found where the user is an owner and if none is found create one.