### PR TITLE
Fix videos and images in a converted activity have dimensions changed

### DIFF
--- a/src/convert-old-lara/convert.ts
+++ b/src/convert-old-lara/convert.ts
@@ -71,7 +71,8 @@ const convertImage = (item: Record<string, any>, libraryInteractive: Record<stri
     credit: item.embeddable.credit,
     creditLink: item.embeddable.credit_url,
     creditLinkDisplayText: "",
-    allowLightbox: true
+    allowLightbox: true,
+    scaling: "fitWidth"
   };
 
   item.embeddable.authored_state = JSON.stringify(authoredState);
@@ -121,7 +122,6 @@ const convertVideoPlayer = (item: Record<string, any>, libraryInteractive: Recor
     prompt: item.embeddable.caption,
     credit: item.embeddable.credit,
     creditLinkDisplayText: "",
-    fixedHeight: item.embeddable.height,
     fixedAspectRatio: "",
     poster: item.embeddable.poster_url
   };


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/178888877

[#178888877]

For videos: LARA sets a default height value of 240 for "LARA native" videos. The height value doesn't seem to be used anywhere, though, and the editing form doesn't seem to allow authors to change that value, either. In LARA runtime, it seems like videos are always shown with a width of 100%. A height isn't explicitly set. So I just removed the setting of a `fixedHeight` value when a video is converted to a QI video.

For images: QI images have a `scaling` property that LARA native images don't. It seems like LARA images also always take up the full width of their containers. So I changed it so the conversion script always set an image's `scaling` property to "fitWidth".