### PR TITLE
feat: Added logging of labbook comments [PT-179239685]

### DIFF
--- a/packages/labbook/src/components/comment-field.tsx
+++ b/packages/labbook/src/components/comment-field.tsx
@@ -1,7 +1,8 @@
-import React, { ChangeEvent } from "react";
+import React, { ChangeEvent, useCallback, useEffect, useState } from "react";
 import { ThumbnailTitle } from "./thumbnail-chooser/thumbnail-title";
-import css from "./comment-field.scss";
+import { Log } from "../labbook-logging";
 
+import css from "./comment-field.scss";
 
 export interface ICommentFieldProps {
   title: string,
@@ -11,22 +12,40 @@ export interface ICommentFieldProps {
   readOnly: boolean;
 }
 
-export const CommentField: React.FC<ICommentFieldProps> = (props) => {
+const kLogCommentWaitTimeout = 10 * 1000;  // 10 seconds
+
+export const CommentField = (props: ICommentFieldProps) => {
   const {title, comment, empty, setComment, readOnly } = props;
   const placeholder = comment
     ? comment
     : "Add comment … "; // TODO: I18n
+  const [logCommentChanged, setLogCommentChanged] = useState(false);
 
-  const handleTextAreaChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+  const logCommentChange = useCallback(() => {
+    if (logCommentChanged) {
+      Log({action: "comment updated", data: {comment}});
+      setLogCommentChanged(false);
+    }
+  }, [logCommentChanged, comment]);
+
+  // Log a text change after a timeout when it changes, unless it has already been logged by the blur event
+  // on the textarea.  This handles the user typing in a comment and then never leaving the field.
+  useEffect(() => {
+    const timer = setTimeout(() => logCommentChange(), kLogCommentWaitTimeout);
+    return () => clearTimeout(timer);
+  }, [logCommentChange]);
+
+  const handleTextAreaChange = useCallback((event: ChangeEvent<HTMLTextAreaElement>) => {
     const text = event.target.value;
     setComment(text);
-  };
+    setLogCommentChanged(text !== comment);
+  }, [comment, setComment]);
 
   return (
       <div className={css["comment-field"]} data-testid="comment-field">
         <ThumbnailTitle title={title} empty={empty}/>
         {readOnly ? <div className={css["comment-field-text"]} data-testid="comment-field-text">{comment.length === 0 ? <em>No comment.</em> : comment}</div> : null}
-        {!readOnly ? <textarea disabled={empty} placeholder={placeholder} value={comment} onChange={handleTextAreaChange} data-testid="comment-field-textarea"></textarea> : null}
+        {!readOnly ? <textarea disabled={empty} placeholder={placeholder} value={comment} onChange={handleTextAreaChange} onBlur={logCommentChange} data-testid="comment-field-textarea"></textarea> : null}
       </div>
   );
 };

--- a/packages/labbook/src/labbook-logging.ts
+++ b/packages/labbook/src/labbook-logging.ts
@@ -9,6 +9,7 @@ export type LabbookLogType =
   | "item deleted"
   | "item selected"
   | "upload fail"
+  | "comment updated"
 
 export interface ILogParams {
   action: LabbookLogType;


### PR DESCRIPTION
Added logging on labbook comments, trigger in two ways:

1. When the comment textarea is blurred and the comment has changed the change is logged.

2. When the comment changes the comment is logged after a 10 second delay (to avoid flooding the logs) unless it is has already been logged by the blur event.  This 10 second delay is reset on each change to the text area.