### PR TITLE
Added start of bar graph interactive [#183479024]

### DIFF
--- a/src/bar-graph/components/app.test.tsx
+++ b/src/bar-graph/components/app.test.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { useAuthoredState, useInitMessage, useInteractiveState
+        } from "@concord-consortium/lara-interactive-api";
+import { App } from "./app";
+import { IAuthoredState, IInteractiveState } from "./types";
+
+jest.unmock("react-jsonschema-form");
+
+jest.mock("@concord-consortium/lara-interactive-api", () => ({
+  useInitMessage: jest.fn(),
+  useAuthoredState: jest.fn(),
+  useInteractiveState: jest.fn(),
+  setSupportedFeatures: jest.fn(),
+  getFirebaseJwt: jest.fn().mockReturnValue({token: "test"}),
+}));
+
+const useInitMessageMock = useInitMessage as jest.Mock;
+const useAuthoredStateMock = useAuthoredState as jest.Mock;
+const useInteractiveStateMock = useInteractiveState as jest.Mock;
+
+const authoredState: IAuthoredState = {
+  version: 1,
+  questionType: "iframe_interactive"
+};
+
+const interactiveState: IInteractiveState = {
+  answerType: "interactive_state",
+};
+
+describe("Bar graph question", () => {
+  useInitMessageMock.mockReturnValue({
+    version: 1,
+    mode: "authoring",
+    authoredState
+  });
+  useAuthoredStateMock.mockReturnValue(authoredState);
+  useInteractiveStateMock.mockReturnValue(interactiveState);
+
+  it("renders in authoring mode", async () => {
+    const { container } = render(<App />);
+    expect(container).toBeDefined();
+  });
+});

--- a/src/bar-graph/components/app.tsx
+++ b/src/bar-graph/components/app.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { JSONSchema6 } from "json-schema";
+import { BaseQuestionApp } from "../../shared/components/base-question-app";
+import { IAuthoredState, IInteractiveState } from "./types";
+import { Runtime } from "./runtime";
+
+const baseAuthoringProps = {
+  schema: {
+    type: "object",
+    properties: {
+      version: {
+        type: "number",
+        default: 1
+      },
+      questionType: {
+        type: "string",
+        default: "iframe_interactive"
+      },
+    }
+  } as JSONSchema6,
+
+  uiSchema: {
+    version: {
+      "ui:widget": "hidden"
+    },
+    questionType: {
+      "ui:widget": "hidden"
+    }
+  }
+};
+
+const isAnswered = (interactiveState: IInteractiveState | null) => false; // TODO
+
+export const App = () => (
+  <BaseQuestionApp<IAuthoredState, IInteractiveState>
+    Runtime={Runtime}
+    baseAuthoringProps={baseAuthoringProps}
+    isAnswered={isAnswered}
+  />
+);

--- a/src/bar-graph/components/report-item/app.test.tsx
+++ b/src/bar-graph/components/report-item/app.test.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { act, render } from "@testing-library/react";
+import { useInitMessage, useReportItem } from "@concord-consortium/lara-interactive-api";
+import { AppComponent } from "./app";
+import { IAuthoredState, IInteractiveState } from "../types";
+
+jest.mock("@concord-consortium/lara-interactive-api", () => ({
+  useReportItem: jest.fn(),
+}));
+
+jest.mock("@concord-consortium/lara-interactive-api", () => ({
+  useInitMessage: jest.fn(),
+  useAutoSetHeight: jest.fn(),
+  useReportItem: jest.fn()
+}));
+
+const useInitMessageMock = useInitMessage as jest.Mock;
+
+const authoredState: IAuthoredState = {
+  version: 1,
+  questionType: "iframe_interactive",
+};
+
+const interactiveState: IInteractiveState = {
+  answerType: "interactive_state",
+};
+
+describe("Bar graph question report item", () => {
+  it("renders a 'Loading...' message if initMessage is not yet defined", async () => {
+    const { container } = render(<AppComponent />);
+    expect(container).toBeDefined();
+    await act(async () => {
+      expect(container.innerHTML).toEqual(expect.stringContaining("Loading..."));
+    });
+  });
+
+  it("renders an error message if mode is not reportItem", async () => {
+    useInitMessageMock.mockReturnValue({
+      version: 1,
+      mode: "authoring",
+      authoredState
+    });
+
+    const { container } = render(<AppComponent />);
+    expect(container).toBeDefined();
+    await act(async () => {
+      expect(container.innerHTML).toEqual(expect.stringContaining("This interactive is only available in 'reportItem' mode but 'authoring' was given."));
+    });
+  });
+
+  it("calls useReportItem", () => {
+    const { container } = render(<AppComponent />);
+    expect(container).toBeDefined();
+    expect(useReportItem).toHaveBeenCalled();
+  });
+
+  it("doesn't render anything if initMessage is set and mode is reportItem", async () => {
+    useInitMessageMock.mockReturnValue({
+      version: 1,
+      mode: "reportItem",
+      authoredState,
+      interactiveState
+    });
+
+    const { container } = render(<AppComponent />);
+    expect(container).toBeDefined();
+    await act(async () => {
+      expect(container.innerHTML).toEqual("");
+    });
+  });
+});

--- a/src/bar-graph/components/report-item/app.tsx
+++ b/src/bar-graph/components/report-item/app.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import { useInitMessage, useAutoSetHeight, IReportItemInitInteractive, useReportItem } from "@concord-consortium/lara-interactive-api";
+import { reportItemHandler } from "./report-item";
+import { IAuthoredState, IInteractiveState } from "../types";
+
+interface Props {}
+
+export const AppComponent: React.FC<Props> = (props) => {
+  const initMessage = useInitMessage<IReportItemInitInteractive<Record<string, unknown>, Record<string, unknown>>, Record<string, unknown>>();
+
+  useAutoSetHeight();
+
+  useReportItem<IInteractiveState, IAuthoredState>({
+    metadata: {
+      compactAnswerReportItemsAvailable: true
+    },
+    handler: reportItemHandler
+  });
+
+  if (!initMessage) {
+    return (
+      <div className="centered">
+        <div className="progress">
+          Loading...
+        </div>
+      </div>
+    );
+  }
+
+  if (initMessage.mode !== "reportItem") {
+    return (
+      <div>
+        <h1>Oops!</h1>
+        <p>
+        ¯\_(ツ)_/¯
+        </p>
+        <p>
+          This interactive is only available in &apos;reportItem&apos; mode but &apos;{initMessage.mode}&apos; was given.
+        </p>
+      </div>
+    );
+  }
+
+  // Report item app can provide UI in the prompt area too, but Open Response never does it. It only responds
+  // to getReportItemAnswer post message from the host window (portal report).
+  return null;
+};

--- a/src/bar-graph/components/report-item/report-item.test.tsx
+++ b/src/bar-graph/components/report-item/report-item.test.tsx
@@ -1,0 +1,28 @@
+/*
+import { reportItemHandler } from "./report-item";
+import { IAuthoredState, IInteractiveState } from "../types";
+import { IReportItemAnswer, sendReportItemAnswer } from "@concord-consortium/lara-interactive-api";
+
+jest.mock("@concord-consortium/lara-interactive-api", () => ({
+  sendReportItemAnswer: jest.fn()
+}));
+
+const authoredState: IAuthoredState = {
+  version: 1,
+  questionType: "iframe_interactive",
+};
+
+const interactiveState: IInteractiveState = {
+  answerType: "interactive_state",
+};
+*/
+
+describe("reportItemHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("has at least one test", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/src/bar-graph/components/report-item/report-item.tsx
+++ b/src/bar-graph/components/report-item/report-item.tsx
@@ -1,0 +1,26 @@
+import * as semver from "semver";
+import { sendReportItemAnswer, IReportItemAnswerItem, IGetReportItemAnswerHandler } from "@concord-consortium/lara-interactive-api";
+import { IAuthoredState, IInteractiveState } from "../types";
+
+export const reportItemHandler: IGetReportItemAnswerHandler<IInteractiveState, IAuthoredState> = request => {
+  const {platformUserId, version, itemsType} = request;
+
+  if (!version) {
+    // for hosts sending older, unversioned requests
+    // tslint:disable-next-line:no-console
+    console.error("Open Response Report Item Interactive: Missing version in getReportItemAnswer request.");
+  }
+  else if (semver.satisfies(version, "2.x")) {
+    const items: IReportItemAnswerItem[] = [];
+
+    // TODO: add items to report
+
+    sendReportItemAnswer({version, platformUserId, items, itemsType});
+  } else {
+    // tslint:disable-next-line:no-console
+    console.error(
+      "Open Response Report Item Interactive: Unsupported version in getReportItemAnswer request:",
+      version
+    );
+  }
+};

--- a/src/bar-graph/components/runtime.scss
+++ b/src/bar-graph/components/runtime.scss
@@ -1,0 +1,2 @@
+.barGraph {
+}

--- a/src/bar-graph/components/runtime.test.tsx
+++ b/src/bar-graph/components/runtime.test.tsx
@@ -1,0 +1,19 @@
+/*
+import React from "react";
+import { IAuthoredState, IInteractiveState } from "./types";
+
+const authoredState: IAuthoredState = {
+  version: 1,
+  questionType: "iframe_interactive",
+};
+
+const interactiveState: IInteractiveState = {
+  answerType: "interactive_state"
+};
+*/
+
+describe("Runtime", () => {
+  it("should have at least one test", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/src/bar-graph/components/runtime.tsx
+++ b/src/bar-graph/components/runtime.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { IRuntimeQuestionComponentProps } from "../../shared/components/base-question-app";
+import { IAuthoredState, IInteractiveState } from "./types";
+
+import css from "./runtime.scss";
+
+interface IProps extends IRuntimeQuestionComponentProps<IAuthoredState, IInteractiveState> {}
+
+export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, report }) => {
+  return (
+    <div className={css.barGraph}>TODO: Runtime View...</div>
+  );
+};

--- a/src/bar-graph/components/types.ts
+++ b/src/bar-graph/components/types.ts
@@ -1,0 +1,12 @@
+import { IAuthoringInteractiveMetadata, IRuntimeInteractiveMetadata } from "@concord-consortium/lara-interactive-api";
+
+// Note that TS interfaces should match JSON schema. Currently there's no way to generate one from the other.
+// TS interfaces are not available in runtime in contrast to JSON schema.
+
+export interface IAuthoredState extends IAuthoringInteractiveMetadata {
+  version: number;
+}
+
+export interface IInteractiveState extends IRuntimeInteractiveMetadata {
+  submitted?: boolean;
+}

--- a/src/bar-graph/index.tsx
+++ b/src/bar-graph/index.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { App } from "./components/app";
+
+ReactDOM.render(
+  <App/>,
+  document.getElementById("app")
+);

--- a/src/bar-graph/report-item-index.tsx
+++ b/src/bar-graph/report-item-index.tsx
@@ -1,0 +1,5 @@
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import { AppComponent } from "./components/report-item/app";
+
+ReactDOM.render(<AppComponent />, document.getElementById("app"));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,7 +42,9 @@ module.exports = (env, argv) => {
       'side-by-side': './src/side-by-side/index.tsx',
       'score-bot': './src/score-bot/index.tsx',
       'score-bot/report-item': './src/score-bot/report-item-index.tsx',
-      'wrapper': './src/shared/wrapper.tsx'
+      'wrapper': './src/shared/wrapper.tsx',
+      'bar-graph': './src/bar-graph/index.tsx',
+      'bar-graph/report-item': './src/bar-graph/report-item-index.tsx'
     },
     mode: 'development',
     output: {
@@ -229,6 +231,16 @@ module.exports = (env, argv) => {
       new HtmlWebpackPlugin({
         chunks: ['score-bot/report-item'],
         filename: 'score-bot/report-item/index.html',
+        template: 'src/shared/index.html'
+      }),
+      new HtmlWebpackPlugin({
+        chunks: ['bar-graph'],
+        filename: 'bar-graph/index.html',
+        template: 'src/shared/index.html'
+      }),
+      new HtmlWebpackPlugin({
+        chunks: ['bar-graph/report-item'],
+        filename: 'bar-graph/report-item/index.html',
         template: 'src/shared/index.html'
       }),
       // Wrapper page, useful for testing and Cypress.


### PR DESCRIPTION
This is the skeleton of the new bar graph question interactive.

To speed test development some code that is not used in the tests but will be later has been commented out to avoid lint errors.