### PR TITLE
Tweak GitHub actions configuration to specify node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
       - name: Install Dependencies
         run: npm ci
       - name: Build
@@ -33,6 +35,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
       - uses: cypress-io/github-action@v2
         with:
           start: npm start
@@ -64,6 +69,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ### Local development setup:
 
-1. At the moment there is no way to preview your components in isolation. You will need to **create a new Library Interactive in your local LARA instance** to develop in this repo. You could also create a Library Interactive on the staging server, but you should clean up after yourself, so that we don't end up with a lot of `https://localhost/` development references on the staging server.
+1. At the moment there is no way to preview your components in isolation. You will need to **create a new Library Interactive in your local LARA instance** to develop in this repo. You could also create a Library Interactive on the staging server, but you should clean up after yourself so that we don't end up with a lot of `https://localhost/` development references on the staging server.
 2. The `Base URL` of your Library interactive will be something like: `http://localhost:8080/<your component directory>/` where your component directory would be something like `open-response`. That should point to the top-level index of your component, e.g. `open-response/index.tsx`.
 3. You will probably want to check the `Save Interactive State` checkbox, and possibly the checkbox for `Interactive provides an authoring UI.`
 
@@ -69,7 +69,7 @@ npm run lara-api:unlink    # removes the global symlink
 
 ## Deployment
 
-Production releases to S3 are based on the contents of the /dist folder and are built automatically by Travis
+Production releases to S3 are based on the contents of the `/dist` folder and are built automatically by Travis
 for each branch pushed to GitHub and each merge into production.
 
 Merges into production are deployed to https://models-resources.concord.org/question-interactives.


### PR DESCRIPTION
Specify node 14 in `ci.yml` since cypress tests were failing under node 16. Presumably this could also be fixed by updating some dependencies but that can wait for another day.