### PR TITLE
Fix snapshot content is blank

### DIFF
--- a/src/drawing-tool/components/take-snapshot.tsx
+++ b/src/drawing-tool/components/take-snapshot.tsx
@@ -5,6 +5,7 @@ import cssHelpers from "../../shared/styles/helpers.scss";
 import CameraIcon from "../../shared/icons/camera.svg";
 import { getInteractiveSnapshot } from "@concord-consortium/lara-interactive-api";
 import { getAnswerType, IGenericAuthoredState, IGenericInteractiveState } from "./types";
+import { useLinkedInteractiveId } from "../../shared/hooks/use-linked-interactive-id";
 
 export interface IProps {
   authoredState: IGenericAuthoredState; // so it works with DrawingTool and ImageQuestion
@@ -16,12 +17,14 @@ export interface IProps {
 
 export const TakeSnapshot: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, onUploadStart, onUploadComplete }) => {
   const [ snapshotInProgress, setSnapshotInProgress ] = useState(false);
+  const snapshotTarget = useLinkedInteractiveId("snapshotTarget");
 
   const handleSnapshot = async () => {
-    if (authoredState.snapshotTarget) {
+
+    if (snapshotTarget) {
       onUploadStart?.();
       setSnapshotInProgress(true);
-      const response = await getInteractiveSnapshot({ interactiveItemId: authoredState.snapshotTarget });
+      const response = await getInteractiveSnapshot({ interactiveItemId: snapshotTarget });
       setSnapshotInProgress(false);
       if (response.success && response.snapshotUrl) {
         setInteractiveState?.(prevState => ({
@@ -41,14 +44,14 @@ export const TakeSnapshot: React.FC<IProps> = ({ authoredState, interactiveState
   return (
     <>
       {
-        authoredState.snapshotTarget &&
+        snapshotTarget &&
         <button className={cssHelpers.apButton} onClick={handleSnapshot} disabled={snapshotInProgress} data-test="snapshot-btn">
           <CameraIcon className={cssHelpers.smallIcon} /> { interactiveState?.userBackgroundImageUrl ? "Replace Snapshot" : "Take a Snapshot" }
         </button>
       }
       { snapshotInProgress && <p>Please wait while the snapshot is being taken...</p> }
       {
-        authoredState.snapshotTarget === undefined &&
+        snapshotTarget === undefined &&
         <p className={css.warn}>Snapshot won&apos;t work, as no target interactive is selected</p>
       }
     </>

--- a/src/labbook/components/take-snapshot.tsx
+++ b/src/labbook/components/take-snapshot.tsx
@@ -3,6 +3,7 @@ import { UploadButton } from "./upload-button";
 
 import { getInteractiveSnapshot } from "@concord-consortium/lara-interactive-api";
 import { getAnswerType, IGenericAuthoredState, IGenericInteractiveState } from "../../drawing-tool/components/types";
+import { useLinkedInteractiveId } from "../../shared/hooks/use-linked-interactive-id";
 
 import SnapShotIcon from "../assets/snapshot-image-icon.svg";
 import { Log } from "../labbook-logging";
@@ -18,12 +19,13 @@ export interface IProps {
 
 export const TakeSnapshot: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, onUploadStart, onUploadComplete, disabled}) => {
   const [ snapshotInProgress, setSnapshotInProgress ] = useState(false);
+  const snapshotTarget = useLinkedInteractiveId("snapshotTarget");
 
   const handleSnapshot = async () => {
-    if (authoredState.snapshotTarget) {
+    if (snapshotTarget) {
       onUploadStart?.();
       setSnapshotInProgress(true);
-      const response = await getInteractiveSnapshot({ interactiveItemId: authoredState.snapshotTarget });
+      const response = await getInteractiveSnapshot({ interactiveItemId: snapshotTarget });
       setSnapshotInProgress(false);
       if (response.success && response.snapshotUrl) {
         setInteractiveState?.(prevState => ({
@@ -44,7 +46,7 @@ export const TakeSnapshot: React.FC<IProps> = ({ authoredState, interactiveState
   return (
     <>
       {
-        authoredState.snapshotTarget &&
+        snapshotTarget &&
           <UploadButton onClick={handleSnapshot}
             disabled={snapshotInProgress || disabled}
             data-test="snapshot-btn">

--- a/src/shared/hooks/use-linked-interactive-id.test.ts
+++ b/src/shared/hooks/use-linked-interactive-id.test.ts
@@ -1,0 +1,28 @@
+import { useLinkedInteractiveId } from "./use-linked-interactive-id";
+import { useInitMessage } from "@concord-consortium/lara-interactive-api";
+
+jest.mock("@concord-consortium/lara-interactive-api", () => ({
+  useInitMessage: jest.fn()
+}));
+const useInitMessageMock = useInitMessage as jest.Mock;
+
+const initMessageWithSnapshotTarget = {
+  mode: "runtime",
+  linkedInteractives: [
+    {
+      id: "123-MwInteractive",
+      label: "snapshotTarget"
+    }
+  ]
+};
+
+describe("useLinkedInteractiveId", () => {
+  beforeEach(() => {
+    useInitMessageMock.mockClear();
+  });
+  it("should return the ID of an interactive that has a specified label", () => {
+    useInitMessageMock.mockReturnValue(initMessageWithSnapshotTarget);
+    const snapshotTargetId = useLinkedInteractiveId("snapshotTarget");
+    expect(snapshotTargetId).toEqual("123-MwInteractive");
+  });
+});

--- a/src/shared/hooks/use-linked-interactive-id.ts
+++ b/src/shared/hooks/use-linked-interactive-id.ts
@@ -1,0 +1,8 @@
+import { useInitMessage } from "@concord-consortium/lara-interactive-api";
+
+export const useLinkedInteractiveId = (label: string) => {
+  const initMessage = useInitMessage();
+  const linkedInteractives = (initMessage?.mode === "authoring" || initMessage?.mode === "runtime") ? initMessage.linkedInteractives : [];
+  const linkedInteractive = linkedInteractives.find(interactive => interactive.label === label);
+  return linkedInteractive?.id;
+};


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/181808855

[#181808855]

These changes fix a problem in runtime where the ID of a linked interactive might be set to a value that does not exist in the DOM. They add a hook that finds a linked interactive that has a specified label, and provides the correct ID value.