### PR TITLE
Record open response runtime -- autosave on nav

### DIFF
--- a/src/open-response/components/runtime.tsx
+++ b/src/open-response/components/runtime.tsx
@@ -42,20 +42,20 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   useEffect(() => {
     setOnUnload((options: IGetInteractiveState) => {
       if (options.unloading) {
-        return new Promise<Record<string, unknown>>((resolve) => {
+        return new Promise(resolve => {
           if (mediaRecorderRef.current) {
+            // Do not resolve to update the final interactive state. 
+            // The stop() method will do that, which will complete the 
+            // onUnload promise in the host.
             mediaRecorderRef.current.stop();
-            if (audioUrl) {
-              resolve;
-            }
           } else {
-            resolve({});
+            resolve(interactiveState || {});
           }
         });
       }
-      return Promise.resolve({});
+      return Promise.resolve(interactiveState || {});
     });
-  }, [audioUrl]);
+  }, [interactiveState]);
 
   useEffect(() => {
     const getAudioUrl = async () => {

--- a/src/open-response/components/runtime.tsx
+++ b/src/open-response/components/runtime.tsx
@@ -1,10 +1,10 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { IRuntimeQuestionComponentProps } from "../../shared/components/base-question-app";
 import { renderHTML } from "../../shared/utilities/render-html";
 import { IAuthoredState, IInteractiveState } from "./types";
 import { DecorateChildren } from "@concord-consortium/text-decorator";
 import { useGlossaryDecoration } from "../../shared/hooks/use-glossary-decoration";
-import { getAttachmentUrl, log, writeAttachment } from "@concord-consortium/lara-interactive-api";
+import { getAttachmentUrl, IGetInteractiveState, log, setOnUnload, writeAttachment } from "@concord-consortium/lara-interactive-api";
 import AudioRecorder from "audio-recorder-polyfill";
 
 import css from "./runtime.scss";
@@ -29,17 +29,35 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   const answerText = !interactiveState?.answerText ? authoredState.defaultAnswer : interactiveState.answerText;
   const attachedAudioFile = interactiveState?.audioFile ? interactiveState.audioFile : undefined;
   let recordedBlobs: Blob[] = [];
-  const [audioUrl, setAudioUrl] = React.useState<string | undefined>(undefined);
-  const [audioSupported, setAudioSupported] = React.useState(browserSupportsAudio);
-  const [recordingStarted, setRecordingStarted] = React.useState(false);
-  const [recordingDisabled, setRecordingDisabled] = React.useState(false);
-  const [recordingFailed, setRecordingFailed] = React.useState(false);
-  const [playDisabled, setPlayDisabled] = React.useState(false);
-  const [stopDisabled, setStopDisabled] = React.useState(true);
-  const mediaRecorderRef = React.useRef<MediaRecorder>();
-  const audioPlayerRef = React.useRef<HTMLAudioElement>(null);
+  const [audioUrl, setAudioUrl] = useState<string | undefined>(undefined);
+  const [audioSupported, setAudioSupported] = useState(browserSupportsAudio);
+  const [recordingStarted, setRecordingStarted] = useState(false);
+  const [recordingDisabled, setRecordingDisabled] = useState(false);
+  const [recordingFailed, setRecordingFailed] = useState(false);
+  const [playDisabled, setPlayDisabled] = useState(false);
+  const [stopDisabled, setStopDisabled] = useState(true);
+  const mediaRecorderRef = useRef<MediaRecorder>();
+  const audioPlayerRef = useRef<HTMLAudioElement>(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
+    setOnUnload((options: IGetInteractiveState) => {
+      if (options.unloading) {
+        return new Promise<Record<string, unknown>>((resolve) => {
+          if (mediaRecorderRef.current) {
+            mediaRecorderRef.current.stop();
+            if (audioUrl) {
+              resolve;
+            }
+          } else {
+            resolve({});
+          }
+        });
+      }
+      return Promise.resolve({});
+    });
+  }, [audioUrl]);
+
+  useEffect(() => {
     const getAudioUrl = async () => {
       if (attachedAudioFile) {
         const s3Url = await fetchAudioUrl(attachedAudioFile);


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/181223914

[#181223914]

These changes fix a problem where an audio file was not properly saved if the user navigated away from the active page before the recording process was allowed to complete. An audio file should be saved and attached to the question/response even if a user starts the recording process and then navigates to another page without either stopping the recording, or allowing it to fully save after stopping the recording.