### PR TITLE
Fix multi-select MC questions set to single select on conversion.

### DIFF
--- a/src/convert-old-lara/convert.ts
+++ b/src/convert-old-lara/convert.ts
@@ -32,7 +32,7 @@ const convertMultipleChoice = (item: Record<string, any>, libraryInteractive: Re
     prompt: "prompt",
     enable_check_answer: "enableCheckAnswer",
     is_prediction: "required",
-    multi_answer: "multipleAnswer",
+    multi_answer: "multipleAnswers",
     hint: "hint",
     give_prediction_feedback: "customFeedback",
     prediction_feedback: "predictionFeedback"


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/178888327

[#178888327]

Fix incorrect property name value from `multipleAnswer` to `multipleAnswers`.