### PR TITLE
Added viewport width/height to  Cypress config

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -17,4 +17,6 @@ export default defineConfig({
     baseUrl: 'http://localhost:8080',
     specPattern: 'cypress/e2e/**/*.{js,jsx,ts,tsx}',
   },
+  viewportHeight: 800,
+  viewportWidth: 1000
 })

--- a/cypress/e2e/bar-graph.test.js
+++ b/cypress/e2e/bar-graph.test.js
@@ -93,10 +93,10 @@ context("Test bar graph interactive", () => {
           dragDropMouseAndCheckValue(index, 110, "100");
           dragDropMouseAndCheckValue(index, 120, "99");
           dragDropMouseAndCheckValue(index, 150, "91");
-          dragDropMouseAndCheckValue(index, 200, "77");
-          dragDropMouseAndCheckValue(index, 300, "49");
-          dragDropMouseAndCheckValue(index, 400, "21");
-          dragDropMouseAndCheckValue(index, 470, "1");
+          dragDropMouseAndCheckValue(index, 200, "76");
+          dragDropMouseAndCheckValue(index, 300, "47");
+          dragDropMouseAndCheckValue(index, 400, "18");
+          dragDropMouseAndCheckValue(index, 460, "1");
           dragDropMouseAndCheckValue(index, 480, "0");
           dragDropMouseAndCheckValue(index, 600, "0");
         }


### PR DESCRIPTION
Without the explicit width/height the bar chart mouse slider values checks were brittle