### PR TITLE
Workaround LARA linked interactive issue

### DIFF
--- a/src/shared/hooks/use-linked-interactive-id.ts
+++ b/src/shared/hooks/use-linked-interactive-id.ts
@@ -3,7 +3,18 @@ import { ILinkedInteractive } from "@concord-consortium/lara-interactive-api";
 
 export const useLinkedInteractiveId = (label: string) => {
   const initMessage = useContextInitMessage();
-  const linkedInteractives = (initMessage && initMessage.mode !== "reportItem") ? initMessage.linkedInteractives : [];
+  let linkedInteractives = (initMessage && initMessage.mode !== "reportItem") ? initMessage.linkedInteractives : [];
+  // This is workaround of a bug in LARA. Usually the init message is like:
+  // `linkedInteractives: [ ... ]`
+  // as that's what LARA ManagedInteractive.to_hash returns.
+  // However, after saving the interactive edit dialog there's an unnecessary nesting:
+  // `linkedInteractives: { linkedInteractives: [ ... ] }`
+  // It happens because LARA page_item.set_linked_interactives expects linked interactives to include two separate
+  // props: linkedInteractives and linkedState (optional). And they get embedded in the edit form that is later
+  // used to generate the init message.
+  if ((linkedInteractives as any).linkedInteractives) {
+    linkedInteractives = (linkedInteractives as any).linkedInteractives;
+  }
   const linkedInteractive = linkedInteractives.find((interactive: ILinkedInteractive) => interactive.label === label);
   return linkedInteractive?.id;
 };


### PR DESCRIPTION
[[#182710781]](https://www.pivotaltracker.com/story/show/182710781)

I'm opening this PR only in case the bug is important to fix ASAP. I doubt so, as it's been around for a while (it's not a regression, but most likely LARA2 problem). It's also a small note to myself about the problem. Otherwise, I wouldn't merge it.

Generally, ManagedInteractive.to_hash method returns a different form of linked_interactives than what the update request is expecting. And there seems to be an assumption that they're the same. Unfortunately, I don't know how to fix that properly in LARA yet. I'll have to discuss it with Ethan or Scott when I'm back next week.

