### PR TITLE
ImageQuestion: reset history after background is set

### DIFF
--- a/src/drawing-tool/components/drawing-tool.test.tsx
+++ b/src/drawing-tool/components/drawing-tool.test.tsx
@@ -4,8 +4,7 @@ import { DrawingTool, LARA_IMAGE_PROXY } from "./drawing-tool";
 
 jest.mock("drawing-tool", () => class DrawingToolLib {
   on = jest.fn();
-  pauseHistory = jest.fn();
-  unpauseHistory = jest.fn();
+  resetHistory = jest.fn();
   save = jest.fn();
   setBackgroundImage = setBackgroundImageMock;
 });

--- a/src/drawing-tool/components/drawing-tool.tsx
+++ b/src/drawing-tool/components/drawing-tool.tsx
@@ -102,9 +102,8 @@ export const DrawingTool: React.FC<IProps> = ({ authoredState, interactiveState,
     if (bgFit === "resizeCanvasToBackground") {
       imageOpts.position = "center"; // anything else is an invalid combo
     }
-    drawingToolRef.current.pauseHistory();
     drawingToolRef.current.setBackgroundImage(imageOpts, bgFit, () => {
-      drawingToolRef.current.unpauseHistory();
+      drawingToolRef.current.resetHistory();
     });
   }, [authoredState.backgroundImageUrl, authoredState.backgroundSource, authoredState.imageFit, authoredState.imagePosition]);
 


### PR DESCRIPTION
This PR fixes the issue that is well described here: [[#183750971]](https://www.pivotaltracker.com/story/show/183750971)

Instead of pausing the history, it's reset right after the background image is set.

This prevents students from undoing/removing authored background. It also works better with snapshots or background uploaded by users, as they can no longer remove it using undo button - it wasn't working anyway, as image question stores this student background separately and sets it each time the interactive is initialized.