### PR TITLE
Fix adding empty line in prompt prevents prompt from saving

### DIFF
--- a/src/shared/widgets/rich-text/rich-text-widget.tsx
+++ b/src/shared/widgets/rich-text/rich-text-widget.tsx
@@ -10,9 +10,9 @@ const kThemeColor = "#34a5be";
 function exportHtml(value: any) {
   const html = slateToHtml(value);
   // convert empty paragraph to empty string
-  return (/<p>\s*<\/p>/i.test(html))
-          ? ""
-          : html;
+  const emptyParagraphsRegex = /<p>\s*<\/p>/gi;
+  const cleanedHTML = html.replace(emptyParagraphsRegex, "");
+  return cleanedHTML;
 }
 
 export const RichTextWidget = (props: WidgetProps) => {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/176574924

The `exportHTML` method was returning an empty string if an empty paragraph was found in the provided HTML. These changes make sure it returns the complete HTML minus the empty paragraphs.