### PR TITLE
Add support for "report" render mode in BaseApp.

### DIFF
--- a/src/shared/components/base-app.tsx
+++ b/src/shared/components/base-app.tsx
@@ -86,6 +86,7 @@ export const BaseApp = <IAuthoredState extends IBaseAuthoredState>(props: IProps
       case "authoring":
         return renderAuthoring();
       case "runtime":
+      case "report":
         return renderRuntime();
       default:
         return "Loading...";

--- a/src/shared/components/base-question-app.tsx
+++ b/src/shared/components/base-question-app.tsx
@@ -28,7 +28,7 @@ interface IBaseQuestionInteractiveState {
 }
 
 export interface IRuntimeQuestionComponentProps<IAuthoredState, IInteractiveState> extends IRuntimeComponentProps<IAuthoredState> {
-  interactiveState?: IInteractiveState | null,
+  interactiveState?: IInteractiveState | null;
   setInteractiveState?: (updateFunc: UpdateFunc<IInteractiveState>) => void;
   report?: boolean;
   view?: "standalone";


### PR DESCRIPTION
PT Stories:

https://www.pivotaltracker.com/story/show/181220233
https://www.pivotaltracker.com/story/show/181154948

[#181220233]
[#181154948]

This adds support for a "report" view to BaseApp. Without it, the graph interactive never loads in reports. (Also fixes a small typo.)