### PR TITLE
fix: Removed updatedText field in voice typing log [PT-185033795]

### DIFF
--- a/packages/open-response/src/components/runtime.tsx
+++ b/packages/open-response/src/components/runtime.tsx
@@ -122,7 +122,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
           ].join("");
           handleUpdateTextArea(updatedText);
           lastTranscriptRef.current = transcript;
-          log("voice typing updated", {voiceText: transcript, updatedText});
+          log("voice typing updated", {voiceText: transcript});
         }
       });
     }


### PR DESCRIPTION
This will both reduce the amount of data logged and it is also redundant as the final text is logged when the voice typing button is toggled off.