### PR TITLE
Changed the labbook question type to "iframe_interactive" to fix the Athena report generation [#178454188]

### DIFF
--- a/src/labbook/components/app.tsx
+++ b/src/labbook/components/app.tsx
@@ -15,7 +15,7 @@ const baseAuthoringProps = deepmerge(drawingToolBaseAuthoringProps, {
       },
       questionType: {
         type: "string",
-        default: "labbook_interactive"
+        default: "iframe_interactive"
       },
       maxItems: {
         type: "number",

--- a/src/labbook/components/app.tsx
+++ b/src/labbook/components/app.tsx
@@ -13,10 +13,6 @@ const baseAuthoringProps = deepmerge(drawingToolBaseAuthoringProps, {
         type: "number",
         default: 1
       },
-      questionType: {
-        type: "string",
-        default: "iframe_interactive"
-      },
       maxItems: {
         type: "number",
         title: "Maximum number of lab book entries",


### PR DESCRIPTION
Labbook was using "labbook_interactive" which caused Athena to skip adding a link url to the details report.