### PR TITLE
Fix drag-and-drop interactive does not look correct in report/dashboard.

### DIFF
--- a/cypress/integration/drag-and-drop.test.js
+++ b/cypress/integration/drag-and-drop.test.js
@@ -96,4 +96,36 @@ context("Test drag and drop interactive", () => {
       }, 100);
     });
   });
+
+  context("Report view", () => {
+    it("handles pre-existing authored state, scales interactive, and does not include prompt", () => {
+      phonePost("initInteractive", {
+        mode: "report",
+        authoredState: {
+          version: 1,
+          prompt: "Test prompt",
+          draggingAreaPrompt: "Test dragging area prompt",
+          hint: "",
+          canvasWidth: 400,
+          canvasHeight: 400,
+          backgroundImageUrl: "https://placekitten.com/200/200",
+          draggableItems: [
+            {id: "1", imageUrl: "https://placekitten.com/40/40"},
+            {id: "2", imageUrl: "https://placekitten.com/60/60"}
+          ]
+        },
+        interactiveState: {
+          itemPositions: {
+            "1": {left: 30, top: 30},
+            "2": {left: 70, top: 70},
+          }
+        }
+      });
+
+      cy.getIframeBody().find("#app").should("not.include.text", "Prompt");
+      cy.getIframeBody().find("[data-cy='dnd-container']").should("have.attr", "style", "width: 400px; height: 400px; background-image: url(\"https://placekitten.com/200/200\"); transform: scale(0.625); transform-origin: left top;");
+      cy.getIframeBody().find("[data-cy='draggable-item-wrapper']").eq(0).should("have.attr", "style", "left: 30px; top: 30px;");
+      cy.getIframeBody().find("[data-cy='draggable-item-wrapper']").eq(1).should("have.attr", "style", "left: 70px; top: 70px;");
+    });
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2530,9 +2530,9 @@
       }
     },
     "@concord-consortium/lara-interactive-api": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.5.0.tgz",
-      "integrity": "sha512-+p9XjiyKLWIIH6HWaSwlGnKi+GXEorSE4UYWTAeXUw6ZkeQv9UGue3MORNUpH1iI5pkn+RxRy2kyUucn4CsjWg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.5.1.tgz",
+      "integrity": "sha512-+oVyTop3EnoNbXjvX8bfxsEi9j9erd0DRP1u8bbmghr6C7W3r7s4m4cY6+OJroeitobiPRCkfhCgdfzVz9KBIw==",
       "requires": {
         "iframe-phone": "^1.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.19.0",
-    "@concord-consortium/lara-interactive-api": "^1.5.0",
+    "@concord-consortium/lara-interactive-api": "^1.5.1",
     "@concord-consortium/slate-editor": "^0.7.3",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@concord-consortium/token-service": "^2.0.0",

--- a/src/drag-and-drop/components/container.tsx
+++ b/src/drag-and-drop/components/container.tsx
@@ -13,7 +13,7 @@ import { cssUrlValue } from "../../shared/utilities/css-url-value";
 export interface IProps extends IRuntimeQuestionComponentProps<IAuthoredState, IInteractiveState> {
   // Used only for authoring (initial state is part of the authored state).
   setInitialState?: (initialState: IInitialState) => void;
-  view?: string;
+  view?: "standalone";
 }
 
 interface IDimensions {

--- a/src/drag-and-drop/components/container.tsx
+++ b/src/drag-and-drop/components/container.tsx
@@ -13,6 +13,7 @@ import { cssUrlValue } from "../../shared/utilities/css-url-value";
 export interface IProps extends IRuntimeQuestionComponentProps<IAuthoredState, IInteractiveState> {
   // Used only for authoring (initial state is part of the authored state).
   setInitialState?: (initialState: IInitialState) => void;
+  view?: string;
 }
 
 interface IDimensions {
@@ -56,13 +57,16 @@ const getTargetTop = (
   return top;
 };
 
-export const Container: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, setInitialState, report }) => {
+export const Container: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, setInitialState, report, view }) => {
   const readOnly = !!(report || (authoredState.required && interactiveState?.submitted));
   const [ itemDimensions, setItemDimensions ] = useState<Record<ItemId, IDimensions>>({});
   const [ targetDimensions, setTargetDimensions ] = useState<Record<TargetId, IDimensions>>({});
   const draggingAreaPromptRef = useRef<HTMLDivElement>(null);
   const canvasWidth = authoredState.canvasWidth || 330;
   const canvasHeight = authoredState.canvasHeight || 300;
+  const xScaleRatioForReport = canvasWidth > 338 ? 338/canvasWidth : 1;
+  const yScaleRatioForReport = canvasHeight > 250 ? 250/canvasHeight : 1;
+  const scaleRatioForReport = Math.min(xScaleRatioForReport, yScaleRatioForReport);
   const draggingAreaPromptHeight = draggingAreaPromptRef.current?.offsetHeight || 0;
   // There are 2 sources from where item positions can be obtained. Note that order is very important here.
   const itemPositions: Record<string, IPosition> = {
@@ -226,7 +230,9 @@ export const Container: React.FC<IProps> = ({ authoredState, interactiveState, s
   const draggingAreaStyle = {
     width: canvasWidth + "px",
     height: canvasHeight + "px",
-    backgroundImage: authoredState.backgroundImageUrl ? cssUrlValue(authoredState.backgroundImageUrl) : undefined
+    backgroundImage: authoredState.backgroundImageUrl ? cssUrlValue(authoredState.backgroundImageUrl) : undefined,
+    transform: report && view !== "standalone" ? `scale(${scaleRatioForReport})` : undefined,
+    transformOrigin: report && view !== "standalone" ? "left top" : undefined
   };
 
   return (

--- a/src/drag-and-drop/components/runtime.tsx
+++ b/src/drag-and-drop/components/runtime.tsx
@@ -4,17 +4,10 @@ import { IAuthoredState, IInteractiveState } from "./types";
 import { renderHTML } from "../../shared/utilities/render-html";
 import { ContainerWithDndProvider } from "./container-with-dnd-provider";
 
-interface IProps extends IRuntimeQuestionComponentProps<IAuthoredState, IInteractiveState> {
-  view?: string;
-}
+interface IProps extends IRuntimeQuestionComponentProps<IAuthoredState, IInteractiveState> {}
 
 export const Runtime: React.FC<IProps> = (props) => {
-  const { authoredState, report } = props;
-  const urlParams = new URLSearchParams(window.location.search);
-  const view = urlParams.get("view");
-  if (view) {
-    props  = {...props, view: view};
-  }
+  const { authoredState, report, view } = props;
   return (
     <div>
       <div>{(!report || view === "standalone") && renderHTML(authoredState.prompt || "")}</div>

--- a/src/drag-and-drop/components/runtime.tsx
+++ b/src/drag-and-drop/components/runtime.tsx
@@ -4,12 +4,20 @@ import { IAuthoredState, IInteractiveState } from "./types";
 import { renderHTML } from "../../shared/utilities/render-html";
 import { ContainerWithDndProvider } from "./container-with-dnd-provider";
 
-interface IProps extends IRuntimeQuestionComponentProps<IAuthoredState, IInteractiveState> {}
+interface IProps extends IRuntimeQuestionComponentProps<IAuthoredState, IInteractiveState> {
+  view?: string;
+}
 
 export const Runtime: React.FC<IProps> = (props) => {
+  const { authoredState, report } = props;
+  const urlParams = new URLSearchParams(window.location.search);
+  const view = urlParams.get("view");
+  if (view) {
+    props  = {...props, view: view};
+  }
   return (
     <div>
-      <div>{renderHTML(props.authoredState.prompt || "")}</div>
+      <div>{(!report || view === "standalone") && renderHTML(authoredState.prompt || "")}</div>
       <ContainerWithDndProvider {...props} />
     </div>
   );

--- a/src/shared/components/base-question-app.tsx
+++ b/src/shared/components/base-question-app.tsx
@@ -7,7 +7,8 @@ import { BaseAuthoring, IBaseAuthoringProps } from "./base-authoring";
 import { SubmitButton } from "./submit-button";
 import { LockedInfo } from "./locked-info";
 import {
-  IAuthoringMetadata, IRuntimeMetadata, setSupportedFeatures, useAuthoredState, useInitMessage, useInteractiveState
+  IAuthoringMetadata, IRuntimeMetadata, setSupportedFeatures, useAuthoredState, useInitMessage, useInteractiveState,
+  IReportInitInteractive
 } from "@concord-consortium/lara-interactive-api";
 import { IBaseAuthoredState, UpdateFunc, IAuthoringComponentProps, IRuntimeComponentProps } from "./base-app";
 import { useBasicLogging } from "../hooks/use-basic-logging";
@@ -30,7 +31,7 @@ export interface IRuntimeQuestionComponentProps<IAuthoredState, IInteractiveStat
   interactiveState?: IInteractiveState | null,
   setInteractiveState?: (updateFunc: UpdateFunc<IInteractiveState>) => void;
   report?: boolean;
-  view?: string;
+  view?: "standalone";
 }
 
 interface IProps<IAuthoredState, IInteractiveState> {
@@ -112,12 +113,14 @@ export const BaseQuestionApp = <IAuthoredState extends IAuthoringMetadata & IBas
   };
 
   const renderReport = () => {
+    const reportInitMessage = initMessage as IReportInitInteractive;
+    const view = reportInitMessage?.view;
     if (!authoredState) {
       return "Authored state is missing.";
     }
     return (
       <div className={css.runtime}>
-        <Runtime authoredState={authoredState} interactiveState={interactiveState} setInteractiveState={setInteractiveState} report={true} view={initMessage?.view} />
+        <Runtime authoredState={authoredState} interactiveState={interactiveState} setInteractiveState={setInteractiveState} report={true} view={view} />
         { authoredState?.required && <div>Question has been { interactiveState?.submitted ? "" : "NOT" } submitted.</div> }
       </div>
     );

--- a/src/shared/components/base-question-app.tsx
+++ b/src/shared/components/base-question-app.tsx
@@ -30,6 +30,7 @@ export interface IRuntimeQuestionComponentProps<IAuthoredState, IInteractiveStat
   interactiveState?: IInteractiveState | null,
   setInteractiveState?: (updateFunc: UpdateFunc<IInteractiveState>) => void;
   report?: boolean;
+  view?: string;
 }
 
 interface IProps<IAuthoredState, IInteractiveState> {
@@ -116,7 +117,7 @@ export const BaseQuestionApp = <IAuthoredState extends IAuthoringMetadata & IBas
     }
     return (
       <div className={css.runtime}>
-        <Runtime authoredState={authoredState} interactiveState={interactiveState} setInteractiveState={setInteractiveState} report={true} />
+        <Runtime authoredState={authoredState} interactiveState={interactiveState} setInteractiveState={setInteractiveState} report={true} view={initMessage?.view} />
         { authoredState?.required && <div>Question has been { interactiveState?.submitted ? "" : "NOT" } submitted.</div> }
       </div>
     );


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/181154848

[#181154848]

When the drag-and-drop interactive is being displayed within a teacher dashboard or report, it will be scaled to fit the confines of its container and not display its prompt. If the optional `view` URL param is present and set to "standalone", the interactive should not be scaled and its prompt should be displayed.

These changes go along with [these changes to portal-report](https://github.com/concord-consortium/portal-report/pull/377) and [these changes in LARA](https://github.com/concord-consortium/lara/pull/909).