### PR TITLE
fix: Set default font size to 1rem [PT-185138973]

### DIFF
--- a/packages/helpers/src/styles/helpers.scss
+++ b/packages/helpers/src/styles/helpers.scss
@@ -9,6 +9,7 @@ $themeColor2: #34a5be;
 @mixin ap-styles {
   // These values should match the Activity Player. In the future, we might extend interactive API so the Activity Player can provide them.
   font-family: Lato, Arial, Helvetica, sans-serif;
+  font-size: pxToRem(16);
   font-weight: 400;
   line-height: 1.35 !important;
   padding: 20px 20px 13px;
@@ -23,6 +24,7 @@ $themeColor2: #34a5be;
   padding: 20px 20px 13px;
   font-family: Helvetica, Arial, sans-serif;
   font-weight: 500;
+  font-size: pxToRem(16);
 
   input[type=checkbox], input[type=radio] {
     margin-right: 10px;


### PR DESCRIPTION
Added back default font size in the ap-styles and lara-styles mixin that was removed in the commit that changed the font sizes from px to rem.  The rest of the files in the commit were examined and these two instances were the only ones deleted.

To view the changes in that commit look here: https://github.com/concord-consortium/question-interactives/commit/16b2c96c488ff589e4fb77270df7a923b9743a8a