### PR TITLE
Add report items tests

### DIFF
--- a/src/open-response/components/report-item/app.test.tsx
+++ b/src/open-response/components/report-item/app.test.tsx
@@ -1,18 +1,17 @@
 import React from "react";
 import { act, render } from "@testing-library/react";
-import { useInitMessage } from "@concord-consortium/lara-interactive-api";
+import { useInitMessage, useReportItem } from "@concord-consortium/lara-interactive-api";
 import { AppComponent } from "./app";
 import { IAuthoredState, IInteractiveState } from "../types";
 
-jest.mock("./report-item", () => ({
-  ReportItemComponent: () => {
-    return <div>MockReportItemComponent</div>;
-  }
+jest.mock("@concord-consortium/lara-interactive-api", () => ({
+  useReportItem: jest.fn(),
 }));
 
 jest.mock("@concord-consortium/lara-interactive-api", () => ({
   useInitMessage: jest.fn(),
   useAutoSetHeight: jest.fn(),
+  useReportItem: jest.fn()
 }));
 
 const useInitMessageMock = useInitMessage as jest.Mock;
@@ -54,7 +53,13 @@ describe("Open response question report item", () => {
     });
   });
 
-  it("returns the report item component if initMessage is set and mode is reportItem", async () => {
+  it("calls useReportItem", () => {
+    const { container } = render(<AppComponent />);
+    expect(container).toBeDefined();
+    expect(useReportItem).toHaveBeenCalled();
+  });
+
+  it("doesn't render anything if initMessage is set and mode is reportItem", async () => {
     useInitMessageMock.mockReturnValue({
       version: 1,
       mode: "reportItem",
@@ -65,7 +70,7 @@ describe("Open response question report item", () => {
     const { container } = render(<AppComponent />);
     expect(container).toBeDefined();
     await act(async () => {
-      expect(container.innerHTML).toEqual(expect.stringContaining("MockReportItemComponent"));
+      expect(container.innerHTML).toEqual("");
     });
   });
 });

--- a/src/open-response/components/report-item/app.tsx
+++ b/src/open-response/components/report-item/app.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
-import { useInitMessage, useAutoSetHeight, IReportItemInitInteractive } from "@concord-consortium/lara-interactive-api";
-import { ReportItemComponent } from "./report-item";
+import { useInitMessage, useAutoSetHeight, IReportItemInitInteractive, useReportItem } from "@concord-consortium/lara-interactive-api";
+import { reportItemHandler } from "./report-item";
+import { IAuthoredState, IInteractiveState } from "../types";
 
 interface Props {}
 
@@ -8,6 +9,13 @@ export const AppComponent: React.FC<Props> = (props) => {
   const initMessage = useInitMessage<IReportItemInitInteractive<Record<string, unknown>, Record<string, unknown>>, Record<string, unknown>>();
 
   useAutoSetHeight();
+
+  useReportItem<IInteractiveState, IAuthoredState>({
+    metadata: {
+      compactAnswerReportItemsAvailable: true
+    },
+    handler: reportItemHandler
+  });
 
   if (!initMessage) {
     return (
@@ -33,5 +41,7 @@ export const AppComponent: React.FC<Props> = (props) => {
     );
   }
 
-  return <ReportItemComponent initMessage={initMessage} />;
+  // Report item app can provide UI in the prompt area too, but Open Response never does it. It only responds
+  // to getReportItemAnswer post message from the host window (portal report).
+  return null;
 };

--- a/src/open-response/components/report-item/report-item.tsx
+++ b/src/open-response/components/report-item/report-item.tsx
@@ -1,44 +1,32 @@
-import * as React from "react";
 import * as semver from "semver";
-import {
-  IReportItemInitInteractive, sendReportItemAnswer, IReportItemAnswerItem, useReportItem
-  } from "@concord-consortium/lara-interactive-api";
+import { sendReportItemAnswer, IReportItemAnswerItem, IGetReportItemAnswerHandler } from "@concord-consortium/lara-interactive-api";
 import { IAuthoredState, IInteractiveState } from "../types";
 
-interface Props {
-  initMessage: IReportItemInitInteractive;
-}
+export const reportItemHandler: IGetReportItemAnswerHandler<IInteractiveState, IAuthoredState> = request => {
+  const {interactiveState, platformUserId, version, itemsType} = request;
 
-export const ReportItemComponent: React.FC<Props> = (props) => {
-  useReportItem<IInteractiveState, IAuthoredState>({
-    metadata: {
-      compactAnswerReportItemsAvailable: false
-    },
-    handler: (request) => {
-      const {interactiveState, platformUserId, version} = request;
+  if (!version) {
+    // for hosts sending older, unversioned requests
+    // tslint:disable-next-line:no-console
+    console.error("Open Response Report Item Interactive: Missing version in getReportItemAnswer request.");
+  }
+  else if (semver.satisfies(version, "2.x")) {
+    const items: IReportItemAnswerItem[] = [];
 
-      if (!version) {
-        // for hosts sending older, unversioned requests
-        // tslint:disable-next-line:no-console
-        console.error("Open Response Report Item Interactive: Missing version in getReportItemAnswer request.");
+    if (itemsType === "fullAnswer") {
+      const { audioFile } = interactiveState as IInteractiveState;
+      if (audioFile) {
+        items.push({type: "attachment", name: audioFile});
       }
-      else if (semver.satisfies(version, "2.x")) {
-        const items: IReportItemAnswerItem[] = [];
-        const { audioFile } = interactiveState as IInteractiveState;
-        if (audioFile) {
-          items.push({type: "attachment", name: audioFile});
-        }
-        items.push({type: "answerText"});
-        sendReportItemAnswer({version, platformUserId, items});
-      } else {
-        // tslint:disable-next-line:no-console
-        console.error(
-          "Open Response Report Item Interactive: Unsupported version in getReportItemAnswer request:",
-          version
-        );
-      }
+      items.push({type: "answerText"});
     }
-  });
 
-  return null;
+    sendReportItemAnswer({version, platformUserId, items});
+  } else {
+    // tslint:disable-next-line:no-console
+    console.error(
+      "Open Response Report Item Interactive: Unsupported version in getReportItemAnswer request:",
+      version
+    );
+  }
 };

--- a/src/score-bot/components/app.tsx
+++ b/src/score-bot/components/app.tsx
@@ -79,10 +79,12 @@ const baseAuthoringProps = {
   uiSchema: {
     "ui:order": [
       "prompt",
-      "required",
       "*"
     ],
     version: {
+      "ui:widget": "hidden"
+    },
+    required: {
       "ui:widget": "hidden"
     },
     questionType: {

--- a/src/score-bot/components/report-item/app.test.tsx
+++ b/src/score-bot/components/report-item/app.test.tsx
@@ -1,18 +1,13 @@
 import React from "react";
 import { act, render } from "@testing-library/react";
-import { useInitMessage } from "@concord-consortium/lara-interactive-api";
+import { useInitMessage, useReportItem } from "@concord-consortium/lara-interactive-api";
 import { AppComponent } from "./app";
 import { IAuthoredState, IInteractiveState } from "../types";
-
-jest.mock("./report-item", () => ({
-  ReportItemComponent: () => {
-    return <div>MockReportItemComponent</div>;
-  }
-}));
 
 jest.mock("@concord-consortium/lara-interactive-api", () => ({
   useInitMessage: jest.fn(),
   useAutoSetHeight: jest.fn(),
+  useReportItem: jest.fn()
 }));
 
 const useInitMessageMock = useInitMessage as jest.Mock;
@@ -56,7 +51,13 @@ describe("Open response question report item", () => {
     });
   });
 
-  it("returns the report item component if initMessage is set and mode is reportItem", async () => {
+  it("calls useReportItem", () => {
+    const { container } = render(<AppComponent />);
+    expect(container).toBeDefined();
+    expect(useReportItem).toHaveBeenCalled();
+  });
+
+  it("doesn't render anything if initMessage is set and mode is reportItem", async () => {
     useInitMessageMock.mockReturnValue({
       version: 1,
       mode: "reportItem",
@@ -67,7 +68,7 @@ describe("Open response question report item", () => {
     const { container } = render(<AppComponent />);
     expect(container).toBeDefined();
     await act(async () => {
-      expect(container.innerHTML).toEqual(expect.stringContaining("MockReportItemComponent"));
+      expect(container.innerHTML).toEqual("");
     });
   });
 });

--- a/src/score-bot/components/report-item/app.tsx
+++ b/src/score-bot/components/report-item/app.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
-import { useInitMessage, useAutoSetHeight, IReportItemInitInteractive } from "@concord-consortium/lara-interactive-api";
-import { ReportItemComponent } from "./report-item";
+import { useInitMessage, useAutoSetHeight, IReportItemInitInteractive, useReportItem } from "@concord-consortium/lara-interactive-api";
+import { reportItemHandler } from "./report-item";
+import { IAuthoredState, IInteractiveState } from "../types";
 
 interface Props {}
 
@@ -8,6 +9,13 @@ export const AppComponent: React.FC<Props> = (props) => {
   const initMessage = useInitMessage<IReportItemInitInteractive<Record<string, unknown>, Record<string, unknown>>, Record<string, unknown>>();
 
   useAutoSetHeight();
+
+  useReportItem<IInteractiveState, IAuthoredState>({
+    metadata: {
+      compactAnswerReportItemsAvailable: true
+    },
+    handler: reportItemHandler
+  });
 
   if (!initMessage) {
     return (
@@ -33,5 +41,7 @@ export const AppComponent: React.FC<Props> = (props) => {
     );
   }
 
-  return <ReportItemComponent initMessage={initMessage} />;
+  // Report item app can provide UI in the prompt area too, but ScoreBOT never does it. It only responds
+  // to getReportItemAnswer post message from the host window (portal report).
+  return null;
 };

--- a/src/score-bot/components/report-item/report-item.tsx
+++ b/src/score-bot/components/report-item/report-item.tsx
@@ -18,8 +18,6 @@ export const reportItemHandler: IGetReportItemAnswerHandler<IInteractiveState, I
     const items: IReportItemAnswerItem[] = [];
 
     if (itemsType === "fullAnswer") {
-      // This item intentionally doesn't include answer text. Answer text is obtained by portal report itself
-      // and preloaded while it's waiting for report items response.
       items.push({ type: "answerText" });
 
       const score = getLastScore(interactiveState);

--- a/src/score-bot/components/report-item/report-item.tsx
+++ b/src/score-bot/components/report-item/report-item.tsx
@@ -1,67 +1,52 @@
 import * as React from "react";
 import * as semver from "semver";
-import {
-  IReportItemInitInteractive, sendReportItemAnswer, IReportItemAnswerItem, useReportItem
-} from "@concord-consortium/lara-interactive-api";
+import { sendReportItemAnswer, IReportItemAnswerItem, IGetReportItemAnswerHandler } from "@concord-consortium/lara-interactive-api";
 import { IAuthoredState, IInteractiveState } from "../types";
 import { renderStyledComponentToString } from "../../../shared/utilities/render-styled-component-to-string";
 import { FeedbackReport } from "./feedback-report";
 import { getLastFeedback, getLastScore, getMaxScore, getNumberOfAttempts, isFeedbackOutdated } from "../../utils";
 
-interface Props {
-  initMessage: IReportItemInitInteractive;
-}
+export const reportItemHandler: IGetReportItemAnswerHandler<IInteractiveState, IAuthoredState> = request => {
+  const { interactiveState, authoredState, platformUserId, version, itemsType } = request;
 
-export const ReportItemComponent: React.FC<Props> = (props) => {
-  useReportItem<IInteractiveState, IAuthoredState>({
-    metadata: {
-      compactAnswerReportItemsAvailable: true
-    },
-    handler: request => {
-      const { interactiveState, authoredState, platformUserId, version, itemsType } = request;
+  if (!version) {
+    // for hosts sending older, unversioned requests
+    // tslint:disable-next-line:no-console
+    console.error("ScoreBOT Report Item Interactive: Missing version in getReportItemAnswer request.");
+  }
+  else if (semver.satisfies(version, "2.x")) {
+    const items: IReportItemAnswerItem[] = [];
 
-      if (!version) {
-        // for hosts sending older, unversioned requests
-        // tslint:disable-next-line:no-console
-        console.error("ScoreBOT Report Item Interactive: Missing version in getReportItemAnswer request.");
-      }
-      else if (semver.satisfies(version, "2.x")) {
-        const items: IReportItemAnswerItem[] = [];
+    if (itemsType === "fullAnswer") {
+      // This item intentionally doesn't include answer text. Answer text is obtained by portal report itself
+      // and preloaded while it's waiting for report items response.
+      items.push({ type: "answerText" });
 
-        if (itemsType === "fullAnswer") {
-          // This item intentionally doesn't include answer text. Answer text is obtained by portal report itself
-          // and preloaded while it's waiting for report items response.
-          items.push({ type: "answerText" });
+      const score = getLastScore(interactiveState);
+      const maxScore = getMaxScore(authoredState);
+      const attempts = getNumberOfAttempts(interactiveState);
+      const feedback = getLastFeedback(authoredState, interactiveState);
+      const isOutdated = isFeedbackOutdated(interactiveState);
+      const feedbackHtml = renderStyledComponentToString(
+        <FeedbackReport score={score} maxScore={maxScore} attempts={attempts} feedback={feedback} outdated={isOutdated} />,
+      );
+      items.push({ type: "html", html: feedbackHtml });
+    }
 
-          const score = getLastScore(interactiveState);
-          const maxScore = getMaxScore(authoredState);
-          const attempts = getNumberOfAttempts(interactiveState);
-          const feedback = getLastFeedback(authoredState, interactiveState);
-          const isOutdated = isFeedbackOutdated(interactiveState);
-          const feedbackHtml = renderStyledComponentToString(
-            <FeedbackReport score={score} maxScore={maxScore} attempts={attempts} feedback={feedback} outdated={isOutdated} />,
-          );
-          items.push({ type: "html", html: feedbackHtml });
-        }
-
-        if (itemsType === "compactAnswer") {
-          const score = getLastScore(interactiveState);
-          const maxScore = getMaxScore(authoredState);
-          if (score !== null && maxScore !== null) {
-            items.push({ type: "score", score, maxScore });
-          }
-        }
-
-        sendReportItemAnswer({version, platformUserId, items, itemsType});
-      } else {
-        // tslint:disable-next-line:no-console
-        console.error(
-          "ScoreBOT Report Item Interactive: Unsupported version in getReportItemAnswer request:",
-          version
-        );
+    if (itemsType === "compactAnswer") {
+      const score = getLastScore(interactiveState);
+      const maxScore = getMaxScore(authoredState);
+      if (score !== null && maxScore !== null) {
+        items.push({ type: "score", score, maxScore });
       }
     }
-  });
 
-  return null;
+    sendReportItemAnswer({version, platformUserId, items, itemsType});
+  } else {
+    // tslint:disable-next-line:no-console
+    console.error(
+      "ScoreBOT Report Item Interactive: Unsupported version in getReportItemAnswer request:",
+      version
+    );
+  }
 };


### PR DESCRIPTION
This PR adds missing report item tests, both for Open Response and ScoreBOT.
I've slightly reorganized code between app.tsx and report-item.tsx files. report-item now only includes the handler function, so it's easier to write unit tests. I've realized that `useReportHandler` hook could make that even simpler by calling `sendReportItemAnswer` itself and expecting the provided handler to return `items` only. On the other hand, it'd make the the logic more hidden and it might be not so easy to understand what's going on in the report item. So, I've left that for now, as it's a minor change anyway. 