### PR TITLE
fix: Audio UI issues found during QA [PT-185083392]

### DIFF
--- a/packages/open-response/src/components/runtime.scss
+++ b/packages/open-response/src/components/runtime.scss
@@ -38,10 +38,10 @@
 
       .saveIndicator {
         animation: isActive .7s infinite;
-        font-size: pxToRem(14);
+        font-size: pxToRem(16);
         position: absolute;
-        top: -20px;
-        width: 80px;
+        top: pxToRem(-20);
+        width: pxToRem(80);
         text-align: center;
         color: #0481a0;
       }
@@ -127,6 +127,8 @@
         cursor: pointer;
 
         svg {
+          width: 34px;
+          height: 34px;
           filter: drop-shadow(2px 2px 2px rgba(49, 49, 49, 0.5));
         }
 


### PR DESCRIPTION
- As per zeplin, font-size for Saving … should be 16px but it is set to 14px
- In large font size settings, Saving … text collide with audio record container
- When compared to zeplin, close icon size looks small
- As per zeplin, for recording stopped & recording saved states, time stamp should be displayed with the length of the recording. But, in the current implementation, time stamp is displayed as 00:00
- As per zeplin, during active playback, when the pause button is clicked, the pause button still should be displayed and it should not pulse. But, in the current implementation, the pause button is changed to the play button and the time stamp color changed to black instead of blue.
- When playback is In-progress, delete the audio recording and record a new audio. Notice the icon after saving. For the new recorded audio, the play button should be displayed after save but the pause button is displayed.
- When the question is set to required, after submitting the question, recorded audio is not displayed.