### PR TITLE
Fix snapshot content is blank

### DIFF
--- a/cypress/integration/carousel.test.js
+++ b/cypress/integration/carousel.test.js
@@ -126,7 +126,7 @@ context("Test carousel interactive", () => {
             target_id: '',
             target_name: '',
             target_value: '',
-            subinteractive_url: "http://localhost:8080/open-response/",
+            subinteractive_url: cy.config().baseUrl + "/open-response/",
             subinteractive_type: "open_response",
             subinteractive_sub_type: undefined,
             subinteractive_id: 'int1'
@@ -141,7 +141,7 @@ context("Test carousel interactive", () => {
             target_id: '',
             target_name: '',
             target_value: 'Test subquestion answer',
-            subinteractive_url: "http://localhost:8080/open-response/",
+            subinteractive_url: cy.config().baseUrl + "/open-response/",
             subinteractive_type: 'open_response',
             subinteractive_sub_type: undefined,
             subinteractive_id: 'int1',

--- a/cypress/integration/graph.test.js
+++ b/cypress/integration/graph.test.js
@@ -13,6 +13,7 @@ context("Test graph interactive", () => {
           version: 1,
           dataSourceInteractive1: "testInt1"
         },
+        linkedInteractives: [ {id: "testInt1", label: "dataSourceInteractive1"} ]
       });
       cy.getIframeBody().find("canvas").should("have.length", 1);
     });

--- a/cypress/integration/scaffolded-question.test.js
+++ b/cypress/integration/scaffolded-question.test.js
@@ -127,7 +127,7 @@ context("Test scaffolded question interactive", () => {
             target_name: '',
             target_value: '',
             scaffolded_question_level: 1,
-            subinteractive_url: "http://localhost:8080/open-response/",
+            subinteractive_url: cy.config().baseUrl + "/open-response/",
             subinteractive_type: "open_response",
             subinteractive_sub_type: undefined,
             subinteractive_id: 'int1'
@@ -143,7 +143,7 @@ context("Test scaffolded question interactive", () => {
             target_name: '',
             target_value: 'Test subquestion answer',
             scaffolded_question_level: 1,
-            subinteractive_url: "http://localhost:8080/open-response/",
+            subinteractive_url: cy.config().baseUrl + "/open-response/",
             subinteractive_type: 'open_response',
             subinteractive_sub_type: undefined,
             subinteractive_id: 'int1',

--- a/src/drawing-tool/components/take-snapshot.tsx
+++ b/src/drawing-tool/components/take-snapshot.tsx
@@ -45,7 +45,7 @@ export const TakeSnapshot: React.FC<IProps> = ({ authoredState, interactiveState
     <>
       {
         snapshotTarget &&
-        <button className={cssHelpers.apButton} onClick={handleSnapshot} disabled={snapshotInProgress} data-test="snapshot-btn">
+        <button className={cssHelpers.apButton} onClick={handleSnapshot} disabled={snapshotInProgress} data-testid="snapshot-btn">
           <CameraIcon className={cssHelpers.smallIcon} /> { interactiveState?.userBackgroundImageUrl ? "Replace Snapshot" : "Take a Snapshot" }
         </button>
       }

--- a/src/graph/components/runtime.tsx
+++ b/src/graph/components/runtime.tsx
@@ -3,6 +3,7 @@ import { IAuthoredState } from "./types";
 import {
   addLinkedInteractiveStateListener, IInteractiveStateWithDataset, removeLinkedInteractiveStateListener, IDataset
 } from "@concord-consortium/lara-interactive-api";
+import { useLinkedInteractiveId } from "../../shared/hooks/use-linked-interactive-id";
 import { Bar } from "react-chartjs-2";
 import { ChartOptions, LinearScale } from "chart.js";
 import ChartDataLabels from "chartjs-plugin-datalabels";
@@ -63,14 +64,16 @@ const getGraphOptions = (authoredState: IAuthoredState, chartData?: CustomChartD
 
 export const Runtime: React.FC<IProps> = ({ authoredState }) => {
   const [ datasets, setDatasets ] = useState<Array<IDataset | null | undefined>>([]);
+  const dataSourceInteractive1 = useLinkedInteractiveId("dataSourceInteractive1");
+  const dataSourceInteractive2 = useLinkedInteractiveId("dataSourceInteractive2");
+  const dataSourceInteractive3 = useLinkedInteractiveId("dataSourceInteractive3");
 
   useEffect(() => {
     const linkedInteractives: string[] = [
-      authoredState.dataSourceInteractive1,
-      authoredState.dataSourceInteractive2,
-      authoredState.dataSourceInteractive3
+      dataSourceInteractive1,
+      dataSourceInteractive2,
+      dataSourceInteractive3
     ].filter(intItemId => intItemId !== undefined) as string[];
-
     const unsubscribeMethods = linkedInteractives.map((dataSourceInteractive, datasetIdx) => {
       const listener = (newLinkedIntState: IInteractiveStateWithDataset | undefined) => {
         const newDataset = newLinkedIntState && newLinkedIntState.dataset;
@@ -101,7 +104,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState }) => {
     return () => {
       unsubscribeMethods.forEach(unsubscribeMethod => unsubscribeMethod());
     };
-  }, [authoredState.dataSourceInteractive1, authoredState.dataSourceInteractive2, authoredState.dataSourceInteractive3]);
+  }, [dataSourceInteractive1, dataSourceInteractive2, dataSourceInteractive3]);
 
   const anyData = datasets.filter(d => d !== null).length > 0;
   const graphContainerClassName = css.graph + " " + css["graphLayout" + (authoredState.graphsPerRow || 1)];

--- a/src/labbook/components/take-snapshot.tsx
+++ b/src/labbook/components/take-snapshot.tsx
@@ -1,10 +1,8 @@
 import React, { useState } from "react";
 import { UploadButton } from "./upload-button";
-
 import { getInteractiveSnapshot } from "@concord-consortium/lara-interactive-api";
 import { getAnswerType, IGenericAuthoredState, IGenericInteractiveState } from "../../drawing-tool/components/types";
 import { useLinkedInteractiveId } from "../../shared/hooks/use-linked-interactive-id";
-
 import SnapShotIcon from "../assets/snapshot-image-icon.svg";
 import { Log } from "../labbook-logging";
 
@@ -49,7 +47,7 @@ export const TakeSnapshot: React.FC<IProps> = ({ authoredState, interactiveState
         snapshotTarget &&
           <UploadButton onClick={handleSnapshot}
             disabled={snapshotInProgress || disabled}
-            data-test="snapshot-btn">
+            data-testid="snapshot-btn">
                 <SnapShotIcon />
                 { snapshotInProgress || disabled
                   ? "Please Wait"

--- a/src/shared/components/base-app.tsx
+++ b/src/shared/components/base-app.tsx
@@ -6,6 +6,7 @@ import { setSupportedFeatures, useAuthoredState, useInitMessage } from "@concord
 import { useBasicLogging } from "../hooks/use-basic-logging";
 import { useLinkedInteractives } from "../hooks/use-linked-interactives";
 import { ILinkedInteractiveProp } from "../hooks/use-linked-interactives-authoring";
+import { InitMessageContext } from "../hooks/use-context-init-message";
 import css from "./base-app.scss";
 
 export type UpdateFunc<State> = (prevState: State | null) => State;
@@ -94,6 +95,10 @@ export const BaseApp = <IAuthoredState extends IBaseAuthoredState>(props: IProps
   };
 
   return (
-    <div ref={container}>{ renderMode() }</div>
+    <div ref={container}>
+      <InitMessageContext.Provider value={initMessage}>
+        { renderMode() }
+      </InitMessageContext.Provider>
+    </div>
   );
 };

--- a/src/shared/components/base-question-app.tsx
+++ b/src/shared/components/base-question-app.tsx
@@ -14,6 +14,7 @@ import { IBaseAuthoredState, UpdateFunc, IAuthoringComponentProps, IRuntimeCompo
 import { useBasicLogging } from "../hooks/use-basic-logging";
 import { useLinkedInteractives } from "../hooks/use-linked-interactives";
 import { ILinkedInteractiveProp } from "../hooks/use-linked-interactives-authoring";
+import { InitMessageContext } from "../hooks/use-context-init-message";
 import css from "./base-app.scss";
 
 
@@ -140,6 +141,10 @@ export const BaseQuestionApp = <IAuthoredState extends IAuthoringMetadata & IBas
   };
 
   return (
-    <div ref={container}>{ renderMode() }</div>
+    <div ref={container}>
+      <InitMessageContext.Provider value={initMessage}>
+        { renderMode() }
+      </InitMessageContext.Provider>
+    </div>
   );
 };

--- a/src/shared/hooks/use-context-init-message.ts
+++ b/src/shared/hooks/use-context-init-message.ts
@@ -1,0 +1,9 @@
+import { createContext, useContext } from "react";
+import { IInitInteractive } from "@concord-consortium/lara-interactive-api";
+
+export const InitMessageContext = createContext<IInitInteractive | null>(null);
+
+export const useContextInitMessage = () => {
+  const initMessage = useContext(InitMessageContext);
+  return initMessage;
+};

--- a/src/shared/hooks/use-linked-interactive-id.test.ts
+++ b/src/shared/hooks/use-linked-interactive-id.test.ts
@@ -1,10 +1,10 @@
+import { useContextInitMessage } from "./use-context-init-message";
 import { useLinkedInteractiveId } from "./use-linked-interactive-id";
-import { useInitMessage } from "@concord-consortium/lara-interactive-api";
 
-jest.mock("@concord-consortium/lara-interactive-api", () => ({
-  useInitMessage: jest.fn()
+jest.mock("./use-context-init-message", () => ({
+  useContextInitMessage: jest.fn()
 }));
-const useInitMessageMock = useInitMessage as jest.Mock;
+const useContextInitMessageMock = useContextInitMessage as jest.Mock;
 
 const initMessageWithSnapshotTarget = {
   mode: "runtime",
@@ -16,13 +16,23 @@ const initMessageWithSnapshotTarget = {
   ]
 };
 
+const initMessageWithoutSnapshotTarget = {
+  mode: "runtime",
+  linkedInteractives: []
+};
+
 describe("useLinkedInteractiveId", () => {
   beforeEach(() => {
-    useInitMessageMock.mockClear();
+    useContextInitMessageMock.mockClear();
   });
   it("should return the ID of an interactive that has a specified label", () => {
-    useInitMessageMock.mockReturnValue(initMessageWithSnapshotTarget);
+    useContextInitMessageMock.mockReturnValue(initMessageWithSnapshotTarget);
     const snapshotTargetId = useLinkedInteractiveId("snapshotTarget");
     expect(snapshotTargetId).toEqual("123-MwInteractive");
+  });
+  it("should return undefined when there is no interactive that has a specified label", () => {
+    useContextInitMessageMock.mockReturnValue(initMessageWithoutSnapshotTarget);
+    const snapshotTargetId = useLinkedInteractiveId("snapshotTarget");
+    expect(snapshotTargetId).toEqual(undefined);
   });
 });

--- a/src/shared/hooks/use-linked-interactive-id.ts
+++ b/src/shared/hooks/use-linked-interactive-id.ts
@@ -1,8 +1,9 @@
-import { useInitMessage } from "@concord-consortium/lara-interactive-api";
+import { useContextInitMessage } from "./use-context-init-message";
+import { ILinkedInteractive } from "@concord-consortium/lara-interactive-api";
 
 export const useLinkedInteractiveId = (label: string) => {
-  const initMessage = useInitMessage();
+  const initMessage = useContextInitMessage();
   const linkedInteractives = (initMessage?.mode === "authoring" || initMessage?.mode === "runtime") ? initMessage.linkedInteractives : [];
-  const linkedInteractive = linkedInteractives.find(interactive => interactive.label === label);
+  const linkedInteractive = linkedInteractives.find((interactive: ILinkedInteractive) => interactive.label === label);
   return linkedInteractive?.id;
 };

--- a/src/shared/hooks/use-linked-interactives-authoring.test.ts
+++ b/src/shared/hooks/use-linked-interactives-authoring.test.ts
@@ -1,14 +1,14 @@
 import { renderHook } from "@testing-library/react-hooks";
 import { useLinkedInteractivesAuthoring } from "./use-linked-interactives-authoring";
 import { act } from "@testing-library/react";
-import {getInteractiveList, setLinkedInteractives} from "@concord-consortium/lara-interactive-api";
+import { getInteractiveList, setLinkedInteractives } from "@concord-consortium/lara-interactive-api";
+import { useContextInitMessage } from "./use-context-init-message";
 
-let initMessage: any;
+let contextInitMessage: any;
 let authoredState: any;
 let interactiveList: any;
 
 jest.mock("@concord-consortium/lara-interactive-api", () => ({
-  useInitMessage: jest.fn(() => initMessage),
   useAuthoredState: jest.fn(() => ({
     authoredState
   })),
@@ -19,17 +19,23 @@ jest.mock("@concord-consortium/lara-interactive-api", () => ({
 const getInteractiveListMock = getInteractiveList as jest.Mock;
 const setLinkedInteractivesMock = setLinkedInteractives as jest.Mock;
 
+jest.mock("./use-context-init-message", () => ({
+  useContextInitMessage: jest.fn(() => contextInitMessage)
+}));
+const useContextInitMessageMock = useContextInitMessage as jest.Mock;
+
 describe("useLinkedInteractives", () => {
   beforeEach(() => {
-    initMessage = {};
+    contextInitMessage = {};
     authoredState = {};
     interactiveList = [];
     getInteractiveListMock.mockClear();
     setLinkedInteractivesMock.mockClear();
+    useContextInitMessageMock.mockClear();
   });
 
   it("downloads list of page interactives for properties present in schema and listed in linkedInteractiveProps", async () => {
-    initMessage = {
+    contextInitMessage = {
       mode: "authoring"
     };
     interactiveList = [
@@ -93,7 +99,7 @@ describe("useLinkedInteractives", () => {
   });
 
   it("does not call setLinkedInteractives when it's not necessary (linkedInteractives array and authoredState are matching)", () => {
-    initMessage = {
+    contextInitMessage = {
       mode: "authoring",
       linkedInteractives: [{id: "ID1", label: "linkedInteractive1"}]
     };
@@ -113,7 +119,7 @@ describe("useLinkedInteractives", () => {
   });
 
   it("monitors authoredState updates and calls setLinkedInteractives when necessary - 1", async () => {
-    initMessage = {
+    contextInitMessage = {
       mode: "authoring",
       linkedInteractives: []
     };
@@ -142,7 +148,7 @@ describe("useLinkedInteractives", () => {
   });
 
   it("monitors authoredState updates and calls setLinkedInteractives when necessary - 2", () => {
-    initMessage = {
+    contextInitMessage = {
       mode: "authoring",
       linkedInteractives: [{id: "ID1", label: "linkedInteractive1"}]
     };
@@ -171,7 +177,7 @@ describe("useLinkedInteractives", () => {
   });
 
   it("monitors authoredState updates and calls setLinkedInteractives when necessary - 3", () => {
-    initMessage = {
+    contextInitMessage = {
       mode: "authoring",
       linkedInteractives: [{id: "ID1", label: "linkedInteractive1"}]
     };

--- a/src/shared/hooks/use-linked-interactives-authoring.tsx
+++ b/src/shared/hooks/use-linked-interactives-authoring.tsx
@@ -2,8 +2,9 @@ import { useEffect, useState } from "react";
 import deepmerge from "deepmerge";
 import { JSONSchema6 } from "json-schema";
 import {
-  useAuthoredState, useInitMessage, getInteractiveList, ILinkedInteractive, setLinkedInteractives
+  useAuthoredState, getInteractiveList, ILinkedInteractive, setLinkedInteractives
 } from "@concord-consortium/lara-interactive-api";
+import { useContextInitMessage } from "./use-context-init-message";
 import usePrevious from "react-hooks-use-previous";
 
 export interface ILinkedInteractiveProp {
@@ -46,7 +47,7 @@ export const useLinkedInteractivesAuthoring = ({ linkedInteractiveProps, schema 
 // linkedInteractives array to LARA parent window. currentLinkedInteractives acts only as a cache, so we don't
 // send the message each time the authoredState is updated (e.g. its other, unrelated fields).
 const useLinkedInteractivesInAuthoredState = (linkedInteractiveProps?: ILinkedInteractiveProp[]) => {
-  const initMessage = useInitMessage<AuthoredState>();
+  const initMessage = useContextInitMessage();
   const [ cachedLinkedInteractives, setCachedLinkedInteractives ] = useState<ILinkedInteractive[]>();
   const { authoredState } = useAuthoredState<AuthoredState>();
   const previousAuthoredState = usePrevious<AuthoredState | null>(authoredState, null);
@@ -67,7 +68,7 @@ const useLinkedInteractivesInAuthoredState = (linkedInteractiveProps?: ILinkedIn
           // This is very important, as it'll prevent overwriting linkedInteractives on the initial load.
           return;
         }
-        const linkedInteractive = currentLinkedInteractives.find(l => l.label === name);
+        const linkedInteractive = currentLinkedInteractives.find((l: ILinkedInteractive) => l.label === name);
         if (!linkedInteractive && authoredStateVal !== undefined) {
           // Add a new item.
           newArray = [...currentLinkedInteractives, {
@@ -77,11 +78,11 @@ const useLinkedInteractivesInAuthoredState = (linkedInteractiveProps?: ILinkedIn
           anyUpdate = true;
         } else if (linkedInteractive && authoredStateVal === undefined) {
           // Remove item from the array.
-          newArray = currentLinkedInteractives.filter(int => int.id !== linkedInteractive.id);
+          newArray = currentLinkedInteractives.filter((int: ILinkedInteractive) => int.id !== linkedInteractive.id);
           anyUpdate = true;
         } else if (linkedInteractive && linkedInteractive.id !== authoredStateVal) {
           // Update array item.
-          newArray = [...currentLinkedInteractives.filter(int => int.id !== linkedInteractive.id), {
+          newArray = [...currentLinkedInteractives.filter((int: ILinkedInteractive) => int.id !== linkedInteractive.id), {
             id: authoredStateVal,
             label: name
           }];
@@ -98,7 +99,7 @@ const useLinkedInteractivesInAuthoredState = (linkedInteractiveProps?: ILinkedIn
 
 // Get the list of interactives that are on the same page.
 const useLinkedInteractivesInSchema = (schema: JSONSchema6, linkedInteractiveProps?: ILinkedInteractiveProp[]) => {
-  const initMessage = useInitMessage<AuthoredState>();
+  const initMessage = useContextInitMessage();
   const [ interactiveList, setInteractiveList ] = useState<{[label: string]: {names: string[], ids: string[]}}>({});
 
   const interactiveItemId = initMessage?.mode === "authoring" && initMessage.interactiveItemId;

--- a/src/shared/hooks/use-linked-interactives.test.ts
+++ b/src/shared/hooks/use-linked-interactives.test.ts
@@ -1,27 +1,33 @@
 import { renderHook } from "@testing-library/react-hooks";
 import { useLinkedInteractives } from "./use-linked-interactives";
+import { useContextInitMessage } from "./use-context-init-message";
 
-let initMessage: any;
+let contextInitMessage: any;
 let authoredState: any;
 const setAuthoredState = jest.fn();
 
 jest.mock("@concord-consortium/lara-interactive-api", () => ({
-  useInitMessage: jest.fn(() => initMessage),
   useAuthoredState: jest.fn(() => ({
     authoredState,
     setAuthoredState
   }))
 }));
 
+jest.mock("./use-context-init-message", () => ({
+  useContextInitMessage: jest.fn(() => contextInitMessage)
+}));
+const useContextInitMessageMock = useContextInitMessage as jest.Mock;
+
 describe("useLinkedInteractives", () => {
   beforeEach(() => {
-    initMessage = {};
+    contextInitMessage = {};
     authoredState = {};
     setAuthoredState.mockClear();
+    useContextInitMessageMock.mockClear();
   });
 
   it("removes linked interactive IDs from authored state if linkedInteractives array is empty or undefined", () => {
-    initMessage = {
+    contextInitMessage = {
       mode: "authoring"
     };
     authoredState = {
@@ -38,7 +44,7 @@ describe("useLinkedInteractives", () => {
   });
 
   it("overwrites linked interactive IDs in authored state if linkedInteractives array is defined - 1", () => {
-    initMessage = {
+    contextInitMessage = {
       mode: "authoring",
       linkedInteractives: [
         { id: "new ID 1", label: "linkedInteractive1" },
@@ -62,7 +68,7 @@ describe("useLinkedInteractives", () => {
   });
 
   it("overwrites linked interactive IDs in authored state if linkedInteractives array is defined - 2", () => {
-    initMessage = {
+    contextInitMessage = {
       mode: "authoring",
       linkedInteractives: [
         { id: "new ID 1", label: "linkedInteractive1" },
@@ -88,7 +94,7 @@ describe("useLinkedInteractives", () => {
   });
 
   it("does nothing if the mode is not authoring or runtime", () => {
-    initMessage = {
+    contextInitMessage = {
       mode: "report",
       linkedInteractives: [
         { id: "new ID 1", label: "linkedInteractive1" },
@@ -108,7 +114,7 @@ describe("useLinkedInteractives", () => {
   });
 
   it("does nothing if linkedInteractives array is matching authored state", () => {
-    initMessage = {
+    contextInitMessage = {
       mode: "authoring",
       linkedInteractives: [
         { id: "ID 1", label: "linkedInteractive1" }

--- a/src/shared/hooks/use-linked-interactives.tsx
+++ b/src/shared/hooks/use-linked-interactives.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useRef } from "react";
-import { useAuthoredState, useInitMessage } from "@concord-consortium/lara-interactive-api";
+import { ILinkedInteractive, useAuthoredState } from "@concord-consortium/lara-interactive-api";
+import { useContextInitMessage } from "./use-context-init-message";
 
 // This hook accepts a list of props that are pointing to other interactives and ensures the most recent ID
 // coming from LARA is being used. Note that ID might change when activity is copied or when interactive is removed.
 // It works both in authoring and runtime mode.
 export const useLinkedInteractives = (linkedInteractiveNames: string[] | undefined) => {
-  const initMessage = useInitMessage();
+  const initMessage = useContextInitMessage();
   const { authoredState, setAuthoredState } = useAuthoredState<Record<string, unknown>>();
   const initialLinkedInteractivesProcessed = useRef(false);
   const linkedInteractives = (initMessage?.mode === "authoring" || initMessage?.mode === "runtime") && initMessage.linkedInteractives;
@@ -23,7 +24,7 @@ export const useLinkedInteractives = (linkedInteractiveNames: string[] | undefin
       const newStateProps: Record<string, unknown> = {};
       linkedInteractiveNames.forEach(name => {
         const authoredStateVal = authoredState[name];
-        const linkedInteractive = linkedInteractives && linkedInteractives.find(l => l.label === name);
+        const linkedInteractive = linkedInteractives && linkedInteractives.find((l: ILinkedInteractive) => l.label === name);
         if (!linkedInteractive && authoredStateVal !== undefined) {
           // Linked interactive no longer present, clear the authoredState value.
           newStateProps[name] = undefined;

--- a/src/shared/hooks/use-linked-interactives.tsx
+++ b/src/shared/hooks/use-linked-interactives.tsx
@@ -9,7 +9,7 @@ export const useLinkedInteractives = (linkedInteractiveNames: string[] | undefin
   const initMessage = useContextInitMessage();
   const { authoredState, setAuthoredState } = useAuthoredState<Record<string, unknown>>();
   const initialLinkedInteractivesProcessed = useRef(false);
-  const linkedInteractives = (initMessage?.mode === "authoring" || initMessage?.mode === "runtime") && initMessage.linkedInteractives;
+  const linkedInteractives = initMessage?.mode === "authoring" && initMessage.linkedInteractives;
 
   useEffect(() => {
     // Note that this hook needs to be executed only once, right after interactive is initialized.
@@ -19,7 +19,7 @@ export const useLinkedInteractives = (linkedInteractiveNames: string[] | undefin
       !initialLinkedInteractivesProcessed.current &&
       linkedInteractiveNames &&
       authoredState &&
-      (initMessage?.mode === "authoring" || initMessage?.mode === "runtime")
+      initMessage?.mode === "authoring"
     ) {
       const newStateProps: Record<string, unknown> = {};
       linkedInteractiveNames.forEach(name => {

--- a/src/shared/hooks/use-required-question.tsx
+++ b/src/shared/hooks/use-required-question.tsx
@@ -1,12 +1,13 @@
 import { useEffect } from "react";
-import { setNavigation, useAuthoredState, useInteractiveState, useInitMessage } from "@concord-consortium/lara-interactive-api";
+import { setNavigation, useAuthoredState, useInteractiveState } from "@concord-consortium/lara-interactive-api";
+import { useContextInitMessage } from "./use-context-init-message";
 
 // This hook can be used by any interactive that defines `required` property in its authored state and
 // `submitted` property in its interactive state (student state).
 export const useRequiredQuestion = () => {
   const { authoredState } = useAuthoredState<{ required?: boolean }>();
   const { interactiveState } = useInteractiveState<{ submitted?: boolean }>();
-  const initMessage = useInitMessage();
+  const initMessage = useContextInitMessage();
 
   useEffect(() => {
     if (initMessage?.mode === "runtime" && authoredState?.required) {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/181808855

[#181808855]

Adds `InitMessageContext` context and `useContextInitMessage` hook. `useContextInitMessage` should be used instead of `useInitMessage` in components that use `BaseApp` or `BaseQuestionApp`. This will limit calls to `useInitMessage` to just one which is desired since multiple calls can lead to unnecessary additional renders.