### PR TITLE
fix: Remove unneeded scrollbars from Labbook thumbnail chooser [PT-184687743]

### DIFF
--- a/packages/labbook/src/components/thumbnail-chooser/thumbnail-chooser.scss
+++ b/packages/labbook/src/components/thumbnail-chooser/thumbnail-chooser.scss
@@ -18,7 +18,7 @@
     height: 110px;
     display: flex;
     align-items: center;
-    overflow: scroll;
+    overflow: hidden;
   }
 
   .arrow-button {


### PR DESCRIPTION
Hides the scrollbars in the Labbook thumbnail chooser as it already has arrow controls to scroll through the thumbnails.