### PR TITLE
Set answerImageUrl on sucess of save to the snapshorUrl initially created

### DIFF
--- a/src/drawing-tool/components/take-snapshot.tsx
+++ b/src/drawing-tool/components/take-snapshot.tsx
@@ -27,6 +27,7 @@ export const TakeSnapshot: React.FC<IProps> = ({ authoredState, interactiveState
         setInteractiveState?.(prevState => ({
           ...prevState,
           userBackgroundImageUrl: response.snapshotUrl,
+          answerImageUrl: response.snapshotUrl,
           answerType: getAnswerType(authoredState.questionType)
         }));
         onUploadComplete?.({ success: true });

--- a/src/image-question/components/runtime.tsx
+++ b/src/image-question/components/runtime.tsx
@@ -37,6 +37,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   const snapshotOrUploadFinished = ({ success }: { success: boolean }) => {
     setControlsHidden(false);
     if (success) {
+      console.log("image is uploaded. should open draw tool now");
       openDrawingToolDialog();
     }
   };
@@ -44,6 +45,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   const openDrawingToolDialog = () => {
     // notCloseable: true disabled click-to-close backdrop and X icon in the corner.
     // Dialog can be closed only via closeModal API.
+    console.log(" in openDrawingToolDialog, url: ", window.location.href + "?" + drawingToolDialogUrlParam);
     showModal({ type: "dialog", url: window.location.href + "?" + drawingToolDialogUrlParam, notCloseable: true });
   };
 

--- a/src/image-question/components/runtime.tsx
+++ b/src/image-question/components/runtime.tsx
@@ -37,7 +37,6 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   const snapshotOrUploadFinished = ({ success }: { success: boolean }) => {
     setControlsHidden(false);
     if (success) {
-      console.log("image is uploaded. should open draw tool now");
       openDrawingToolDialog();
     }
   };
@@ -45,7 +44,6 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   const openDrawingToolDialog = () => {
     // notCloseable: true disabled click-to-close backdrop and X icon in the corner.
     // Dialog can be closed only via closeModal API.
-    console.log(" in openDrawingToolDialog, url: ", window.location.href + "?" + drawingToolDialogUrlParam);
     showModal({ type: "dialog", url: window.location.href + "?" + drawingToolDialogUrlParam, notCloseable: true });
   };
 


### PR DESCRIPTION
Currently, if a student clicks on the Take Snapshot button, which opens the draw tool with the interactive as the background image, and then closes the tab without closing the draw tool, the answer imageUrl is not set. This causes the portal report to show blank answers for the student, even though they think they have taken the snapshot.
This PR assigns answer imageUrl on click of the Take Snapshot button instead of on close of the draw tool. We will assume that the intent of the student was at least to take a snapshot of the current state of their interactive. This way there is always an answer imageUrl for the portal report.