### PR TITLE
Image: fix zoom button layout, rm unused allowLightbox

### DIFF
--- a/packages/image/src/components/app.tsx
+++ b/packages/image/src/components/app.tsx
@@ -42,10 +42,6 @@ const baseAuthoringProps = {
         title: "Credit Link Display Text",
         type: "string"
       },
-      allowLightbox: {
-        title: "Allow lightbox",
-        type: "boolean"
-      },
       scaling: {
         title: "Choose a scaling style for the image",
         type: "string",
@@ -98,9 +94,6 @@ const baseAuthoringProps = {
     },
     creditLinkDisplayText: {
       "ui:help": "Text to display for the link to attribution (leave blank to display the url)"
-    },
-    allowLightbox: {
-      "ui:help": "Allow image to be shown in lightbox"
     },
     scaling: {
       "ui:widget": "radio"

--- a/packages/image/src/components/runtime.scss
+++ b/packages/image/src/components/runtime.scss
@@ -1,49 +1,62 @@
 @import "@concord-consortium/question-interactives-helpers/src/styles/helpers";
-.runtime{
-  height:100%;
-}
-.imageContainer{
-  width: 100%;
-  margin-bottom: 10px;
-  img{
-    max-width: 100%;
-    height: auto;
-  }
-  &.fitWidth{
-    img{
-      width: 100%;
+
+.runtime {
+  height: 100%;
+
+  .imageContainer {
+    width: 100%;
+    margin-bottom: 10px;
+
+    img {
+      max-width: 100%;
+      height: auto;
+    }
+
+    &.fitWidth {
+      img {
+        width: 100%;
+      }
+    }
+
+    &.originalDimensions {
+      img {
+        width: auto;
+      }
     }
   }
-  &.originalDimensions{
-    img{
-      width: auto;
+
+  .captionAndZoomIn {
+    display: flex;
+    flex-direction: row;
+
+    .textContainer {
+      // flex: 1 sets flex-grow and ensures that text container takes up all available space.
+      flex: 1;
+
+      .caption {
+        font-size: 0.8em;
+        width: 100%;
+        line-height: 1.5em;
+      }
+
+      .credit {
+        font-size: 0.8em;
+        width: 100%;
+        line-height: 1.2em;
+      }
+
+      .creditLink {
+        font-size: 0.8em;
+        width: 100%;
+        line-height: 1.2em;
+      }
+    }
+
+    .viewHighRes {
+      width: 30px;
+      height: 30px;
+      font-size: 0.8em;
+      cursor: zoom-in;
     }
   }
-}
-.caption{
-  font-size: 0.8em;
-  width: 100%;
-  line-height: 1.5em;
-}
-
-.credit{
-  font-size: 0.8em;
-  width: 100%;
-  line-height: 1.2em;
-}
-
-.creditLink{
-  font-size: 0.8em;
-  width: 100%;
-  line-height: 1.2em;
-}
-
-.viewHighRes{
-  position: absolute;
-  right: 30px;
-  width: 30px;
-  height: 30px;
-  margin-top:-30px;
-  font-size: 0.8em;
-  cursor: zoom-in;
 }

--- a/packages/image/src/components/runtime.test.tsx
+++ b/packages/image/src/components/runtime.test.tsx
@@ -13,7 +13,6 @@ const authoredState: IAuthoredState = {
   credit: "Copyright Concord Consortium",
   creditLink: "https://concord.org",
   creditLinkDisplayText: "Concord.org",
-  allowLightbox: true,
   scaling: "fitWidth"
 };
 const naturalWidthImageAuthoredState: IAuthoredState = {
@@ -25,7 +24,6 @@ const naturalWidthImageAuthoredState: IAuthoredState = {
   credit: "Copyright Concord Consortium",
   creditLink: "https://concord.org",
   creditLinkDisplayText: "Concord.org",
-  allowLightbox: true,
   scaling: "originalDimensions"
 };
 const onlyHighResUrlAuthoredState: IAuthoredState = {
@@ -37,7 +35,6 @@ const onlyHighResUrlAuthoredState: IAuthoredState = {
   credit: "Copyright Concord Consortium",
   creditLink: "https://concord.org",
   creditLinkDisplayText: "Concord.org",
-  allowLightbox: true,
   scaling: "fitWidth"
 };
 

--- a/packages/image/src/components/runtime.tsx
+++ b/packages/image/src/components/runtime.tsx
@@ -5,8 +5,9 @@ import ReactDOMServer from "react-dom/server";
 import { log } from "@concord-consortium/lara-interactive-api";
 import { DecorateChildren } from "@concord-consortium/text-decorator";
 import { useGlossaryDecoration } from "@concord-consortium/question-interactives-helpers/src/hooks/use-glossary-decoration";
-import css from "./runtime.scss";
 import ZoomIcon from "@concord-consortium/question-interactives-helpers/src/icons/zoom-in.svg";
+
+import css from "./runtime.scss";
 
 interface IProps {
   authoredState: IAuthoredState;
@@ -87,13 +88,19 @@ export const Runtime: React.FC<IProps> = ({ authoredState }) => {
           onLoad={getOriginalImageSize}
         />
       </div>
-      {caption &&
-        <DecorateChildren decorateOptions={decorateOptions}>
-          <div className={css.caption}>{caption}</div>
-        </DecorateChildren> }
-      {credit && <div className={css.credit}>{credit}</div>}
-      {getCreditLink()}
-      <div className={`${css.viewHighRes} .glyphicon-zoom-in`} onClick={handleClick}><ZoomIcon /></div>
+      <div className={css.captionAndZoomIn}>
+        <div className={css.textContainer}>
+          {
+            caption &&
+            <DecorateChildren decorateOptions={decorateOptions}>
+              <div className={css.caption}>{caption}</div>
+            </DecorateChildren>
+          }
+          { credit && <div className={css.credit}>{credit}</div> }
+          { getCreditLink() }
+        </div>
+        <div className={`${css.viewHighRes} .glyphicon-zoom-in`} onClick={handleClick}><ZoomIcon /></div>
+      </div>
     </div>
   );
 };

--- a/packages/image/src/components/types.ts
+++ b/packages/image/src/components/types.ts
@@ -10,6 +10,5 @@ export interface IAuthoredState {
   credit?: string;
   creditLink?: string;
   creditLinkDisplayText?: string;
-  allowLightbox?: boolean;
   scaling?: "fitWidth" | "originalDimensions";
 }

--- a/packages/tests-e2e/e2e/image.test.js
+++ b/packages/tests-e2e/e2e/image.test.js
@@ -83,7 +83,6 @@ context("Test Image interactive", () => {
       app.should("include.text", "Credit");
       app.should("include.text", "Credit Link");
       app.should("include.text", "Credit Link Display Text");
-      app.should("include.text", "Allow lightbox");
       app.should("include.text", "Choose a scaling style for the image");
       app.should("include.text", "Drop an image here, or click to select a file to upload. Only popular image formats are supported (e.g. png, jpeg, gif, svg, webp).");
 

--- a/packages/tests-e2e/e2e/image.test.js
+++ b/packages/tests-e2e/e2e/image.test.js
@@ -10,7 +10,6 @@ const authoredStateSample = {
   credit: "Copyright Concord Consortium",
   creditLink: "https://concord.org",
   creditLinkDisplayText: "Concord.org",
-  allowLightbox: true,
   scaling: "fitWidth"
 };
 
@@ -95,8 +94,6 @@ context("Test Image interactive", () => {
       cy.getIframeBody().find("#root_credit").should("include.text", authoredStateSample.credit);
       cy.getIframeBody().find("#root_creditLink").should("have.value", authoredStateSample.creditLink);
       cy.getIframeBody().find("#root_creditLinkDisplayText").should("have.value", authoredStateSample.creditLinkDisplayText);
-      cy.getIframeBody().find("#root_allowLightbox").should("be.checked");
-
     });
   });
 


### PR DESCRIPTION
[[#183726314]](https://www.pivotaltracker.com/story/show/183726314)

Issues are described well in the PT story. This PR fixes zoom-in button positioning and removes unused authoring property.