### PR TITLE
fix: Text/button overlapping image question dialog textarea [PT-185160708]

### DIFF
--- a/packages/image-question/src/components/runtime.scss
+++ b/packages/image-question/src/components/runtime.scss
@@ -36,7 +36,6 @@ legend.prompt { // clear bootstrap stuff
 }
 
 .dialogContent {
-  height: 600px;
   width: 960px;
   margin: 0 auto;
   position: relative;
@@ -52,13 +51,9 @@ legend.prompt { // clear bootstrap stuff
     vertical-align: top;
     display: inline-block;
     width: 280px;
-  }
 
-  .closeDialogSection {
-    width: 280px;
-    text-align: right;
-    position: absolute;
-    bottom: 0;
-    right: 0;
+    .closeDialogSection {
+      text-align: right;
+    }
   }
 }

--- a/packages/image-question/src/components/runtime.tsx
+++ b/packages/image-question/src/components/runtime.tsx
@@ -177,14 +177,14 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
             placeholder={authoredState.defaultAnswer || kGlobalDefaultAnswer}
           />
         </> }
-      </div>
-      <div className={css.closeDialogSection}>
-        { savingAnnotatedImage ?
-          <div>Please wait while your drawing is being saved...</div> :
-          <button className={cssHelpers.apButton} onClick={handleClose} data-test="close-dialog-btn">
-            Close
-          </button>
-        }
+        <div className={css.closeDialogSection}>
+          { savingAnnotatedImage ?
+            <div>Please wait while your drawing is being saved...</div> :
+            <button className={cssHelpers.apButton} onClick={handleClose} data-test="close-dialog-btn">
+              Close
+            </button>
+          }
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
This change removes the constraint for the dialog height and moves the close section into the right panel allowing the absolute positioning that was causing the overlap to be removed.

BEFORE:

![image](https://github.com/concord-consortium/question-interactives/assets/112938/967693ae-a87c-4a27-afd0-90960db1367c)

AFTER:

![image](https://github.com/concord-consortium/question-interactives/assets/112938/fd3a2d30-d202-4519-8fc4-18a92cea8076)
