### PR TITLE
Add custom number input ui widget [#183580065]

### DIFF
--- a/src/bar-graph/components/app.tsx
+++ b/src/bar-graph/components/app.tsx
@@ -56,12 +56,14 @@ const baseAuthoringProps = {
       maxYValue: {
         title: "Y-axis Max Value",
         type: "number",
-        default: 100
+        default: 100,
+        minimum: 1
       },
       yAxisCountBy: {
         title: "Y-axis Tick Spacing (this may be ignored if no space is available)",
         type: "number",
-        default: 10
+        default: 10,
+        minimum: 1
       },
       showValuesAboveBars: {
         type: "boolean",
@@ -71,7 +73,8 @@ const baseAuthoringProps = {
       numberOfDecimalPlaces: {
         title: "Number of Decimal Places (Bar Values)",
         type: "number",
-        default: 0
+        default: 0,
+        minimum: 0
       },
       bars: {
         type: "array",
@@ -86,6 +89,7 @@ const baseAuthoringProps = {
             value: {
               title: "Pre-defined bar value",
               type: "number",
+              minimum: 0
             },
             lockValue: {
               type: "boolean",
@@ -121,6 +125,15 @@ const baseAuthoringProps = {
     hint: {
       "ui:widget": "richtext"
     },
+    maxYValue: {
+      "ui:widget": "numberInput"
+    },
+    yAxisCountBy: {
+      "ui:widget": "numberInput"
+    },
+    numberOfDecimalPlaces: {
+      "ui:widget": "numberInput"
+    },
     bars: {
       items: {
         "ui:order": [
@@ -129,6 +142,9 @@ const baseAuthoringProps = {
           "lockValue",
           "color"
         ],
+        value: {
+          "ui:widget": "numberInput"
+        },
         color: {
           "ui:widget": "color"
         }

--- a/src/shared/components/base-authoring.tsx
+++ b/src/shared/components/base-authoring.tsx
@@ -8,6 +8,7 @@ import { ILinkedInteractiveProp, useLinkedInteractivesAuthoring } from "../hooks
 import "../../shared/styles/boostrap-3.3.7.css"; // necessary to style react-jsonschema-form
 import { getFirebaseJwt } from "@concord-consortium/lara-interactive-api";
 import { TokenServiceClient } from "@concord-consortium/token-service";
+import { NumberInputWidget } from "../widgets/number-input/number-index";
 
 import css from "../../shared/styles/authoring.scss";
 
@@ -32,7 +33,8 @@ export interface IFormContext<IAuthoredState> {
 // custom widgets
 const widgets = {
   richtext: RichTextWidget,
-  imageUpload: ImageUploadWidget
+  imageUpload: ImageUploadWidget,
+  numberInput: NumberInputWidget
 };
 
 export const getTokenServiceEnv = (claims: any) => {

--- a/src/shared/widgets/number-input/number-index.tsx
+++ b/src/shared/widgets/number-input/number-index.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from "react";
+import { WidgetProps } from "react-jsonschema-form";
+
+export const NumberInputWidget = (props: WidgetProps) => {
+  const [value, setValue] = useState<number|string>(props.schema.default === undefined ? "" : props.schema.default as number);
+  const noNegativeNumbers = props.schema.minimum !== undefined && props.schema.minimum >= 0;
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // don't allow negative numbers if minimum is 0
+    if ((e.key === "-") && noNegativeNumbers) {
+      e.preventDefault();
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (props.schema.minimum !== undefined) {
+      const newValue = parseFloat(e.target.value);
+      if (newValue < props.schema.minimum) {
+        e.preventDefault();
+        return;
+      }
+    }
+    setValue(e.target.value);
+    props.onChange(e.target.value);
+  };
+
+  return (
+    <input
+      className="form-control"
+      id={props.id}
+      type="number"
+      step={1}
+      min={props.schema.minimum}
+      value={value}
+      onKeyDown={handleKeyDown}
+      onChange={handleChange}
+    />
+  );
+};


### PR DESCRIPTION
This ui widget does not allow the user to enter numbers less than minimum schema value (if defined).  This is needed because while html allows you to enter a min for a number field it is only enforced by the up/down arrows and not text input (which is crazy).