### PR TITLE
TecRock table: display user notes

### DIFF
--- a/packages/tecrock-table/src/components/runtime.tsx
+++ b/packages/tecrock-table/src/components/runtime.tsx
@@ -57,7 +57,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
         <div className={css.table}>
           <table>
             <thead>
-              <tr><th>Rock</th><th>Temperature</th><th>Pressure</th></tr>
+              <tr><th>Rock</th><th>Temperature</th><th>Pressure</th><th>Notes</th></tr>
             </thead>
             <tbody>
               {


### PR DESCRIPTION
[#184074624]

Related to: https://github.com/concord-consortium/tectonic-explorer/pull/294
Currently, TecRock table iterates over all the columns in the dataset, so it was enough to add a new header. Soon, there'll be more advanced filtering, as authors might want to show/hide selected columns.