### PR TITLE
 Support interactiveApi with the full-screen Scaling interactive [#181103123]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2530,9 +2530,9 @@
       }
     },
     "@concord-consortium/lara-interactive-api": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.1.0.tgz",
-      "integrity": "sha512-skNR306/b7ScP6+7SfSmjeTMgtRFetMsnutnFj4imvwUIpKc3yFVMxRXIreGwP5jeCUK0c+Utvy99/foa7Mynw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.5.0.tgz",
+      "integrity": "sha512-+p9XjiyKLWIIH6HWaSwlGnKi+GXEorSE4UYWTAeXUw6ZkeQv9UGue3MORNUpH1iI5pkn+RxRy2kyUucn4CsjWg==",
       "requires": {
         "iframe-phone": "^1.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.19.0",
-    "@concord-consortium/lara-interactive-api": "^1.1.0",
+    "@concord-consortium/lara-interactive-api": "^1.5.0",
     "@concord-consortium/slate-editor": "^0.7.3",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@concord-consortium/token-service": "^2.0.0",

--- a/src/full-screen/components/runtime.tsx
+++ b/src/full-screen/components/runtime.tsx
@@ -93,7 +93,7 @@ export const Runtime: React.FC = () => {
 
   if (!subinteractiveUrl) {
     return <div>No sub items available. Please add them using the authoring interface.</div>;
-  } else {
+  } else if (initMessage) {
     return (
       <>
         <IframeRuntime url={subinteractiveUrl}
@@ -101,10 +101,13 @@ export const Runtime: React.FC = () => {
                        interactiveState={interactiveState}
                        setInteractiveState={setInteractiveState}
                        setHint={setHint}
+                       initMessage={initMessage}
         />
         {screenfull &&
           <FullScreenButton isFullScreen={screenfull.isFullscreen} handleToggleFullScreen={toggleFullScreen} />}
       </>
     );
+  } else {
+    return <div>Loading...</div>;
   }
 };

--- a/src/full-screen/components/runtime.tsx
+++ b/src/full-screen/components/runtime.tsx
@@ -90,8 +90,7 @@ export const Runtime: React.FC = () => {
   if (!wrappedInteractive) {
     return <div>No sub items available. Please add them using the authoring interface.</div>;
   } else {
-    const shared = queryString.parse(location.hash)?.shared;
-    const url = `${wrappedInteractive}${shared ? `#shared=${shared}` : ""}`;
+    const url = Array.isArray(wrappedInteractive) ? wrappedInteractive[0] : wrappedInteractive;
 
     return (
       <>

--- a/src/full-screen/components/runtime.tsx
+++ b/src/full-screen/components/runtime.tsx
@@ -85,29 +85,25 @@ export const Runtime: React.FC = () => {
 
   const iframeStyle = setScaling();
 
-  const params = queryString.parse(location.search);
-  const hash = queryString.parse(location.hash);
-  const sharedDoc = hash.shared ? "#shared="+hash.shared : "";
-  const preUrl = params?.wrappedInteractive + sharedDoc;
-  const subinteractiveUrl = preUrl && encodeURI(preUrl);
+  const wrappedInteractive = queryString.parse(location.search)?.wrappedInteractive;
 
-  if (!subinteractiveUrl) {
+  if (!wrappedInteractive) {
     return <div>No sub items available. Please add them using the authoring interface.</div>;
-  } else if (initMessage) {
+  } else {
+    const shared = queryString.parse(location.hash)?.shared;
+    const url = `${wrappedInteractive}${shared ? `#shared=${shared}` : ""}`;
+
     return (
       <>
-        <IframeRuntime url={subinteractiveUrl}
+        <IframeRuntime url={url}
                        iframeStyling={iframeStyle}
                        interactiveState={interactiveState}
                        setInteractiveState={setInteractiveState}
                        setHint={setHint}
-                       initMessage={initMessage}
         />
         {screenfull &&
           <FullScreenButton isFullScreen={screenfull.isFullscreen} handleToggleFullScreen={toggleFullScreen} />}
       </>
     );
-  } else {
-    return <div>Loading...</div>;
   }
 };

--- a/src/full-screen/components/runtime.tsx
+++ b/src/full-screen/components/runtime.tsx
@@ -100,6 +100,7 @@ export const Runtime: React.FC = () => {
                        interactiveState={interactiveState}
                        setInteractiveState={setInteractiveState}
                        setHint={setHint}
+                       initMessage={initMessage}
         />
         {screenfull &&
           <FullScreenButton isFullScreen={screenfull.isFullscreen} handleToggleFullScreen={toggleFullScreen} />}

--- a/src/shared/components/iframe-runtime.tsx
+++ b/src/shared/components/iframe-runtime.tsx
@@ -93,14 +93,16 @@ export const IframeRuntime: React.FC<IProps> =
         linkedInteractives = [ {id: authoredState[libraryInteractive.localLinkedInteractiveProp], label: libraryInteractive.localLinkedInteractiveProp} ];
       }
 
-      phone.post("initInteractive", {
+      const initInteractiveMessage = {
         ...initMessage,   // for now only fullscreen sets this prop so that the needed info for cfm interactiveApi is passed
         mode: report ? "report" : "runtime",
         authoredState,
         // This is a trick not to depend on interactiveState.
         interactiveState: interactiveStateRef.current,
         linkedInteractives
-      });
+      };
+
+      phone.post("initInteractive", initInteractiveMessage);
     };
 
     if (iframeRef.current) {

--- a/src/shared/components/iframe-runtime.tsx
+++ b/src/shared/components/iframe-runtime.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { renderHTML } from "../../shared/utilities/render-html";
 import { IframePhone } from "../types";
 import iframePhone from "iframe-phone";
-import { closeModal, IAddLinkedInteractiveStateListenerRequest, ICloseModal, IHintRequest, IShowModal, log, showModal } from "@concord-consortium/lara-interactive-api";
+import { closeModal, IAddLinkedInteractiveStateListenerRequest, ICloseModal, IHintRequest, IInitInteractive, IShowModal, log, showModal } from "@concord-consortium/lara-interactive-api";
 import { getLibraryInteractive } from "../utilities/library-interactives";
 import css from "./iframe-runtime.scss";
 
@@ -20,6 +20,7 @@ interface IProps {
   logRequestData?: Record<string, unknown>;
   report?: boolean;
   url: string;
+  initMessage?: IInitInteractive | null;
   setInteractiveState: (state: any) => void | null;
   setHint?: (state: any) => void | null;
   addLocalLinkedDataListener?: (request: IAddLinkedInteractiveStateListenerRequest, phone: IframePhone) => void;
@@ -27,7 +28,7 @@ interface IProps {
 
 export const IframeRuntime: React.FC<IProps> =
   ({ authoredState, id, iframeStyling, interactiveState, logRequestData, report,
-      url, setHint, setInteractiveState, addLocalLinkedDataListener }) => {
+      url, setHint, setInteractiveState, addLocalLinkedDataListener, initMessage }) => {
     const [ iframeHeight, setIframeHeight ] = useState(300);
     const [ internalHint, setInternalHint ] = useState("");
     const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -91,7 +92,9 @@ export const IframeRuntime: React.FC<IProps> =
       if (libraryInteractive?.localLinkedInteractiveProp && authoredState?.[libraryInteractive.localLinkedInteractiveProp]) {
         linkedInteractives = [ {id: authoredState[libraryInteractive.localLinkedInteractiveProp], label: libraryInteractive.localLinkedInteractiveProp} ];
       }
+
       phone.post("initInteractive", {
+        ...initMessage,   // for now only fullscreen sets this prop so that the needed info for cfm interactiveApi is passed
         mode: report ? "report" : "runtime",
         authoredState,
         // This is a trick not to depend on interactiveState.
@@ -112,7 +115,7 @@ export const IframeRuntime: React.FC<IProps> =
         phoneRef.current.disconnect();
       }
     };
-  },[addLocalLinkedDataListener, authoredState, logRequestData, report, setHint, url]);
+  },[addLocalLinkedDataListener, authoredState, logRequestData, report, setHint, url, initMessage]);
 
   const iframeStyle = iframeStyling ?? {width: "100%", height: iframeHeight, border: "none"};
   return (


### PR DESCRIPTION
This change upgrades the lara client client to the current version and passes the full initInteractive message passed by AP to the fullscreen interactive mixed in with the current initMessage the fullscreen interactive creates.  The interactiveApi in CFM needs the info in the full message.

It was decided in this PR to only address the fullscreen interactive.  This same init message passing may need to be done for the other interactives that use the iframe-runtime container.