### PR TITLE
Align Lato font link with AP [#180588632]

### DIFF
--- a/src/labbook/components/vars.scss
+++ b/src/labbook/components/vars.scss
@@ -1,6 +1,6 @@
 $default-font-family: Lato, 'Helvetica Neue', HelveticaNeue, Helvetica, sans-serif;
 $default-font-size: 14px;
-$default-font-weight: 500;
+$default-font-weight: 400;
 $default-color: #242424;
 
 $gray-dark: #333333;

--- a/src/labbook/index.html
+++ b/src/labbook/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>Labbook Interactive</title>
     <meta name="description" content="Labbook Interactive">
-    <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Lato:wght@100;400;700;900&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="app"></div>

--- a/src/shared/index.html
+++ b/src/shared/index.html
@@ -5,7 +5,7 @@
     <title>Question Interactives</title>
     <meta name="description" content="Question Interactives">
     <link rel="shortcut icon" href="favicon.ico">
-    <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Lato:wght@100;400;700;900&display=swap" rel="stylesheet">
     <style>
       html, body {
         margin: 0;

--- a/src/shared/wrapper.html
+++ b/src/shared/wrapper.html
@@ -5,7 +5,7 @@
     <title>Question Interactives Wrapper (testing / Cypress)</title>
     <meta name="description" content="Question Interactives">
     <link rel="shortcut icon" href="favicon.ico">
-    <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Lato:wght@100;400;700;900&display=swap" rel="stylesheet">
     <style>
       html, body {
         margin: 0;


### PR DESCRIPTION
AP uses 400, 700, and 900 font-weight for Lato.  This change makes question-interactives align with that plus adds 100 as locked-info.scss uses lighter for a font-weight which is 100 when at normal 400 weight.

This also sets the $default-font-weight SCSS variable to 400.  Currently this variable is not used but may be used in the future.