### PR TITLE
fix(TokenServiceClient): fix logic that picks the right Token Servic environment [PT-185381893]

### DIFF
--- a/packages/helpers/src/components/base-authoring.tsx
+++ b/packages/helpers/src/components/base-authoring.tsx
@@ -40,7 +40,9 @@ const widgets = {
 };
 
 export const getTokenServiceEnv = (claims: any) => {
-  const host = claims?.platform_id || "";
+  // Provided object usually has nested `claims` object. Keep backward compatibility with old (probably incorrect)
+  // format just in case, as it costs us nothing.
+  const host = claims?.platform_id || claims?.claims?.platform_id || "";
   return host.match(/learn\.concord\.org/) ? "production" : "staging";
 };
 


### PR DESCRIPTION
This PR fixes an issue described here: https://www.pivotaltracker.com/story/show/185381893
Long story short, we were **always** using Token Service staging env... So, all the authored images (and student attachments? And anything that uses TokenService) are living in Concord AWS QA account. 😮‍💨 

Now, when authors upload images, they'll be uploaded to this bucket instead:
https://s3.console.aws.amazon.com/s3/buckets/cc-project-resources?region=us-east-1

Also, I had to update CORS settings of this bucket and add "PUT" request to make that work. I've added other methods too, so now it's "GET","HEAD","POST","DELETE","PUT".