### PR TITLE
Fix side-by-side interactive sometimes does not save state

### DIFF
--- a/src/side-by-side/components/runtime.tsx
+++ b/src/side-by-side/components/runtime.tsx
@@ -52,6 +52,9 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
 
   type InteractiveStateSide = "leftInteractiveState" | "rightInteractiveState";
 
+  // TODO: Type newInteractiveState and whatever calls handleNewInteractiveState better.
+  // It is possible that newInteractiveState could be a string which might cause an error
+  // since it would not be undefined but would not have a dataset property.
   const handleNewInteractiveState = (interactiveStateSide: InteractiveStateSide, newInteractiveState: any) => {
     setInteractiveState?.((prevState: IInteractiveState) => {
       if (newInteractiveState?.dataset && dataListeners.length > 0) {

--- a/src/side-by-side/components/runtime.tsx
+++ b/src/side-by-side/components/runtime.tsx
@@ -54,7 +54,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
 
   const handleNewInteractiveState = (interactiveStateSide: InteractiveStateSide, newInteractiveState: any) => {
     setInteractiveState?.((prevState: IInteractiveState) => {
-      if (newInteractiveState.dataset && dataListeners.length > 0) {
+      if (newInteractiveState?.dataset && dataListeners.length > 0) {
         updateDataListeners(newInteractiveState);
       }
       return {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/181641552

[#181641552]

The side-by-side interactive's `handleNewInteractiveState` method was sometimes throwing the error `Uncaught TypeError: Cannot read properties of undefined (reading 'dataset')` when trying to set the interactive state.