### PR TITLE
Fix TE correct & distractor markers don't line up with radio buttons

### DIFF
--- a/src/multiple-choice/components/runtime.scss
+++ b/src/multiple-choice/components/runtime.scss
@@ -18,6 +18,7 @@ legend.prompt {     // clear bootstrap stuff
 
   &.vertical {
     div {
+      align-items: flex-start;
       display: flex;
     }
   }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/180414126

[#180414126]

This fixes a bug viewable only in Firefox where Teacher Edition correct and distractor markers for multiple choice questions don't line up correctly with their associated radio buttons.

(The missing question number heading in the local AP screen grab below is an issue unrelated to the change made in this PR.)

![image](https://user-images.githubusercontent.com/367459/149412710-aa171e88-f62c-422e-9068-1d074eb61447.png)

