### PR TITLE
178168627 labbook fix qa issues

### DIFF
--- a/src/labbook/components/app.tsx
+++ b/src/labbook/components/app.tsx
@@ -26,6 +26,11 @@ const baseAuthoringProps = deepmerge(drawingToolBaseAuthoringProps, {
         type: "number",
         title: "How many thumbnails to display",
         default: 4
+      },
+      backgroundSource: {
+        title: "Background source",
+        type: "string",
+        default: "any"
       }
     }
   } as JSONSchema6,
@@ -44,6 +49,9 @@ const baseAuthoringProps = deepmerge(drawingToolBaseAuthoringProps, {
       "ui:widget": "hidden"
     },
     questionType: {
+      "ui:widget": "hidden"
+    },
+    backgroundSource: {
       "ui:widget": "hidden"
     }
   },

--- a/src/labbook/components/comment-field.scss
+++ b/src/labbook/components/comment-field.scss
@@ -16,6 +16,11 @@
     padding-left: 32px;
     font-family: Lato;
     flex: 1;
+    resize: vertical;
+    min-width: 313px;
+    max-width: 100%;
+    max-height: 100%;
+    min-height: 56px;
   }
 }
 

--- a/src/labbook/components/take-snapshot.tsx
+++ b/src/labbook/components/take-snapshot.tsx
@@ -55,10 +55,6 @@ export const TakeSnapshot: React.FC<IProps> = ({ authoredState, interactiveState
                 }
           </UploadButton>
       }
-      {
-        authoredState.snapshotTarget === undefined &&
-        <p>Snapshot won&apos;t work, as no target interactive is selected</p>
-      }
     </>
   );
 };

--- a/src/labbook/components/upload-button.scss
+++ b/src/labbook/components/upload-button.scss
@@ -9,6 +9,7 @@
   border: solid 1.5px var(--cc-charcoal-light-1);
   background-color: var(--cc-teal-light-5);
   font-family: Lato;
+  font-weight: normal;
   color: var(--cc-charcoal);
   &:hover {
     background-color: var(--cc-teal-light-4);


### PR DESCRIPTION

## QA Concerns addressed:
- Target will always be "any" meaning upload and snapshot.
- When a snapshot target is specified, the snaphot button appears.
- No warning text is displayed if the snapshot target attribute is missing.
- Upload and snapshot both use normal font-weight.
- Caption textbox is constrainted to vertical resizing, and will not resize out of the parent container.

## QA Concerned not addressed:
- When you take a snapshot or upload an image, both buttons say "Please wait" - intentional?   **YES** Intentional.
- When you upload an image, it doesn't appear as a thumbnail unless you draw on it. I am not sure this is true. It does take several seconds for the thumbnail to update however.

## PT Story:
[#178168627] -- https://www.pivotaltracker.com/story/show/178168627