### PR TITLE
fix: Label of prediction feedback [PT-185100790]

### DIFF
--- a/packages/open-response/src/components/app.tsx
+++ b/packages/open-response/src/components/app.tsx
@@ -41,7 +41,7 @@ const baseAuthoringProps = {
         title: "Default answer"
       },
       predictionFeedback: {
-        title: "Prediction feedback (optional)",
+        title: "Post-submission feedback (optional)",
         type: "string"
       },
     }


### PR DESCRIPTION
The title of the prediction feedback should be Post-submission feedback.  This was lost when the field was moved out of the optional schema declaration.