### PR TITLE
Added optional flushOnSave to iframe-runtime [#182039050]

### DIFF
--- a/src/full-screen/components/runtime.tsx
+++ b/src/full-screen/components/runtime.tsx
@@ -100,6 +100,7 @@ export const Runtime: React.FC = () => {
                        setHint={setHint}
                        initMessage={initMessage}
                        report={initMessage?.mode === "report"}
+                       flushOnSave={true}
         />
         {screenfull &&
           <FullScreenButton isFullScreen={screenfull.isFullscreen} handleToggleFullScreen={toggleFullScreen} />}


### PR DESCRIPTION
This is used in the full-screen interactive to flush the saves immediately so that linked interactive previews can access the latest save data.