### PR TITLE
Fix Drawing Tool state saving on background update

### DIFF
--- a/cypress/e2e/labbook.test.js
+++ b/cypress/e2e/labbook.test.js
@@ -60,7 +60,7 @@ context("Test Lab book interactive", () => {
           mode: "runtime",
           authoredState: UploadImageAuthoredState
         });
-  
+
         le.getThumbnailWrapper().should("have.length", 4);
         le.getThumbnailButton(1).should("be.enabled");
         le.getThumbnailTitle(1).should("have.text", "A");
@@ -68,17 +68,17 @@ context("Test Lab book interactive", () => {
         le.getThumbnailClose(1).should("be.enabled");
         le.getDrawToolThumbnailTitle().should("have.text", "A");
         le.getCommentsFieldThumbnailTitle().should("have.text", "A");
-  
+
         le.getThumbnailButton(2).should("have.text", "New");
         le.getThumbnailTitle(2).should("have.text", "");
         le.getThumbnailPlusButton(2).should("exist");
         le.getThumbnailClose(2).should("not.exist");
-  
+
         le.getThumbnailButton(3).should("have.text", "New");
         le.getThumbnailTitle(3).should("have.text", "");
         le.getThumbnailPlusButton(3).should("exist");
         le.getThumbnailClose(3).should("not.exist");
-  
+
         le.getThumbnailButton(4).should("have.text", "New");
         le.getThumbnailTitle(4).should("have.text", "");
         le.getThumbnailPlusButton(4).should("exist");
@@ -145,7 +145,7 @@ context("Test Lab book interactive", () => {
         le.getPreviousArrow().should("be.disabled");
         le.getNextArrow().should("be.enabled");
         le.getNextArrow().click();
-  
+
         le.getThumbnailTitle(1).should("have.text", "B");
         le.getThumbnailTitle(2).should("have.text", "C");
         le.getThumbnailTitle(3).should("have.text", "D");
@@ -222,7 +222,7 @@ context("Test Lab book interactive", () => {
         le.getUploadButton().should("have.text", "Upload Image");
         le.getUploadButton().selectFile('cypress/fixtures/image-upload.png', {force: true});
         le.getUploadButton().should("have.text", "Please Wait");
-        cy.wait(500);
+        cy.wait(4000);
         le.getThumbnail(1).find(".dt-canvas-container").should("exist");
         le.getUploadButton().should("have.text", "Upload Image");
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "babel-core": "^6.26.3",
         "babel-jest": "^26.6.3",
         "babel-loader": "^8.2.3",
-        "canvas": "2.9.1",
+        "canvas": "2.10.2",
         "css-loader": "^4.3.0",
         "cypress": "^10.7.0",
         "enzyme": "^3.11.0",
@@ -9483,14 +9483,14 @@
       ]
     },
     "node_modules/canvas": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.9.1.tgz",
-      "integrity": "sha512-vSQti1uG/2gjv3x6QLOZw7TctfufaerTWbVe+NSduHxxLGB+qf3kFgQ6n66DSnuoINtVUjrLLIK2R+lxrBG07A==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.10.2.tgz",
+      "integrity": "sha512-FSmlsip0nZ0U4Zcfht0qBJqDhlfGuevTZKE8h+dBOYrJjGvY3iqMGSzzbvkaFhvMXiVxfcMaPHS/kge++T5SKg==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
-        "nan": "^2.15.0",
+        "nan": "^2.17.0",
         "simple-get": "^3.0.3"
       },
       "engines": {
@@ -18786,9 +18786,9 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
       "devOptional": true
     },
     "node_modules/nanoid": {
@@ -33732,13 +33732,13 @@
       "integrity": "sha512-xjlIAFHucBRSMUo1kb5D4LYgcN1M45qdKP++lhqowDpwJwGkpIRTt5qQqnhxjj1vHcI7nrJxWhCC1ATrCEBTcw=="
     },
     "canvas": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.9.1.tgz",
-      "integrity": "sha512-vSQti1uG/2gjv3x6QLOZw7TctfufaerTWbVe+NSduHxxLGB+qf3kFgQ6n66DSnuoINtVUjrLLIK2R+lxrBG07A==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.10.2.tgz",
+      "integrity": "sha512-FSmlsip0nZ0U4Zcfht0qBJqDhlfGuevTZKE8h+dBOYrJjGvY3iqMGSzzbvkaFhvMXiVxfcMaPHS/kge++T5SKg==",
       "devOptional": true,
       "requires": {
         "@mapbox/node-pre-gyp": "^1.0.0",
-        "nan": "^2.15.0",
+        "nan": "^2.17.0",
         "simple-get": "^3.0.3"
       }
     },
@@ -40892,9 +40892,9 @@
       }
     },
     "nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
       "devOptional": true
     },
     "nanoid": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "babel-core": "^6.26.3",
     "babel-jest": "^26.6.3",
     "babel-loader": "^8.2.3",
-    "canvas": "2.9.1",
+    "canvas": "2.10.2",
     "css-loader": "^4.3.0",
     "cypress": "^10.7.0",
     "enzyme": "^3.11.0",

--- a/src/drawing-tool/components/drawing-tool.test.tsx
+++ b/src/drawing-tool/components/drawing-tool.test.tsx
@@ -6,6 +6,7 @@ jest.mock("drawing-tool", () => class DrawingToolLib {
   on = jest.fn();
   pauseHistory = jest.fn();
   unpauseHistory = jest.fn();
+  save = jest.fn();
   setBackgroundImage = setBackgroundImageMock;
 });
 

--- a/src/drawing-tool/components/drawing-tool.tsx
+++ b/src/drawing-tool/components/drawing-tool.tsx
@@ -103,9 +103,14 @@ export const DrawingTool: React.FC<IProps> = ({ authoredState, interactiveState,
       imageOpts.position = "center"; // anything else is an invalid combo
     }
     drawingToolRef.current.pauseHistory();
+    const oldDtState = drawingToolRef.current.save();
     drawingToolRef.current.setBackgroundImage(imageOpts, bgFit, () => {
       drawingToolRef.current.unpauseHistory();
-      if (readOnly) return;
+      const newDtState = drawingToolRef.current.save();
+      if (readOnly || oldDtState === newDtState) {
+        // Do not call setInteractiveStateRef if state hasn't changed.
+        return;
+      }
       setInteractiveStateRef.current({ drawingState: drawingToolRef.current.save() });
     });
   }, [authoredState.backgroundImageUrl, authoredState.backgroundSource, authoredState.imageFit, authoredState.imagePosition, readOnly]);


### PR DESCRIPTION
Fixes:
- [**[Lab book]** Lab book is considered to be an answered question in the reports even if the user doesn't use it (opening AP page is enough)](https://www.pivotaltracker.com/story/show/183716771)
- [**[Drawing Tool]** If question is marked as required, submit button is enabled by default in version V1.10.3](https://www.pivotaltracker.com/story/show/183661940)