### PR TITLE
fix: Set minium value for Lab book authoring number inputs [PT-184821574]

### DIFF
--- a/packages/labbook/src/components/app.tsx
+++ b/packages/labbook/src/components/app.tsx
@@ -16,12 +16,14 @@ const baseAuthoringProps = deepmerge(drawingToolBaseAuthoringProps, {
       maxItems: {
         type: "number",
         title: "Maximum number of lab book entries",
-        default: 12
+        default: 12,
+        minimum: 1
       },
       showItems: {
         type: "number",
         title: "How many thumbnails to display",
-        default: 4
+        default: 4,
+        minimum: 1
       },
       backgroundSource: {
         title: "Background source",


### PR DESCRIPTION
This sets the minium value of the "Maximum number of lab book entries" and "How many thumbnails to display" number inputs to 1.  Previously there was no minimum which allowed for zero or negative values.