### PR TITLE
Changes video player name in conversion script to match template doc

### DIFF
--- a/src/convert-old-lara/convert.ts
+++ b/src/convert-old-lara/convert.ts
@@ -346,7 +346,7 @@ const convert = async (laraResource: string, laraRoot: string, libraryInteractiv
     "multiple_choice": "Multiple Choice",
     "open_response": "Open Response",
     "image": "Image Interactive",
-    "video": "Video player",
+    "video": "Video Player",
     "image_question": "Image Question"
   };
 

--- a/src/convert-old-lara/convert.ts
+++ b/src/convert-old-lara/convert.ts
@@ -119,6 +119,7 @@ const convertVideoPlayer = (item: Record<string, any>, libraryInteractive: Recor
     version: 1,
     questionType: "iframe_interactive",
     videoUrl: videoSource,
+    description: item.embeddable.prompt,
     caption: item.embeddable.caption,
     credit: item.embeddable.credit,
     creditLinkDisplayText: "",
@@ -345,7 +346,7 @@ const convert = async (laraResource: string, laraRoot: string, libraryInteractiv
     "multiple_choice": "Multiple Choice",
     "open_response": "Open Response",
     "image": "Image Interactive",
-    "video": "Video Player",
+    "video": "Video player",
     "image_question": "Image Question"
   };
 

--- a/src/video-player/components/types.ts
+++ b/src/video-player/components/types.ts
@@ -7,6 +7,7 @@ export interface IAuthoredState extends IAuthoringInteractiveMetadata {
   version: number;
   videoUrl?: string;
   captionUrl?: string;
+  description?: string;
   poster?: string;
   caption?: string;
   credit?: string;


### PR DESCRIPTION
There's was a problem with how the question interactives conversion script was converting videos. Template document was pointing the the wrong interactive during conversion, and names didn't match type map and so script was not seeing the template. This fix makes the conversion script match the template activity.