### PR TITLE
fix(DrawingTool): better support of staging Token Service environments

### DIFF
--- a/packages/drawing-tool/src/components/app.test.tsx
+++ b/packages/drawing-tool/src/components/app.test.tsx
@@ -11,6 +11,9 @@ describe("validation helper", () => {
     baseAuthoringProps.validate({ version: 1, backgroundSource: "url", backgroundImageUrl: "https://aws.concord.org/img/123.png" }, errors);
     expect(errors.backgroundImageUrl?.addError).not.toHaveBeenCalled();
 
+    baseAuthoringProps.validate({ version: 1, backgroundSource: "url", backgroundImageUrl: "https://token-service-files.concordqa.org/img/123.png" }, errors);
+    expect(errors.backgroundImageUrl?.addError).not.toHaveBeenCalled();
+
     baseAuthoringProps.validate({ version: 1, backgroundSource: "url", backgroundImageUrl: "https://token-service-files.s3.amazonaws.com/img/123.png" }, errors);
     expect(errors.backgroundImageUrl?.addError).not.toHaveBeenCalled();
 

--- a/packages/drawing-tool/src/components/app.tsx
+++ b/packages/drawing-tool/src/components/app.tsx
@@ -269,7 +269,10 @@ export const baseAuthoringProps = {
     if (formData.backgroundImageUrl && formData.backgroundSource === "url") {
       try {
         const url = new URL(formData.backgroundImageUrl);
-        if (!url.host.match(/concord\.org/) && !url.host.match(/token-service-files\.s3\.amazonaws\.com/)) {
+        // concordqa.org should be used by the staging environment. token-service-files.s3.amazonaws.com probably should
+        // not be used at all, but Token Service has been misconfigured for a long time and it's used for plenty of
+        // authored backgrounds. See: https://www.pivotaltracker.com/story/show/185233166
+        if (!url.host.match(/concord\.org/) && !url.host.match(/concordqa\.org/) && !url.host.match(/token-service-files\.s3\.amazonaws\.com/)) {
           errors.backgroundImageUrl?.addError(`Please use only uploaded images or images hosted at *.concord.org.`);
         }
       } catch (e) {

--- a/packages/helpers/src/hooks/use-cors-image-error-check.ts
+++ b/packages/helpers/src/hooks/use-cors-image-error-check.ts
@@ -14,7 +14,11 @@ export const isImgCORSEnabled = (imgSrc: string): Promise<boolean> => {
 export const shouldUseLARAImgProxy = (imgSrc?: string): boolean => {
   try {
     const url = new URL(imgSrc || "");
-    if (!url.host.match(/concord\.org/)) {
+    const host = url.host;
+    // concordqa.org should be used by the staging environment. token-service-files.s3.amazonaws.com probably should
+    // not be used at all, but Token Service has been misconfigured for a long time and it's used for plenty of
+    // authored backgrounds. See: https://www.pivotaltracker.com/story/show/185233166
+    if (!host.match(/concord\.org/) && !host.match(/concordqa\.org/) && !host.match(/token-service-files\.s3\.amazonaws\.com/)) {
       // Use LARA image proxy to avoid tainting canvas when external image URL is used.
       // Note that concord.org domain is actually not enough when the subdomains are different.
       // So, the host needs to have CORS headers enabled. It's more likely for servers owned by CC. In practice

--- a/packages/helpers/src/hooks/use-cors-image-error-check.ts
+++ b/packages/helpers/src/hooks/use-cors-image-error-check.ts
@@ -15,10 +15,7 @@ export const shouldUseLARAImgProxy = (imgSrc?: string): boolean => {
   try {
     const url = new URL(imgSrc || "");
     const host = url.host;
-    // concordqa.org should be used by the staging environment. token-service-files.s3.amazonaws.com probably should
-    // not be used at all, but Token Service has been misconfigured for a long time and it's used for plenty of
-    // authored backgrounds. See: https://www.pivotaltracker.com/story/show/185233166
-    if (!host.match(/concord\.org/) && !host.match(/concordqa\.org/) && !host.match(/token-service-files\.s3\.amazonaws\.com/)) {
+    if (!host.match(/concord\.org/) && !host.match(/concordqa\.org/)) {
       // Use LARA image proxy to avoid tainting canvas when external image URL is used.
       // Note that concord.org domain is actually not enough when the subdomains are different.
       // So, the host needs to have CORS headers enabled. It's more likely for servers owned by CC. In practice


### PR DESCRIPTION
[PT-185233166]

This PR will allow us to reconfigure Token Service to use `https://token-service-files.concordqa.org/` domain instead of `https://token-service-files.s3.amazonaws.com/`. 

Note that there's another bug somewhere around that makes Token Service **always** use the staging / QA environment - even on LARA production. But this will improve things on staging, and it'll slightly improve things on production until the other bug is fixed.