### PR TITLE
Open Response default text should stay

### DIFF
--- a/cypress/integration/open-response.test.js
+++ b/cypress/integration/open-response.test.js
@@ -30,7 +30,7 @@ context("Test open response interactive", () => {
 
       cy.getIframeBody().find("#app fieldset legend").should("include.text", "Test prompt");
 
-      cy.getIframeBody().find("textarea").should("have.attr", "placeholder", "Default answer");
+      cy.getIframeBody().find("textarea").should("have.attr", "placeholder", "Please type your answer here.");
       cy.getIframeBody().find("textarea").should("have.value", "Test response");
     });
 
@@ -46,10 +46,10 @@ context("Test open response interactive", () => {
         }
       });
       phoneListen("interactiveState");
-
-      cy.getIframeBody().find("textarea").type("test answer");
+      cy.getIframeBody().find("textarea").should("have.value", "Default answer");
+      cy.getIframeBody().find("textarea").type(". Test answer");
       getAndClearLastPhoneMessage((state) => {
-        expect(state).eql({ answerType: "open_response_answer", answerText: "test answer" });
+        expect(state).eql({ answerType: "open_response_answer", answerText: "Default answer. Test answer" });
       });
     });
   });
@@ -63,7 +63,7 @@ context("Test open response interactive", () => {
           version: 1,
           prompt: "Test prompt",
           hint: "Hint",
-          defaultAnswer: "Default answer",
+          defaultAnswer: "",
           required: true,
           predictionFeedback: "Good guess"
         }
@@ -154,7 +154,7 @@ context("Test open response interactive", () => {
 
       cy.getIframeBody().find("#app").should("include.text", "Test prompt");
 
-      cy.getIframeBody().find("textarea").should("have.attr", "placeholder", "Default answer");
+      cy.getIframeBody().find("textarea").should("have.attr", "placeholder", "Please type your answer here.");
       cy.getIframeBody().find("textarea").should("have.value", "Test response");
 
       cy.getIframeBody().find("textarea").type("New answer", { force: true });

--- a/src/open-response/components/runtime.tsx
+++ b/src/open-response/components/runtime.tsx
@@ -11,6 +11,8 @@ interface IProps extends IRuntimeQuestionComponentProps<IAuthoredState, IInterac
 
 export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, report }) => {
   const readOnly = report || (authoredState.required && interactiveState?.submitted);
+  const placeholderText = "Please type your answer here.";
+  const answerText = !interactiveState?.answerText ? authoredState.defaultAnswer : interactiveState.answerText;
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     setInteractiveState?.(prevState => ({...prevState, answerType: "open_response_answer", answerText: event.target.value }));
   };
@@ -25,12 +27,12 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
         </DecorateChildren> }
       <div>
         <textarea
-          value={interactiveState?.answerText}
+          value={answerText}
           onChange={readOnly ? undefined : handleChange}
           readOnly={readOnly}
           disabled={readOnly}
           rows={8}
-          placeholder={authoredState.defaultAnswer || "Please type your answer here."}
+          placeholder={placeholderText}
         />
       </div>
     </fieldset>


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/180721068

[#180721068]

These changes put `defaultAnswer` content (when present) into the textarea's `value` property instead of its `placeholder` property. Default answer content is meant to remain as part of the student's response instead of being a temporary placeholder.