### PR TITLE
Fix snapshot content is blank -- adjust use of useContextInitMessage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2367,9 +2367,9 @@
       }
     },
     "@concord-consortium/lara-interactive-api": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.6.0.tgz",
-      "integrity": "sha512-+kGvyVcw7E2LReAjqx04xdm8QuNlyXHPY03jTlJMFuh/GxV9M5MLRMBd8uhYToHZwmUx9GSr4cxR6TuUvv+zxg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.6.1.tgz",
+      "integrity": "sha512-WnuGf0oXf5Kr43Oekk0WglcjTuh1rkl1y+VnVnWteO0wFm3ltnfzi8BBdks0NAgDVL/mafQsIHk3TTQOW4XuCA==",
       "requires": {
         "iframe-phone": "^1.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.53.1",
     "@aws-sdk/signature-v4-crt": "^3.53.0",
-    "@concord-consortium/lara-interactive-api": "^1.6.0",
+    "@concord-consortium/lara-interactive-api": "^1.6.1",
     "@concord-consortium/slate-editor": "^0.7.3",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@concord-consortium/token-service": "^2.1.0",

--- a/src/shared/components/base-app.tsx
+++ b/src/shared/components/base-app.tsx
@@ -49,7 +49,7 @@ export const BaseApp = <IAuthoredState extends IBaseAuthoredState>(props: IProps
   useAutoHeight({ container: container.current, disabled: isRuntimeView && disableAutoHeight || isLoading });
   useShutterbug({ container: "." + css.runtime });
   useBasicLogging({ disabled: !isRuntimeView });
-  useLinkedInteractives(linkedInteractiveProps?.map(li => li.label));
+  useLinkedInteractives(linkedInteractiveProps?.map(li => li.label), initMessage);
 
   useEffect(() => {
     setSupportedFeatures({

--- a/src/shared/components/base-question-app.tsx
+++ b/src/shared/components/base-question-app.tsx
@@ -65,10 +65,10 @@ export const BaseQuestionApp = <IAuthoredState extends IAuthoringMetadata & IBas
 
   useAutoHeight({ container: container.current, disabled: isRuntimeView && disableAutoHeight || isLoading });
   useHint();
-  useRequiredQuestion();
+  useRequiredQuestion(initMessage);
   useShutterbug({ container: "." + css.runtime });
   useBasicLogging({ disabled: !isRuntimeView });
-  useLinkedInteractives(linkedInteractiveProps?.map(li => li.label));
+  useLinkedInteractives(linkedInteractiveProps?.map(li => li.label), initMessage);
 
   useEffect(() => {
     setSupportedFeatures({

--- a/src/shared/hooks/use-context-init-message.test.ts
+++ b/src/shared/hooks/use-context-init-message.test.ts
@@ -1,0 +1,12 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { useContextInitMessage } from "./use-context-init-message";
+
+describe("useContextInitMessage", () => {
+  it("should return an error if it is called from outside a context", () => {
+    const HookWrapper = () => {
+      useContextInitMessage();
+    };
+    const { result } = renderHook(HookWrapper);
+    expect(result.error.message).toBe("useContextInitMessage must be used within a <InitMessageContext.Provider>");
+  });
+});

--- a/src/shared/hooks/use-context-init-message.ts
+++ b/src/shared/hooks/use-context-init-message.ts
@@ -5,6 +5,9 @@ export const InitMessageContext = createContext<IInitInteractive | null | undefi
 
 export const useContextInitMessage = () => {
   const initMessage = useContext(InitMessageContext);
+  // initMessage will be undefined unless a value is supplied by a context provider.
+  // useInitMessage in the interactive client returns null until the init message is ready,
+  // after which it returns an object of type IInitInteractive
   if (initMessage === undefined) {
     throw new Error("useContextInitMessage must be used within a <InitMessageContext.Provider>");
   }

--- a/src/shared/hooks/use-context-init-message.ts
+++ b/src/shared/hooks/use-context-init-message.ts
@@ -1,9 +1,12 @@
 import { createContext, useContext } from "react";
 import { IInitInteractive } from "@concord-consortium/lara-interactive-api";
 
-export const InitMessageContext = createContext<IInitInteractive | null>(null);
+export const InitMessageContext = createContext<IInitInteractive | null | undefined>(undefined);
 
 export const useContextInitMessage = () => {
   const initMessage = useContext(InitMessageContext);
+  if (initMessage === undefined) {
+    throw new Error("useContextInitMessage must be used within a <InitMessageContext.Provider>");
+  }
   return initMessage;
 };

--- a/src/shared/hooks/use-linked-interactive-id.ts
+++ b/src/shared/hooks/use-linked-interactive-id.ts
@@ -3,7 +3,7 @@ import { ILinkedInteractive } from "@concord-consortium/lara-interactive-api";
 
 export const useLinkedInteractiveId = (label: string) => {
   const initMessage = useContextInitMessage();
-  const linkedInteractives = (initMessage?.mode === "authoring" || initMessage?.mode === "runtime" || initMessage?.mode === "report") ? initMessage.linkedInteractives : [];
+  const linkedInteractives = (initMessage && initMessage.mode !== "reportItem") ? initMessage.linkedInteractives : [];
   const linkedInteractive = linkedInteractives.find((interactive: ILinkedInteractive) => interactive.label === label);
   return linkedInteractive?.id;
 };

--- a/src/shared/hooks/use-linked-interactive-id.ts
+++ b/src/shared/hooks/use-linked-interactive-id.ts
@@ -3,7 +3,7 @@ import { ILinkedInteractive } from "@concord-consortium/lara-interactive-api";
 
 export const useLinkedInteractiveId = (label: string) => {
   const initMessage = useContextInitMessage();
-  const linkedInteractives = (initMessage?.mode === "authoring" || initMessage?.mode === "runtime") ? initMessage.linkedInteractives : [];
+  const linkedInteractives = (initMessage?.mode === "authoring" || initMessage?.mode === "runtime" || initMessage?.mode === "report") ? initMessage.linkedInteractives : [];
   const linkedInteractive = linkedInteractives.find((interactive: ILinkedInteractive) => interactive.label === label);
   return linkedInteractive?.id;
 };

--- a/src/shared/hooks/use-linked-interactives.test.ts
+++ b/src/shared/hooks/use-linked-interactives.test.ts
@@ -1,8 +1,7 @@
 import { renderHook } from "@testing-library/react-hooks";
 import { useLinkedInteractives } from "./use-linked-interactives";
-import { useContextInitMessage } from "./use-context-init-message";
 
-let contextInitMessage: any;
+let initMessage: any;
 let authoredState: any;
 const setAuthoredState = jest.fn();
 
@@ -13,21 +12,15 @@ jest.mock("@concord-consortium/lara-interactive-api", () => ({
   }))
 }));
 
-jest.mock("./use-context-init-message", () => ({
-  useContextInitMessage: jest.fn(() => contextInitMessage)
-}));
-const useContextInitMessageMock = useContextInitMessage as jest.Mock;
-
 describe("useLinkedInteractives", () => {
   beforeEach(() => {
-    contextInitMessage = {};
+    initMessage = {};
     authoredState = {};
     setAuthoredState.mockClear();
-    useContextInitMessageMock.mockClear();
   });
 
   it("removes linked interactive IDs from authored state if linkedInteractives array is empty or undefined", () => {
-    contextInitMessage = {
+    initMessage = {
       mode: "authoring"
     };
     authoredState = {
@@ -35,7 +28,7 @@ describe("useLinkedInteractives", () => {
       linkedInteractive2: "ID 2"
     };
     const HookWrapper = () => {
-      return useLinkedInteractives([ "linkedInteractive1", "linkedInteractive2" ]);
+      return useLinkedInteractives([ "linkedInteractive1", "linkedInteractive2" ], initMessage);
     };
     renderHook(HookWrapper);
     expect(setAuthoredState).toHaveBeenCalledTimes(1);
@@ -44,7 +37,7 @@ describe("useLinkedInteractives", () => {
   });
 
   it("overwrites linked interactive IDs in authored state if linkedInteractives array is defined - 1", () => {
-    contextInitMessage = {
+    initMessage = {
       mode: "authoring",
       linkedInteractives: [
         { id: "new ID 1", label: "linkedInteractive1" },
@@ -55,7 +48,7 @@ describe("useLinkedInteractives", () => {
       linkedInteractive2: "ID 2"
     };
     const HookWrapper = () => {
-      return useLinkedInteractives([ "linkedInteractive1", "linkedInteractive2" ]);
+      return useLinkedInteractives([ "linkedInteractive1", "linkedInteractive2" ], initMessage);
     };
     const { rerender } = renderHook(HookWrapper);
     expect(setAuthoredState).toHaveBeenCalledTimes(1);
@@ -68,7 +61,7 @@ describe("useLinkedInteractives", () => {
   });
 
   it("overwrites linked interactive IDs in authored state if linkedInteractives array is defined - 2", () => {
-    contextInitMessage = {
+    initMessage = {
       mode: "authoring",
       linkedInteractives: [
         { id: "new ID 1", label: "linkedInteractive1" },
@@ -81,7 +74,7 @@ describe("useLinkedInteractives", () => {
       linkedInteractive2: "ID 2"
     };
     const HookWrapper = () => {
-      return useLinkedInteractives([ "linkedInteractive1", "linkedInteractive2" ]);
+      return useLinkedInteractives([ "linkedInteractive1", "linkedInteractive2" ], initMessage);
     };
     const { rerender } = renderHook(HookWrapper);
     expect(setAuthoredState).toHaveBeenCalledTimes(1);
@@ -94,7 +87,7 @@ describe("useLinkedInteractives", () => {
   });
 
   it("does nothing if the mode is not authoring or runtime", () => {
-    contextInitMessage = {
+    initMessage = {
       mode: "report",
       linkedInteractives: [
         { id: "new ID 1", label: "linkedInteractive1" },
@@ -107,14 +100,14 @@ describe("useLinkedInteractives", () => {
       linkedInteractive2: "ID 2"
     };
     const HookWrapper = () => {
-      return useLinkedInteractives([ "linkedInteractive1", "linkedInteractive2" ]);
+      return useLinkedInteractives([ "linkedInteractive1", "linkedInteractive2" ], initMessage);
     };
     renderHook(HookWrapper);
     expect(setAuthoredState).not.toHaveBeenCalled();
   });
 
   it("does nothing if linkedInteractives array is matching authored state", () => {
-    contextInitMessage = {
+    initMessage = {
       mode: "authoring",
       linkedInteractives: [
         { id: "ID 1", label: "linkedInteractive1" }
@@ -124,7 +117,7 @@ describe("useLinkedInteractives", () => {
       linkedInteractive1: "ID 1"
     };
     const HookWrapper = () => {
-      return useLinkedInteractives([ "linkedInteractive1", "linkedInteractive2" ]);
+      return useLinkedInteractives([ "linkedInteractive1", "linkedInteractive2" ], initMessage);
     };
     renderHook(HookWrapper);
     expect(setAuthoredState).not.toHaveBeenCalled();

--- a/src/shared/hooks/use-linked-interactives.tsx
+++ b/src/shared/hooks/use-linked-interactives.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useRef } from "react";
-import { ILinkedInteractive, useAuthoredState } from "@concord-consortium/lara-interactive-api";
-import { useContextInitMessage } from "./use-context-init-message";
+import { IInitInteractive, ILinkedInteractive, useAuthoredState } from "@concord-consortium/lara-interactive-api";
 
 // This hook accepts a list of props that are pointing to other interactives and ensures the most recent ID
 // coming from LARA is being used. Note that ID might change when activity is copied or when interactive is removed.
 // It works both in authoring and runtime mode.
-export const useLinkedInteractives = (linkedInteractiveNames: string[] | undefined) => {
-  const initMessage = useContextInitMessage();
+export const useLinkedInteractives = (
+  linkedInteractiveNames: string[] | undefined,
+  initMessage: IInitInteractive | null
+  ) => {
   const { authoredState, setAuthoredState } = useAuthoredState<Record<string, unknown>>();
   const initialLinkedInteractivesProcessed = useRef(false);
   const linkedInteractives = initMessage?.mode === "authoring" && initMessage.linkedInteractives;

--- a/src/shared/hooks/use-required-question.tsx
+++ b/src/shared/hooks/use-required-question.tsx
@@ -1,13 +1,11 @@
 import { useEffect } from "react";
-import { setNavigation, useAuthoredState, useInteractiveState } from "@concord-consortium/lara-interactive-api";
-import { useContextInitMessage } from "./use-context-init-message";
+import { IInitInteractive, setNavigation, useAuthoredState, useInteractiveState } from "@concord-consortium/lara-interactive-api";
 
 // This hook can be used by any interactive that defines `required` property in its authored state and
 // `submitted` property in its interactive state (student state).
-export const useRequiredQuestion = () => {
+export const useRequiredQuestion = (initMessage: IInitInteractive | null) => {
   const { authoredState } = useAuthoredState<{ required?: boolean }>();
   const { interactiveState } = useInteractiveState<{ submitted?: boolean }>();
-  const initMessage = useContextInitMessage();
 
   useEffect(() => {
     if (initMessage?.mode === "runtime" && authoredState?.required) {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/181808855

[#181808855]

`useLinkedIInteractives` and `useRequiredQuestion` cannot use `useContextInitMessage` since they are called by the components rendering the context (instead of by child components inside the context). So instead, we pass `initMessage` as a parameter to them.

These changes rely on changes in [this LARA pull request](https://github.com/concord-consortium/lara/pull/935) that will update the LARA Interactive API.