### PR TITLE
fix: Changed iframe runtime to accept readOnly property [PT-184981533]

### DIFF
--- a/packages/carousel/src/components/runtime.tsx
+++ b/packages/carousel/src/components/runtime.tsx
@@ -5,7 +5,6 @@ import { renderHTML } from "@concord-consortium/question-interactives-helpers/sr
 import { Carousel } from "react-responsive-carousel";
 import { libraryInteractiveIdToUrl } from "@concord-consortium/question-interactives-helpers/src/utilities/library-interactives";
 import { cssUrlValue } from "@concord-consortium/question-interactives-helpers/src/utilities/css-url-value";
-import classNames from "classnames";
 import { DynamicText } from "@concord-consortium/dynamic-text";
 import { useAccessibility } from "@concord-consortium/lara-interactive-api";
 
@@ -113,7 +112,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
                                                             subinteractive_id: interactive.id,
                                                           };
           return (
-            <div key={index} className={classNames(css.runtime, { [css.disabled]: readOnly })}>
+            <div key={index} className={css.runtime}>
               { authoredState.prompt &&
                 <div><DynamicText>{renderHTML(authoredState.prompt)}</DynamicText></div> }
                 <IframeRuntime
@@ -127,6 +126,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
                   onUnloadCallback={handleNewInteractiveState.bind(null, interactive.id)}
                   scrolling="no"
                   accessibility={accessibility}
+                  readOnly={readOnly}
                 />
             </div>
           );

--- a/packages/helpers/src/components/iframe-runtime.tsx
+++ b/packages/helpers/src/components/iframe-runtime.tsx
@@ -22,6 +22,7 @@ interface IProps {
   interactiveState: any;
   logRequestData?: Record<string, unknown>;
   report?: boolean;
+  readOnly?: boolean;
   url: string;
   initMessage?: IInitInteractive | null;
   setInteractiveState: (state: any) => void | null;
@@ -37,7 +38,7 @@ interface IProps {
 export const IframeRuntime: React.FC<IProps> =
   ({ authoredState, id, iframeStyling, interactiveState, logRequestData, report,
       url, setHint, setInteractiveState, addLocalLinkedDataListener, initMessage,
-      scale, onUnloadCallback, scrolling, flushOnSave, accessibility }) => {
+      scale, onUnloadCallback, scrolling, flushOnSave, accessibility, readOnly }) => {
     const [ iframeHeight, setIframeHeight ] = useState(300);
     const [ internalHint, setInternalHint ] = useState("");
     const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -209,6 +210,11 @@ export const IframeRuntime: React.FC<IProps> =
                         : scaledIframeStyle
                           ? scaledIframeStyle
                           : {width: "100%", height: iframeHeight, border: "none"};
+
+  if (readOnly) {
+    iframeStyle.pointerEvents = "none";
+  }
+
   return (
     <>
       <iframe
@@ -216,6 +222,7 @@ export const IframeRuntime: React.FC<IProps> =
         src={url}
         style={iframeStyle}
         scrolling={scrolling}
+        tabIndex={readOnly ? -1 : undefined}
         allow="geolocation; microphone; camera; bluetooth; clipboard-read; clipboard-write"
       />
       { internalHint &&

--- a/packages/scaffolded-question/src/components/runtime.tsx
+++ b/packages/scaffolded-question/src/components/runtime.tsx
@@ -111,7 +111,8 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
         authoredState={currentInteractive.authoredState}
         interactiveState={subState}
         setInteractiveState={readOnly ? undefined : handleNewInteractiveState.bind(null, currentInteractive.id)}
-        report={readOnly}
+        report={report}
+        readOnly={readOnly}
         logRequestData={logRequestData}
         // Since child interactives still have a functioning onUnload handler after a scaffolded question is
         // submitted and locked, onUnloadCallback should still be set to make sure the scaffolded question doesn't


### PR DESCRIPTION
This fixes an issue with the font-size of scafolded questions after they are submitted as it was then showing the iframe in report mode which doesn't support the font-size change.

To set the iframe as read only pointer events are disabled and the tab index is removed to prevent tabbing into the iframe.

The carousel interactive was updated to use this new prop instead of adding a disabled div around the iframe.