### PR TITLE
Update to lara-interactive-api 1.9.3-pre.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29984,7 +29984,7 @@
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@rjsf/utils": "^5.0.1",
         "chart.js": "^3.9.1",
@@ -30043,9 +30043,9 @@
       }
     },
     "packages/bar-graph/node_modules/@concord-consortium/lara-interactive-api": {
-      "version": "1.9.3-pre.6",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-      "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+      "version": "1.9.3-pre.7",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+      "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
       "dependencies": {
         "iframe-phone": "^1.3.1"
       },
@@ -30059,7 +30059,7 @@
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@rjsf/utils": "^5.0.1",
         "classnames": "^2.3.1",
@@ -30120,9 +30120,9 @@
       }
     },
     "packages/carousel/node_modules/@concord-consortium/lara-interactive-api": {
-      "version": "1.9.3-pre.6",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-      "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+      "version": "1.9.3-pre.7",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+      "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
       "dependencies": {
         "iframe-phone": "^1.3.1"
       },
@@ -30136,7 +30136,7 @@
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@rjsf/utils": "^5.0.1",
         "iframe-phone": "^1.3.1",
@@ -30197,9 +30197,9 @@
       }
     },
     "packages/drag-and-drop/node_modules/@concord-consortium/lara-interactive-api": {
-      "version": "1.9.3-pre.6",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-      "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+      "version": "1.9.3-pre.7",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+      "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
       "dependencies": {
         "iframe-phone": "^1.3.1"
       },
@@ -30214,7 +30214,7 @@
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@concord-consortium/text-decorator": "^1.0.2",
         "@rjsf/utils": "^5.0.1",
@@ -30273,9 +30273,9 @@
       }
     },
     "packages/drawing-tool/node_modules/@concord-consortium/lara-interactive-api": {
-      "version": "1.9.3-pre.6",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-      "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+      "version": "1.9.3-pre.7",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+      "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
       "dependencies": {
         "iframe-phone": "^1.3.1"
       },
@@ -30289,7 +30289,7 @@
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@concord-consortium/text-decorator": "^1.0.2",
         "@rjsf/utils": "^5.0.1",
@@ -30346,9 +30346,9 @@
       }
     },
     "packages/fill-in-the-blank/node_modules/@concord-consortium/lara-interactive-api": {
-      "version": "1.9.3-pre.6",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-      "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+      "version": "1.9.3-pre.7",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+      "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
       "dependencies": {
         "iframe-phone": "^1.3.1"
       },
@@ -30361,7 +30361,7 @@
       "version": "1.14.0",
       "license": "MIT",
       "dependencies": {
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@rjsf/utils": "^5.0.1",
         "query-string": "^7.1.1",
@@ -30417,9 +30417,9 @@
       }
     },
     "packages/full-screen/node_modules/@concord-consortium/lara-interactive-api": {
-      "version": "1.9.3-pre.6",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-      "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+      "version": "1.9.3-pre.7",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+      "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
       "dependencies": {
         "iframe-phone": "^1.3.1"
       },
@@ -30457,7 +30457,7 @@
       "version": "1.14.0",
       "license": "MIT",
       "dependencies": {
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@rjsf/utils": "^5.0.1",
         "chart.js": "^3.9.1",
@@ -30514,9 +30514,9 @@
       }
     },
     "packages/graph/node_modules/@concord-consortium/lara-interactive-api": {
-      "version": "1.9.3-pre.6",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-      "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+      "version": "1.9.3-pre.7",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+      "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
       "dependencies": {
         "iframe-phone": "^1.3.1"
       },
@@ -30532,7 +30532,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.229.0",
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/slate-editor": "^0.8.2",
         "@concord-consortium/text-decorator": "^1.0.2",
         "@concord-consortium/token-service": "^2.1.0",
@@ -30588,9 +30588,9 @@
       }
     },
     "packages/helpers/node_modules/@concord-consortium/lara-interactive-api": {
-      "version": "1.9.3-pre.6",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-      "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+      "version": "1.9.3-pre.7",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+      "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
       "dependencies": {
         "iframe-phone": "^1.3.1"
       },
@@ -30604,7 +30604,7 @@
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@concord-consortium/text-decorator": "^1.0.2",
         "@rjsf/utils": "^5.0.1",
@@ -30663,7 +30663,7 @@
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@concord-consortium/text-decorator": "^1.0.2",
         "@rjsf/utils": "^5.0.1",
@@ -30722,9 +30722,9 @@
       }
     },
     "packages/image-question/node_modules/@concord-consortium/lara-interactive-api": {
-      "version": "1.9.3-pre.6",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-      "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+      "version": "1.9.3-pre.7",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+      "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
       "dependencies": {
         "iframe-phone": "^1.3.1"
       },
@@ -30734,9 +30734,9 @@
       }
     },
     "packages/image/node_modules/@concord-consortium/lara-interactive-api": {
-      "version": "1.9.3-pre.6",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-      "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+      "version": "1.9.3-pre.7",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+      "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
       "dependencies": {
         "iframe-phone": "^1.3.1"
       },
@@ -30750,7 +30750,7 @@
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@rjsf/utils": "^5.0.1",
         "classnames": "^2.3.1",
@@ -30811,9 +30811,9 @@
       }
     },
     "packages/labbook/node_modules/@concord-consortium/lara-interactive-api": {
-      "version": "1.9.3-pre.6",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-      "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+      "version": "1.9.3-pre.7",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+      "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
       "dependencies": {
         "iframe-phone": "^1.3.1"
       },
@@ -30888,7 +30888,7 @@
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@concord-consortium/text-decorator": "^1.0.2",
         "@rjsf/utils": "^5.0.1",
@@ -30945,9 +30945,9 @@
       }
     },
     "packages/multiple-choice-alerts/node_modules/@concord-consortium/lara-interactive-api": {
-      "version": "1.9.3-pre.6",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-      "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+      "version": "1.9.3-pre.7",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+      "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
       "dependencies": {
         "iframe-phone": "^1.3.1"
       },
@@ -30961,7 +30961,7 @@
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@concord-consortium/text-decorator": "^1.0.2",
         "@rjsf/utils": "^5.0.1",
@@ -31018,9 +31018,9 @@
       }
     },
     "packages/open-response/node_modules/@concord-consortium/lara-interactive-api": {
-      "version": "1.9.3-pre.6",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-      "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+      "version": "1.9.3-pre.7",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+      "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
       "dependencies": {
         "iframe-phone": "^1.3.1"
       },
@@ -31034,7 +31034,7 @@
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@concord-consortium/text-decorator": "^1.0.2",
         "@rjsf/utils": "^5.0.1",
@@ -31094,9 +31094,9 @@
       }
     },
     "packages/scaffolded-question/node_modules/@concord-consortium/lara-interactive-api": {
-      "version": "1.9.3-pre.6",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-      "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+      "version": "1.9.3-pre.7",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+      "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
       "dependencies": {
         "iframe-phone": "^1.3.1"
       },
@@ -31110,7 +31110,7 @@
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@concord-consortium/text-decorator": "^1.0.2",
         "@rjsf/utils": "^5.0.1",
@@ -31169,9 +31169,9 @@
       }
     },
     "packages/score-bot/node_modules/@concord-consortium/lara-interactive-api": {
-      "version": "1.9.3-pre.6",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-      "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+      "version": "1.9.3-pre.7",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+      "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
       "dependencies": {
         "iframe-phone": "^1.3.1"
       },
@@ -31185,7 +31185,7 @@
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@rjsf/utils": "^5.0.1",
         "deep-equal": "^2.0.5",
@@ -31244,9 +31244,9 @@
       }
     },
     "packages/side-by-side/node_modules/@concord-consortium/lara-interactive-api": {
-      "version": "1.9.3-pre.6",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-      "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+      "version": "1.9.3-pre.7",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+      "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
       "dependencies": {
         "iframe-phone": "^1.3.1"
       },
@@ -31267,7 +31267,7 @@
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@concord-consortium/text-decorator": "^1.0.2",
         "@rjsf/utils": "^5.0.1",
@@ -31323,9 +31323,9 @@
       }
     },
     "packages/video-player/node_modules/@concord-consortium/lara-interactive-api": {
-      "version": "1.9.3-pre.6",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-      "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+      "version": "1.9.3-pre.7",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+      "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
       "dependencies": {
         "iframe-phone": "^1.3.1"
       },
@@ -33813,7 +33813,7 @@
       "requires": {
         "@aws-sdk/client-s3": "^3.229.0",
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/slate-editor": "^0.8.2",
         "@concord-consortium/text-decorator": "^1.0.2",
         "@concord-consortium/token-service": "^2.1.0",
@@ -33863,9 +33863,9 @@
       },
       "dependencies": {
         "@concord-consortium/lara-interactive-api": {
-          "version": "1.9.3-pre.6",
-          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-          "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+          "version": "1.9.3-pre.7",
+          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+          "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
           "requires": {
             "iframe-phone": "^1.3.1"
           }
@@ -39520,7 +39520,7 @@
       "version": "file:packages/bar-graph",
       "requires": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@rjsf/utils": "^5.0.1",
         "@svgr/webpack": "^6.5.1",
@@ -39577,9 +39577,9 @@
       },
       "dependencies": {
         "@concord-consortium/lara-interactive-api": {
-          "version": "1.9.3-pre.6",
-          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-          "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+          "version": "1.9.3-pre.7",
+          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+          "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
           "requires": {
             "iframe-phone": "^1.3.1"
           }
@@ -40161,7 +40161,7 @@
       "version": "file:packages/carousel",
       "requires": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@rjsf/utils": "^5.0.1",
         "@svgr/webpack": "^6.5.1",
@@ -40220,9 +40220,9 @@
       },
       "dependencies": {
         "@concord-consortium/lara-interactive-api": {
-          "version": "1.9.3-pre.6",
-          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-          "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+          "version": "1.9.3-pre.7",
+          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+          "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
           "requires": {
             "iframe-phone": "^1.3.1"
           }
@@ -42015,7 +42015,7 @@
       "version": "file:packages/drag-and-drop",
       "requires": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@rjsf/utils": "^5.0.1",
         "@svgr/webpack": "^6.5.1",
@@ -42074,9 +42074,9 @@
       },
       "dependencies": {
         "@concord-consortium/lara-interactive-api": {
-          "version": "1.9.3-pre.6",
-          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-          "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+          "version": "1.9.3-pre.7",
+          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+          "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
           "requires": {
             "iframe-phone": "^1.3.1"
           }
@@ -42106,7 +42106,7 @@
       "version": "file:packages/drawing-tool",
       "requires": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@concord-consortium/text-decorator": "^1.0.2",
         "@rjsf/utils": "^5.0.1",
@@ -42163,9 +42163,9 @@
       },
       "dependencies": {
         "@concord-consortium/lara-interactive-api": {
-          "version": "1.9.3-pre.6",
-          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-          "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+          "version": "1.9.3-pre.7",
+          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+          "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
           "requires": {
             "iframe-phone": "^1.3.1"
           }
@@ -43602,7 +43602,7 @@
       "version": "file:packages/fill-in-the-blank",
       "requires": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@concord-consortium/text-decorator": "^1.0.2",
         "@rjsf/utils": "^5.0.1",
@@ -43657,9 +43657,9 @@
       },
       "dependencies": {
         "@concord-consortium/lara-interactive-api": {
-          "version": "1.9.3-pre.6",
-          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-          "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+          "version": "1.9.3-pre.7",
+          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+          "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
           "requires": {
             "iframe-phone": "^1.3.1"
           }
@@ -43897,7 +43897,7 @@
     "full-screen": {
       "version": "file:packages/full-screen",
       "requires": {
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@rjsf/utils": "^5.0.1",
         "@svgr/webpack": "^6.5.1",
@@ -43951,9 +43951,9 @@
       },
       "dependencies": {
         "@concord-consortium/lara-interactive-api": {
-          "version": "1.9.3-pre.6",
-          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-          "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+          "version": "1.9.3-pre.7",
+          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+          "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
           "requires": {
             "iframe-phone": "^1.3.1"
           }
@@ -44308,7 +44308,7 @@
     "graph": {
       "version": "file:packages/graph",
       "requires": {
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@rjsf/utils": "^5.0.1",
         "@svgr/webpack": "^6.5.1",
@@ -44363,9 +44363,9 @@
       },
       "dependencies": {
         "@concord-consortium/lara-interactive-api": {
-          "version": "1.9.3-pre.6",
-          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-          "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+          "version": "1.9.3-pre.7",
+          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+          "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
           "requires": {
             "iframe-phone": "^1.3.1"
           }
@@ -44949,7 +44949,7 @@
       "version": "file:packages/image",
       "requires": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@concord-consortium/text-decorator": "^1.0.2",
         "@rjsf/utils": "^5.0.1",
@@ -45002,9 +45002,9 @@
       },
       "dependencies": {
         "@concord-consortium/lara-interactive-api": {
-          "version": "1.9.3-pre.6",
-          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-          "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+          "version": "1.9.3-pre.7",
+          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+          "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
           "requires": {
             "iframe-phone": "^1.3.1"
           }
@@ -45015,7 +45015,7 @@
       "version": "file:packages/image-question",
       "requires": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@concord-consortium/text-decorator": "^1.0.2",
         "@rjsf/utils": "^5.0.1",
@@ -45072,9 +45072,9 @@
       },
       "dependencies": {
         "@concord-consortium/lara-interactive-api": {
-          "version": "1.9.3-pre.6",
-          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-          "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+          "version": "1.9.3-pre.7",
+          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+          "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
           "requires": {
             "iframe-phone": "^1.3.1"
           }
@@ -47329,7 +47329,7 @@
       "version": "file:packages/labbook",
       "requires": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@rjsf/utils": "^5.0.1",
         "@svgr/webpack": "^6.5.1",
@@ -47388,9 +47388,9 @@
       },
       "dependencies": {
         "@concord-consortium/lara-interactive-api": {
-          "version": "1.9.3-pre.6",
-          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-          "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+          "version": "1.9.3-pre.7",
+          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+          "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
           "requires": {
             "iframe-phone": "^1.3.1"
           }
@@ -48861,7 +48861,7 @@
       "version": "file:packages/multiple-choice-alerts",
       "requires": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@concord-consortium/text-decorator": "^1.0.2",
         "@rjsf/utils": "^5.0.1",
@@ -48916,9 +48916,9 @@
       },
       "dependencies": {
         "@concord-consortium/lara-interactive-api": {
-          "version": "1.9.3-pre.6",
-          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-          "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+          "version": "1.9.3-pre.7",
+          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+          "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
           "requires": {
             "iframe-phone": "^1.3.1"
           }
@@ -50107,7 +50107,7 @@
       "version": "file:packages/open-response",
       "requires": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@concord-consortium/text-decorator": "^1.0.2",
         "@rjsf/utils": "^5.0.1",
@@ -50162,9 +50162,9 @@
       },
       "dependencies": {
         "@concord-consortium/lara-interactive-api": {
-          "version": "1.9.3-pre.6",
-          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-          "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+          "version": "1.9.3-pre.7",
+          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+          "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
           "requires": {
             "iframe-phone": "^1.3.1"
           }
@@ -52317,7 +52317,7 @@
       "version": "file:packages/scaffolded-question",
       "requires": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@concord-consortium/text-decorator": "^1.0.2",
         "@rjsf/utils": "^5.0.1",
@@ -52375,9 +52375,9 @@
       },
       "dependencies": {
         "@concord-consortium/lara-interactive-api": {
-          "version": "1.9.3-pre.6",
-          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-          "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+          "version": "1.9.3-pre.7",
+          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+          "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
           "requires": {
             "iframe-phone": "^1.3.1"
           }
@@ -52399,7 +52399,7 @@
       "version": "file:packages/score-bot",
       "requires": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@concord-consortium/text-decorator": "^1.0.2",
         "@rjsf/utils": "^5.0.1",
@@ -52456,9 +52456,9 @@
       },
       "dependencies": {
         "@concord-consortium/lara-interactive-api": {
-          "version": "1.9.3-pre.6",
-          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-          "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+          "version": "1.9.3-pre.7",
+          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+          "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
           "requires": {
             "iframe-phone": "^1.3.1"
           }
@@ -52722,7 +52722,7 @@
       "version": "file:packages/side-by-side",
       "requires": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@rjsf/utils": "^5.0.1",
         "@svgr/webpack": "^6.5.1",
@@ -52779,9 +52779,9 @@
       },
       "dependencies": {
         "@concord-consortium/lara-interactive-api": {
-          "version": "1.9.3-pre.6",
-          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-          "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+          "version": "1.9.3-pre.7",
+          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+          "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
           "requires": {
             "iframe-phone": "^1.3.1"
           }
@@ -54898,7 +54898,7 @@
       "version": "file:packages/video-player",
       "requires": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+        "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@concord-consortium/text-decorator": "^1.0.2",
         "@rjsf/utils": "^5.0.1",
@@ -54952,9 +54952,9 @@
       },
       "dependencies": {
         "@concord-consortium/lara-interactive-api": {
-          "version": "1.9.3-pre.6",
-          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.6.tgz",
-          "integrity": "sha512-d52urK9/44G/G/Mf8VmzYysjQnu29gRzpl3m9FjO97PsZUMXlvOc9vhDZBOiwtVeZ6JhXlCGIG8HFtEdcWhVuQ==",
+          "version": "1.9.3-pre.7",
+          "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.3-pre.7.tgz",
+          "integrity": "sha512-fFRjIEmSa055ZqK2tCZYghl/Ulv2htEHCvH6jC/Ix/2sKqGujSblDx/N6B/WT9rH6bs9ciLw2bCg7/V8Ym0FAA==",
           "requires": {
             "iframe-phone": "^1.3.1"
           }

--- a/packages/bar-graph/package.json
+++ b/packages/bar-graph/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@rjsf/utils": "^5.0.1",
     "chart.js": "^3.9.1",

--- a/packages/carousel/package.json
+++ b/packages/carousel/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@rjsf/utils": "^5.0.1",
     "classnames": "^2.3.1",

--- a/packages/drag-and-drop/package.json
+++ b/packages/drag-and-drop/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@rjsf/utils": "^5.0.1",
     "iframe-phone": "^1.3.1",

--- a/packages/drawing-tool/package.json
+++ b/packages/drawing-tool/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@rjsf/utils": "^5.0.1",

--- a/packages/fill-in-the-blank/package.json
+++ b/packages/fill-in-the-blank/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@rjsf/utils": "^5.0.1",

--- a/packages/full-screen/package.json
+++ b/packages/full-screen/package.json
@@ -99,7 +99,7 @@
     "webpack-dev-server": "^4.7.4"
   },
   "dependencies": {
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@rjsf/utils": "^5.0.1",
     "query-string": "^7.1.1",

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -105,7 +105,7 @@
     "webpack-dev-server": "^4.7.4"
   },
   "dependencies": {
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@rjsf/utils": "^5.0.1",
     "chart.js": "^3.9.1",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -90,7 +90,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.229.0",
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
     "@concord-consortium/slate-editor": "^0.8.2",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@concord-consortium/token-service": "^2.1.0",

--- a/packages/image-question/package.json
+++ b/packages/image-question/package.json
@@ -106,7 +106,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@rjsf/utils": "^5.0.1",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -106,7 +106,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@rjsf/utils": "^5.0.1",

--- a/packages/labbook/package.json
+++ b/packages/labbook/package.json
@@ -108,7 +108,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@rjsf/utils": "^5.0.1",
     "classnames": "^2.3.1",

--- a/packages/multiple-choice-alerts/package.json
+++ b/packages/multiple-choice-alerts/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@rjsf/utils": "^5.0.1",

--- a/packages/open-response/package.json
+++ b/packages/open-response/package.json
@@ -106,7 +106,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@rjsf/utils": "^5.0.1",

--- a/packages/scaffolded-question/package.json
+++ b/packages/scaffolded-question/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@rjsf/utils": "^5.0.1",

--- a/packages/score-bot/package.json
+++ b/packages/score-bot/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@rjsf/utils": "^5.0.1",

--- a/packages/side-by-side/package.json
+++ b/packages/side-by-side/package.json
@@ -102,7 +102,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@rjsf/utils": "^5.0.1",
     "deep-equal": "^2.0.5",

--- a/packages/video-player/package.json
+++ b/packages/video-player/package.json
@@ -106,7 +106,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.6",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@rjsf/utils": "^5.0.1",


### PR DESCRIPTION
This pulls in a fix in the useAccessibility hook that caused the master branch of AP to fail when displaying interactives as the font family info is currently only passed in the notebook branch.