### PR TITLE
Fix snapshot content is blank

### DIFF
--- a/src/side-by-side/components/runtime.tsx
+++ b/src/side-by-side/components/runtime.tsx
@@ -87,7 +87,6 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
               addLocalLinkedDataListener={handleAddLocalLinkedDataListener}
               report={report}
               scale={report && view !== "standalone" ? scaleForReportLeft : undefined}
-              onUnloadCallback={report ? undefined : handleNewInteractiveState.bind(null, "leftInteractiveState")}
             />
         </div> }
         { rightInteractive &&
@@ -102,7 +101,6 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
               addLocalLinkedDataListener={handleAddLocalLinkedDataListener}
               report={report}
               scale={report && view !== "standalone" ? scaleForReportRight : undefined}
-              onUnloadCallback={report ? undefined : handleNewInteractiveState.bind(null, "rightInteractiveState")}
             />
         </div> }
       </div>


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/181808855

[#181808855]

Remove the Side-by-Side Interactive's setting of `onUnloadCallback` because it is not needed and it is causing infinite re-rendering of child components.

Note that the re-rendering issue was identified in snapshot bug QA, but it was caused by changes made to fix the lost student response bug (PT Story: https://www.pivotaltracker.com/story/show/181899333).