### PR TITLE
Added version.json generation in webpack.

### DIFF
--- a/generate-version-json.js
+++ b/generate-version-json.js
@@ -1,0 +1,13 @@
+const {name, version , description} = require('./package.json');
+
+const now = new Date();
+
+module.exports = () => {
+  return {
+    name,
+    version,
+    description,
+    buildDate: now.toString(),
+    buildTimestamp: now.getTime()
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -11400,6 +11400,12 @@
         "json-bigint": "^1.0.0"
       }
     },
+    "generate-json-from-js-webpack-plugin": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/generate-json-from-js-webpack-plugin/-/generate-json-from-js-webpack-plugin-0.1.1.tgz",
+      "integrity": "sha512-y3fzWC8/OrsR4/KVXNx/XsCGQ5C1l3e0obNm+pWAKuvPuKo6IiYLJX0Vtp5J8AelkkM+jHDt0kElII3s2CvvzA==",
+      "dev": true
+    },
     "gensync": {
       "version": "1.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "eslint-plugin-react": "^7.20.6",
     "eslint-plugin-react-hooks": "^4.1.0",
     "file-loader": "^6.0.0",
+    "generate-json-from-js-webpack-plugin": "^0.1.1",
     "html-webpack-plugin": "^4.3.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.4.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,8 @@
 
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const GenerateJsonFromJsPlugin = require('generate-json-from-js-webpack-plugin');
+
 const path = require("path");
 
 module.exports = (env, argv) => {
@@ -216,6 +218,11 @@ module.exports = (env, argv) => {
         chunks: ['wrapper'],
         filename: 'wrapper.html',
         template: 'src/shared/wrapper.html'
+      }),
+      // generate version.json
+      new GenerateJsonFromJsPlugin({
+        path: './generate-version-json.js',
+        filename: 'version.json'
       })
     ]
   };


### PR DESCRIPTION
This is so we can see which version is live in the root production deploy either manually or programmatically.

This generates a root level file at compile time containing the following information pulled either from the package.json file or the current date:

- name
- version
- description
- buildDate (human readable)
- buildTimestamp (unix timestamp)

**UPDATE**

Here is the generated version.json for this branch:

https://models-resources.concord.org/question-interactives/branch/generate-version-json/version.json