### PR TITLE
Fix Drag & Drop items not registering if placed on top of another item.

### DIFF
--- a/src/drag-and-drop/components/container.tsx
+++ b/src/drag-and-drop/components/container.tsx
@@ -192,7 +192,7 @@ export const Container: React.FC<IProps> = ({ authoredState, interactiveState, s
     }
   }, [setInteractiveState]);
 
-  const [, drop] = useDrop({
+  const [{ itemDragging, isOver }, drop] = useDrop({
     accept: [DraggableItemWrapperType, DropZoneWrapperType],
     drop(wrapper: IDraggableItemWrapper | IDropZoneWrapper, monitor) {
       const didDrop = monitor.didDrop();
@@ -225,6 +225,7 @@ export const Container: React.FC<IProps> = ({ authoredState, interactiveState, s
       }
     },
     collect: monitor => ({
+      itemDragging: monitor.getItem(),
       isOver: !!monitor.isOver(),
     }),
   });
@@ -275,7 +276,11 @@ export const Container: React.FC<IProps> = ({ authoredState, interactiveState, s
               top: Math.min(canvasHeight - margin, top)
             };
           }
-          return <DraggableItemWrapper key={item.id} item={item} position={position} draggable={!readOnly} />;
+          // When an item is being dragged, temporarily disable all other draggables until it is dropped. This 
+          // ensures the item registers as dropped in a drop zone even if it is dropped on top of another 
+          // draggable that is already in the drop zone.
+          const tempDisable = isOver && itemDragging.item.id !== item.id;
+          return <DraggableItemWrapper key={item.id} item={item} position={position} draggable={!readOnly && !tempDisable} />;
         })
       }
     </div>

--- a/src/drag-and-drop/components/container.tsx
+++ b/src/drag-and-drop/components/container.tsx
@@ -192,7 +192,7 @@ export const Container: React.FC<IProps> = ({ authoredState, interactiveState, s
     }
   }, [setInteractiveState]);
 
-  const [{ itemDragging, isOver }, drop] = useDrop({
+  const [{ itemDragging }, drop] = useDrop({
     accept: [DraggableItemWrapperType, DropZoneWrapperType],
     drop(wrapper: IDraggableItemWrapper | IDropZoneWrapper, monitor) {
       const didDrop = monitor.didDrop();
@@ -225,8 +225,7 @@ export const Container: React.FC<IProps> = ({ authoredState, interactiveState, s
       }
     },
     collect: monitor => ({
-      itemDragging: monitor.getItem(),
-      isOver: !!monitor.isOver(),
+      itemDragging: monitor.getItem()
     }),
   });
 
@@ -279,7 +278,7 @@ export const Container: React.FC<IProps> = ({ authoredState, interactiveState, s
           // When an item is being dragged, temporarily disable all other draggables until it is dropped. This 
           // ensures the item registers as dropped in a drop zone even if it is dropped on top of another 
           // draggable that is already in the drop zone.
-          const tempDisable = isOver && itemDragging.item.id !== item.id;
+          const tempDisable = itemDragging && itemDragging.item.id !== item.id;
           return <DraggableItemWrapper key={item.id} item={item} position={position} draggable={!readOnly && !tempDisable} />;
         })
       }

--- a/src/drag-and-drop/components/draggable-item-wrapper.scss
+++ b/src/drag-and-drop/components/draggable-item-wrapper.scss
@@ -2,9 +2,12 @@
 
 .draggableItemWrapper {
   position: absolute;
+  pointer-events: none;
 
   &.draggable {
     cursor: move;
+    pointer-events: auto;
+
     &:hover {
       $border-width: 4px;
       border: $border-width solid #ffdd00;


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/182015941

[#182015941]

When an item is being dragged, we should disable all other draggable items until the item being dragged is dropped. This ensures that items dropped into a drop zone will register as dropped even if they are dropped directly on top of another item that's already in the drop zone.