### PR TITLE
Video player should show first frame of video if no poster is specified

### DIFF
--- a/src/video-player/components/runtime.tsx
+++ b/src/video-player/components/runtime.tsx
@@ -168,7 +168,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   };
 
   const getPoster = () => {
-    if (!hasStartedPlayback) {
+    if (!hasStartedPlayback && authoredState.poster !== "") {
       return authoredState.poster;
     }
   };
@@ -190,6 +190,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
             onPause={readOnly ? undefined : handleStop}
             onSeeked={handleSeek}
             controls={!readOnly}
+            preload="metadata"
           />
         </div>
       </div>

--- a/src/video-player/components/runtime.tsx
+++ b/src/video-player/components/runtime.tsx
@@ -168,8 +168,9 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   };
 
   const getPoster = () => {
-    if (!hasStartedPlayback && authoredState.poster !== "") {
-      return authoredState.poster;
+    const poster = (authoredState.poster || "").trim();
+    if (!hasStartedPlayback && !!poster) {
+      return poster;
     }
   };
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/178889194

[#178889194]

Set video preload to "metadata" so browser retrieves the video's first frame. Also make sure `getPoster` doesn't return an empty value. (If it does return an empty value, the video player will show a black rectangle instead of the first frame. That can happen if a poster value is specified for the video, but then removed.)