### PR TITLE
Fixed two issues found during QA of image uploads:

### DIFF
--- a/src/drawing-tool/components/app.test.tsx
+++ b/src/drawing-tool/components/app.test.tsx
@@ -11,6 +11,9 @@ describe("validation helper", () => {
     baseAuthoringProps.validate({ version: 1, backgroundSource: "url", backgroundImageUrl: "https://aws.concord.org/img/123.png" }, errors);
     expect(errors.backgroundImageUrl.addError).not.toHaveBeenCalled();
 
+    baseAuthoringProps.validate({ version: 1, backgroundSource: "url", backgroundImageUrl: "https://token-service-files.s3.amazonaws.com/img/123.png" }, errors);
+    expect(errors.backgroundImageUrl.addError).not.toHaveBeenCalled();
+
     baseAuthoringProps.validate({ version: 1, backgroundSource: "upload", backgroundImageUrl: "malformed URL" }, errors);
     expect(errors.backgroundImageUrl.addError).not.toHaveBeenCalled(); // don't validate backgroundImageUrl when it's not used (bgSource = upload)
 
@@ -18,6 +21,6 @@ describe("validation helper", () => {
     expect(errors.backgroundImageUrl.addError).toHaveBeenCalledWith("Invalid background image URL."); // missing protocol
 
     baseAuthoringProps.validate({ version: 1, backgroundSource: "url", backgroundImageUrl: "https://aws.example.com/img/123.png" }, errors);
-    expect(errors.backgroundImageUrl.addError).toHaveBeenCalledWith("Please use only images hosted at *.concord.org.");
+    expect(errors.backgroundImageUrl.addError).toHaveBeenCalledWith("Please use only uploaded images or images hosted at *.concord.org.");
   });
 });

--- a/src/drawing-tool/components/app.tsx
+++ b/src/drawing-tool/components/app.tsx
@@ -269,8 +269,8 @@ export const baseAuthoringProps = {
     if (formData.backgroundImageUrl && formData.backgroundSource === "url") {
       try {
         const url = new URL(formData.backgroundImageUrl);
-        if (!url.host.match(/concord\.org/)) {
-          errors.backgroundImageUrl.addError(`Please use only images hosted at *.concord.org.`);
+        if (!url.host.match(/concord\.org/) && !url.host.match(/token-service-files\.s3\.amazonaws\.com/)) {
+          errors.backgroundImageUrl.addError(`Please use only uploaded images or images hosted at *.concord.org.`);
         }
       } catch (e) {
         errors.backgroundImageUrl.addError(`Invalid background image URL.`);

--- a/src/shared/utilities/s3-upload.test.ts
+++ b/src/shared/utilities/s3-upload.test.ts
@@ -65,4 +65,9 @@ describe("uniqueFilename", () => {
     expect(prefix.length).toEqual(32);
     expect(filename).toEqual("test.png");
   });
+
+  it("replaces spaces in the filename with dashes", () => {
+    const [prefix, ...rest] = uniqueFilename("   test filename   with   multiple spaces.png").split("-");
+    expect(rest.join("-")).toEqual("test-filename-with-multiple-spaces.png");
+  });
 });

--- a/src/shared/utilities/s3-upload.ts
+++ b/src/shared/utilities/s3-upload.ts
@@ -28,4 +28,4 @@ export const s3Upload = async ({client, credentials, filename, resource, body, c
   return client.getPublicS3Url(resource, filename);
 };
 
-export const uniqueFilename = (filename: string) => `${uuid().replace(/-/g, "")}-${filename}`;
+export const uniqueFilename = (filename: string) => `${uuid().replace(/-/g, "")}-${filename.trim().replace(/\s+/g, "-")}`;


### PR DESCRIPTION
- To pass the "uri" format validation spaces in the uploaded filename are converted and compressed down a single dash
- An additional check of the token-service domain was added to the image url validator