### PR TITLE
fix: Default answer disappearing in authoring [PT-185100790]

### DIFF
--- a/packages/open-response/src/components/app.tsx
+++ b/packages/open-response/src/components/app.tsx
@@ -39,35 +39,11 @@ const baseAuthoringProps = {
       defaultAnswer: {
         type: "string",
         title: "Default answer"
-      }
-    },
-    dependencies: {
-      required: {
-        oneOf: [
-          {
-            properties: {
-              required: {
-                enum: [
-                  false
-                ]
-              }
-            }
-          },
-          {
-            properties: {
-              required: {
-                enum: [
-                  true
-                ]
-              },
-              predictionFeedback: {
-                title: "Post-submission feedback (optional)",
-                type: "string"
-              }
-            }
-          }
-        ]
-      }
+      },
+      predictionFeedback: {
+        title: "Prediction feedback (optional)",
+        type: "string"
+      },
     }
   } as RJSFSchema,
 
@@ -77,6 +53,8 @@ const baseAuthoringProps = {
       "required",
       "audioEnabled",
       "voiceTypingEnabled",
+      "hint",
+      "defaultAnswer",
       "predictionFeedback",
       "*"
     ],


### PR DESCRIPTION
The default answer was disappearing in open response authoring when the required checkbox was selected as it was not specified in the UI order AND the authoring iframe useAutoHeight() hook was not updating the height when the prediction feeback field showed after required was selected.

This change sets the UI order and makes the prediction feedback always show at the bottom of the form so it is not cut-off from view.