### PR TITLE
fix: update LARA image proxy URL to use production [PT-185233166]

### DIFF
--- a/packages/drawing-tool/src/components/drawing-tool.tsx
+++ b/packages/drawing-tool/src/components/drawing-tool.tsx
@@ -13,7 +13,7 @@ const kDrawingToolPreferredWidth = 600; // in practice it can be smaller if ther
 const kDrawingToolHeight = 600;
 
 // Use LARA image proxy to avoid tainting canvas when external image URL is used.
-export const LARA_IMAGE_PROXY = "https://lara-master.concordqa.org/image-proxy?url=";
+export const LARA_IMAGE_PROXY = "https://authoring.concord.org/image-proxy?url=";
 
 export interface IProps {
   authoredState: IGenericAuthoredState; // so it works with DrawingTool and ImageQuestion


### PR DESCRIPTION
When I was testing it myself, I experienced https://lara-master.concordqa.org returning 503 error (both the main index page and image-proxy), and a moment later everything was fine. So I think that's the main reason why backgrounds don't work in a consistent way.