### PR TITLE
Fix input text styling (PT-185345611).

### DIFF
--- a/packages/helpers/src/components/base-app.scss
+++ b/packages/helpers/src/components/base-app.scss
@@ -13,8 +13,5 @@ html {
     width: 100%;
     padding: 16px;
     font-style: italic;
-    &:focus, &:target {
-      font-style: normal;
-    }
   }
 }

--- a/packages/helpers/src/components/base-app.scss
+++ b/packages/helpers/src/components/base-app.scss
@@ -13,5 +13,8 @@ html {
     width: 100%;
     padding: 16px;
     font-style: italic;
+    &:focus, &:target {
+      font-style: normal;
+    }
   }
 }

--- a/packages/image-question/src/components/runtime.scss
+++ b/packages/image-question/src/components/runtime.scss
@@ -57,6 +57,14 @@ legend.prompt { // clear bootstrap stuff
       margin-top: 5px;
     }
 
+    .default {
+      font-style: italic;
+    }
+
+    .typedIn {
+      font-style: normal;
+    }
+
     hr {
       border-color: var(--cc-charcoal-light-1);
     }

--- a/packages/image-question/src/components/runtime.scss
+++ b/packages/image-question/src/components/runtime.scss
@@ -27,7 +27,6 @@ legend.prompt { // clear bootstrap stuff
 }
 
 .studentAnswerText {
-  font-style: italic;
   font-size: 0.9rem;
 }
 
@@ -61,7 +60,7 @@ legend.prompt { // clear bootstrap stuff
       font-style: italic;
     }
 
-    .typedIn {
+    .hasAnswer {
       font-style: normal;
     }
 

--- a/packages/image-question/src/components/runtime.tsx
+++ b/packages/image-question/src/components/runtime.tsx
@@ -32,6 +32,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   const [ controlsHidden, setControlsHidden ] = useState(false);
   const [ drawingStateUpdated, setDrawingStateUpdated ] = useState(false);
   const [ savingAnnotatedImage, setSavingAnnotatedImage ] = useState(false);
+  const [textAreaClass, setTextAreaClass] = useState(css.default);
   const drawingToolDialog = getURLParam(drawingToolDialogUrlParam);
   const authoredBgCorsError = useCorsImageErrorCheck({
     performTest: authoredState.backgroundSource === "url" && !!authoredState.backgroundImageUrl,
@@ -62,6 +63,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   };
 
   const handleTextChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setTextAreaClass(css.typedIn);
     setInteractiveState?.((prevState: IInteractiveState) => ({
       ...prevState,
       answerText: event.target.value,
@@ -74,6 +76,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   };
 
   const handleCancel = () => {
+    setTextAreaClass(css.default);
     setInteractiveState?.((prevState: IInteractiveState) => ({
       ...prevState,
       userBackgroundImageUrl: undefined,
@@ -192,6 +195,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
             value={interactiveState?.answerText || ""}
             onChange={handleTextChange}
             rows={8}
+            className={textAreaClass}
             placeholder={authoredState.defaultAnswer || kGlobalDefaultAnswer}
           />
         </> }

--- a/packages/image-question/src/components/runtime.tsx
+++ b/packages/image-question/src/components/runtime.tsx
@@ -32,7 +32,6 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   const [ controlsHidden, setControlsHidden ] = useState(false);
   const [ drawingStateUpdated, setDrawingStateUpdated ] = useState(false);
   const [ savingAnnotatedImage, setSavingAnnotatedImage ] = useState(false);
-  const [textAreaClass, setTextAreaClass] = useState(css.default);
   const drawingToolDialog = getURLParam(drawingToolDialogUrlParam);
   const authoredBgCorsError = useCorsImageErrorCheck({
     performTest: authoredState.backgroundSource === "url" && !!authoredState.backgroundImageUrl,
@@ -63,7 +62,6 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   };
 
   const handleTextChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setTextAreaClass(css.typedIn);
     setInteractiveState?.((prevState: IInteractiveState) => ({
       ...prevState,
       answerText: event.target.value,
@@ -76,7 +74,6 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   };
 
   const handleCancel = () => {
-    setTextAreaClass(css.default);
     setInteractiveState?.((prevState: IInteractiveState) => ({
       ...prevState,
       userBackgroundImageUrl: undefined,
@@ -195,7 +192,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
             value={interactiveState?.answerText || ""}
             onChange={handleTextChange}
             rows={8}
-            className={textAreaClass}
+            className={interactiveState?.answerText ? css.hasAnswer : css.default}
             placeholder={authoredState.defaultAnswer || kGlobalDefaultAnswer}
           />
         </> }


### PR DESCRIPTION
This PR makes it so that in Image Question, only placeholder text in a textarea is italicized. The student answer typed in and displayed after are not italicized.