### PR TITLE
Labbook: add "Show Upload Image button" authoring option and don't show "Take Snapshot" button when not necessary

### DIFF
--- a/src/labbook/components/app.tsx
+++ b/src/labbook/components/app.tsx
@@ -6,6 +6,7 @@ import { IAuthoredState, IInteractiveState } from "./types";
 import { FormValidation } from "react-jsonschema-form";
 import { baseAuthoringProps as drawingToolBaseAuthoringProps } from "../../drawing-tool/components/app";
 import deepmerge from "deepmerge";
+
 const baseAuthoringProps = deepmerge(drawingToolBaseAuthoringProps, {
   schema: {
     properties: {
@@ -32,9 +33,6 @@ const baseAuthoringProps = deepmerge(drawingToolBaseAuthoringProps, {
   } as JSONSchema6,
 
   uiSchema: {
-    "ui:order": [
-      "maxItems", "showItems", "questionType"
-    ],
     maxItems: {
       "ui:widget": "updown"
     },
@@ -54,6 +52,24 @@ const baseAuthoringProps = deepmerge(drawingToolBaseAuthoringProps, {
     // TODO: Some actual validation would be good.
     return errors;
   }
+});
+
+// This list combines all the fields from drawing-tool app and custom ones specified by Labbook.
+baseAuthoringProps.uiSchema["ui:order"] = [
+  "prompt", "required", "predictionFeedback", "hint", "backgroundSource", "showUploadImageButton", "snapshotTarget",
+  "backgroundImageUrl", "imageFit", "imagePosition",  "stampCollections", "maxItems", "showItems", "version", "questionType"
+];
+
+// Show "Show Upload Image button" checkbox only when user doesn't select "Upload" as background source.
+// In such case, this button must be shown.
+(baseAuthoringProps as any).schema.dependencies.backgroundSource.oneOf.filter((item: any) =>
+  item.properties.backgroundSource.enum[0] !== "upload"
+).forEach((item: any) => {
+  item.properties.showUploadImageButton = {
+    type: "boolean",
+    title: "Show Upload Image button",
+    default: true
+  };
 });
 
 // TODO: Figure out a better heuristic

--- a/src/labbook/components/runtime.scss
+++ b/src/labbook/components/runtime.scss
@@ -51,11 +51,18 @@
     flex-direction: row;
     justify-content: space-around;
     width: 100%;
+
     .buttons {
       display: flex;
       flex-direction: column;
-      width: 40%;
+      width: 160px;
+      height: 96px;
       align-items: center;
+      justify-content: center;
+
+      & > * {
+        width: 152px;
+      }
     }
   }
   .draw-tool-wrapper {

--- a/src/labbook/components/runtime.tsx
+++ b/src/labbook/components/runtime.tsx
@@ -57,7 +57,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     return result;
   };
 
-  const {maxItems, showItems} = authoredState;
+  const {maxItems, showItems, showUploadImageButton, backgroundSource } = authoredState;
   const {entries, selectedId} = ensureSelected(interactiveState as IInteractiveState) as IInteractiveState;
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -243,23 +243,27 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
         <div className={css["under-sketch"]}>
           {!readOnly &&
           <div className={css["buttons"]}>
-            <UploadImage
-              authoredState={authoredState}
-              setInteractiveState={setDrawingStateFn}
-              disabled={disableUI}
-              onUploadStart={onUploadStart}
-              onUploadComplete={onUploadEnd}
-            />
-
-            <TakeSnapshot
-              authoredState={authoredState}
-              interactiveState={{...selectedItem?.data, answerType: "interactive_state"}}
-              setInteractiveState={setDrawingStateFn}
-              disabled={disableUI}
-              onUploadStart={onUploadStart}
-              onUploadComplete={onUploadEnd}
-            />
-
+            {
+              (backgroundSource === "upload" || showUploadImageButton) &&
+              <UploadImage
+                authoredState={authoredState}
+                setInteractiveState={setDrawingStateFn}
+                disabled={disableUI}
+                onUploadStart={onUploadStart}
+                onUploadComplete={onUploadEnd}
+              />
+            }
+            {
+              backgroundSource === "snapshot" &&
+              <TakeSnapshot
+                authoredState={authoredState}
+                interactiveState={{...selectedItem?.data, answerType: "interactive_state"}}
+                setInteractiveState={setDrawingStateFn}
+                disabled={disableUI}
+                onUploadStart={onUploadStart}
+                onUploadComplete={onUploadEnd}
+              />
+            }
           </div>}
           <CommentField
             title={title}

--- a/src/labbook/components/types.ts
+++ b/src/labbook/components/types.ts
@@ -1,18 +1,17 @@
 import {
-  IInteractiveState as IDrawingToolInteractiveState
+  IInteractiveState as IDrawingToolInteractiveState,
+  IAuthoredState as IDrawingToolAuthoredState
 } from "../../drawing-tool/components/types";
-
 import {
-  IAuthoringInteractiveMetadata,
   IRuntimeInteractiveMetadata
 } from "@concord-consortium/lara-interactive-api";
 
-export interface IAuthoredState extends IAuthoringInteractiveMetadata{
+export interface IAuthoredState extends IDrawingToolAuthoredState {
   // IAuthoringLabbookMetadata adds:
   answerPrompt?: string;
-  version: number;
   maxItems: number;
   showItems: number;
+  showUploadImageButton: boolean;
 }
 
 export interface ILabbookEntry {


### PR DESCRIPTION
[#182021867]

This PR adds "Show Upload Image button" authoring option to Labbook. It also fixes "Take Snapshot" button that was always displayed, even if it wasn't functional at all (when the background source was URL or Upload).