### PR TITLE
Created start of generic demo framework [#183479068]

### DIFF
--- a/src/bar-graph/demo.tsx
+++ b/src/bar-graph/demo.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { DemoComponent } from "../shared/components/demo";
+import { App } from "./components/app";
+import { IAuthoredState, IInteractiveState } from "./components/types";
+
+const DemoContainer = () => {
+  const authoredState: IAuthoredState = {
+    version: 1,
+    questionType: "iframe_interactive"
+  };
+  const interactiveState: IInteractiveState = {
+    answerType: "interactive_state"
+  };
+
+  return (
+    <DemoComponent<IAuthoredState, IInteractiveState>
+      title="Bar Graph Demo"
+      App={<App />}
+      authoredState={authoredState}
+      interactiveState={interactiveState}
+    />
+  );
+};
+
+ReactDOM.render(
+  <DemoContainer />,
+  document.getElementById("app")
+);

--- a/src/shared/components/demo-authoring.scss
+++ b/src/shared/components/demo-authoring.scss
@@ -1,0 +1,7 @@
+.demoAuthoring {
+  margin: 10px;
+
+  h2 {
+    font-size: 18px;
+  }
+}

--- a/src/shared/components/demo-authoring.tsx
+++ b/src/shared/components/demo-authoring.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+import css from "./demo-authoring.scss";
+
+interface IProps<IAuthoredState> {
+  url: string;
+  authoredState: IAuthoredState;
+  setAuthoredState: React.Dispatch<React.SetStateAction<IAuthoredState>>
+}
+
+export function DemoAuthoringComponent<IAuthoredState>(props: IProps<IAuthoredState>) {
+  const {authoredState} = props;
+
+  return (
+    <div className={css.demoAuthoring}>
+      <h2>Authored State</h2>
+
+      <p>
+        (to be replaced in the future with real authoring component)
+      </p>
+
+      <pre>
+        {JSON.stringify(authoredState, null, 2)}
+      </pre>
+    </div>
+  );
+}

--- a/src/shared/components/demo.scss
+++ b/src/shared/components/demo.scss
@@ -1,0 +1,44 @@
+.demo {
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+
+  .header {
+    padding: 10px;
+
+    h1 {
+      margin: 0;
+      padding: 0;
+      font-weight: normal;
+      font-size: 20px;
+    }
+  }
+
+  .split {
+    height: 100%;
+    width: 100%;
+    display: flex;
+    gap: 10px;
+
+    > div {
+      flex-grow: 1;
+      padding: 0 10px 10px 10px;
+      width: 100%;
+      height: 100%;
+
+      iframe {
+        width: 100%;
+        height: 100%;
+        border: 1px solid #777;
+      }
+    }
+
+    div:nth-child(1) {
+      padding-right: 0;
+    }
+    div:nth-child(2) {
+      padding-left: 0;
+    }
+  }
+}

--- a/src/shared/components/demo.tsx
+++ b/src/shared/components/demo.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+
+import { IframeRuntime } from "../../shared/components/iframe-runtime";
+import { DemoAuthoringComponent } from "./demo-authoring";
+
+import css from "./demo.scss";
+
+interface IProps<IAuthoredState, IInteractiveState> {
+  title: string;
+  App: JSX.Element;
+  authoredState: IAuthoredState;
+  interactiveState: IInteractiveState;
+}
+
+const iframe = new URLSearchParams(window.location.search).get("iframe");
+
+export const DemoComponent = <IAuthoredState, IInteractiveState>(props: IProps<IAuthoredState, IInteractiveState>) => {
+  const {App, authoredState, interactiveState, title} = props;
+
+  // this is just dropped on the floor as we don't need to save in the demo
+  const setInteractiveState = () => undefined;
+
+  // TODO: in future once bar graph authoring is done setup a iframe proxy
+  // to send the new authored state to the root demo and have it re-render
+  const setAuthoredState = () => undefined;
+
+  switch (iframe) {
+    case "authoring-container":
+      return (
+        <DemoAuthoringComponent
+          url="demo.html?iframe=authoring"
+          authoredState={authoredState}
+          setAuthoredState={setAuthoredState}
+        />
+      );
+
+    case "runtime-container":
+      return (
+        <IframeRuntime
+          url="demo.html?iframe=runtime"
+          authoredState={authoredState}
+          interactiveState={interactiveState}
+          setInteractiveState={setInteractiveState}
+        />
+      );
+
+    case "authoring":
+      return App;
+
+    case "runtime":
+      return App;
+
+    default:
+      return (
+        <div className={css.demo}>
+          <div className={css.header}><h1>{title}</h1></div>
+          <div className={css.split}>
+            <div className={css.authoring}><iframe src="demo.html?iframe=authoring-container" /></div>
+            <div className={css.runtime}><iframe src="demo.html?iframe=runtime-container" /></div>
+          </div>
+        </div>
+      );
+  }
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,7 +44,8 @@ module.exports = (env, argv) => {
       'score-bot/report-item': './src/score-bot/report-item-index.tsx',
       'wrapper': './src/shared/wrapper.tsx',
       'bar-graph': './src/bar-graph/index.tsx',
-      'bar-graph/report-item': './src/bar-graph/report-item-index.tsx'
+      'bar-graph/report-item': './src/bar-graph/report-item-index.tsx',
+      'bar-graph/demo': './src/bar-graph/demo.tsx'
     },
     mode: 'development',
     output: {
@@ -241,6 +242,11 @@ module.exports = (env, argv) => {
       new HtmlWebpackPlugin({
         chunks: ['bar-graph/report-item'],
         filename: 'bar-graph/report-item/index.html',
+        template: 'src/shared/index.html'
+      }),
+      new HtmlWebpackPlugin({
+        chunks: ['bar-graph/demo'],
+        filename: 'bar-graph/demo.html',
         template: 'src/shared/index.html'
       }),
       // Wrapper page, useful for testing and Cypress.


### PR DESCRIPTION
This is being developed along with the bar graph interactive and will be completed once that interactive has a real authoring component.  Once completed this will allow the bar graph, along with any other question interactive in the repo, to expose a demo page that has both authoring and runtime on one page.

Here is what it looks like for now:

![image](https://user-images.githubusercontent.com/112938/195341027-a53ead98-3b05-4973-8bf5-d4f9475c05b2.png)
