### PR TITLE
ScoreBOT: don't show score when when feedback is outdated / question unsubmitted

### DIFF
--- a/src/score-bot/components/report-item/report-item.test.tsx
+++ b/src/score-bot/components/report-item/report-item.test.tsx
@@ -21,7 +21,7 @@ const interactiveState = {
   answerType: "interactive_state",
   answerText: "Test answer",
   attempts: [
-    { score: 3, answerText: "bar" }
+    { score: 3, answerText: "Test answer" }
   ]
 } as IInteractiveState;
 
@@ -74,6 +74,31 @@ describe("reportItemHandler", () => {
 
       expect(scoreItem.score).toEqual(3);
       expect(scoreItem.maxScore).toEqual(4);
+    });
+  });
+
+  describe("when feedback is outdated", () => {
+    it("returns an empty list of report items (to clear previous score)", () => {
+      const interactiveStateWithOutdatedFeedback = { ...interactiveState};
+      interactiveStateWithOutdatedFeedback.answerText = "Updated answer text";
+
+      reportItemHandler({
+        version: "2.1.0",
+        platformUserId: "user1",
+        authoredState,
+        interactiveState: interactiveStateWithOutdatedFeedback,
+        itemsType: "compactAnswer",
+        requestId: 1
+      });
+
+      expect(sendReportItemAnswer).toHaveBeenCalledTimes(1);
+      const response: IReportItemAnswer = (sendReportItemAnswer as jest.Mock).mock.calls[0][0];
+
+      expect(response.items.length).toEqual(0);
+
+      expect(response.items.find(i => i.type === "score")).toBeUndefined();
+      expect(response.items.find(i => i.type === "answerText")).toBeUndefined();
+      expect(response.items.find(i => i.type === "html")).toBeUndefined();
     });
   });
 });

--- a/src/score-bot/components/report-item/report-item.tsx
+++ b/src/score-bot/components/report-item/report-item.tsx
@@ -32,10 +32,15 @@ export const reportItemHandler: IGetReportItemAnswerHandler<IInteractiveState, I
     }
 
     if (itemsType === "compactAnswer") {
-      const score = getLastScore(interactiveState);
-      const maxScore = getMaxScore(authoredState);
-      if (score !== null && maxScore !== null) {
-        items.push({ type: "score", score, maxScore });
+      // Do not send any score if feedback is outdated, as Portal Dashboard won't even mark
+      // the question as answered in this case.
+      const isOutdated = isFeedbackOutdated(interactiveState);
+      if (!isOutdated) {
+        const score = getLastScore(interactiveState);
+        const maxScore = getMaxScore(authoredState);
+        if (score !== null && maxScore !== null) {
+          items.push({ type: "score", score, maxScore });
+        }
       }
     }
 


### PR DESCRIPTION
[#182460339]

This PR addresses one of the problems found by Saravanan:
https://www.pivotaltracker.com/story/show/182460339/comments/232264981

Unsubmitted ScoreBOT question was still sending score item to Portal Dashboard. ScoreBOT becomes unsubmitted when user updates his answer and feedback is outdated.
