### PR TITLE
Fix question text cut off when image appears in question prompt

### DIFF
--- a/src/image-question/components/runtime.scss
+++ b/src/image-question/components/runtime.scss
@@ -5,6 +5,11 @@ legend.prompt { // clear bootstrap stuff
   font-size: unset;
   border: unset;
   padding-bottom: 5px;
+
+  img {
+    height: auto;
+    max-width: 100%;
+  }
 }
 
 .answerPrompt {

--- a/src/multiple-choice-alerts/components/runtime.scss
+++ b/src/multiple-choice-alerts/components/runtime.scss
@@ -13,6 +13,11 @@ legend.prompt {     // clear bootstrap stuff
   font-size: unset;
   border: unset;
   padding-bottom: 5px;
+
+  img {
+    height: auto;
+    max-width: 100%;
+  }
 }
 
 .choices {

--- a/src/multiple-choice/components/runtime.scss
+++ b/src/multiple-choice/components/runtime.scss
@@ -7,6 +7,11 @@ legend.prompt {     // clear bootstrap stuff
   font-size: unset;
   border: unset;
   padding-bottom: 5px;
+
+  img {
+    height: auto;
+    max-width: 100%;
+  }
 }
 
 .choices {

--- a/src/open-response/components/runtime.scss
+++ b/src/open-response/components/runtime.scss
@@ -5,4 +5,9 @@ legend.prompt {     // clear bootstrap stuff
   font-size: unset;
   border: unset;
   padding-bottom: 5px;
+
+  img {
+    height: auto;
+    max-width: 100%;
+  }
 }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/181427575

[#181427575]

Adds style rules to ensure images in an interactive's prompt text will not be wider than their container. This will prevent large images from causing interactive content to be cut off by a narrow containing column. 

It's possible the `height: auto` rule will prevent authors from setting an image to a specific height, but I think it's unlikely authors will need to do that. And it's probably more important to maintain an image's aspect ratio so it doesn't get distorted.

![image](https://user-images.githubusercontent.com/367459/156453772-412ada18-fe8f-4645-823d-d2221eac7993.png)

