### PR TITLE
Upgrade lara-interactive-api to ^1.9.3.-pre.8 (PT-185453872)

### DIFF
--- a/packages/bar-graph/package.json
+++ b/packages/bar-graph/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.8",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@rjsf/utils": "^5.0.1",
     "chart.js": "^3.9.1",

--- a/packages/carousel/package.json
+++ b/packages/carousel/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.8",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@rjsf/utils": "^5.0.1",
     "classnames": "^2.3.1",

--- a/packages/drag-and-drop/package.json
+++ b/packages/drag-and-drop/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.8",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@rjsf/utils": "^5.0.1",
     "iframe-phone": "^1.3.1",

--- a/packages/drawing-tool/package.json
+++ b/packages/drawing-tool/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.8",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@rjsf/utils": "^5.0.1",

--- a/packages/fill-in-the-blank/package.json
+++ b/packages/fill-in-the-blank/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.8",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@rjsf/utils": "^5.0.1",

--- a/packages/full-screen/package.json
+++ b/packages/full-screen/package.json
@@ -99,7 +99,7 @@
     "webpack-dev-server": "^4.7.4"
   },
   "dependencies": {
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.8",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@rjsf/utils": "^5.0.1",
     "query-string": "^7.1.1",

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -105,7 +105,7 @@
     "webpack-dev-server": "^4.7.4"
   },
   "dependencies": {
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.8",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@rjsf/utils": "^5.0.1",
     "chart.js": "^3.9.1",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -90,7 +90,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.229.0",
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.8",
     "@concord-consortium/slate-editor": "^0.8.2",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@concord-consortium/token-service": "^2.1.0",

--- a/packages/image-question/package.json
+++ b/packages/image-question/package.json
@@ -106,7 +106,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.8",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@rjsf/utils": "^5.0.1",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -106,7 +106,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.8",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@rjsf/utils": "^5.0.1",

--- a/packages/labbook/package.json
+++ b/packages/labbook/package.json
@@ -108,7 +108,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.8",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@rjsf/utils": "^5.0.1",
     "classnames": "^2.3.1",

--- a/packages/multiple-choice-alerts/package.json
+++ b/packages/multiple-choice-alerts/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.8",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@rjsf/utils": "^5.0.1",

--- a/packages/open-response/package.json
+++ b/packages/open-response/package.json
@@ -106,7 +106,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.8",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@rjsf/utils": "^5.0.1",

--- a/packages/scaffolded-question/package.json
+++ b/packages/scaffolded-question/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.8",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@rjsf/utils": "^5.0.1",

--- a/packages/score-bot/package.json
+++ b/packages/score-bot/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.8",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@rjsf/utils": "^5.0.1",

--- a/packages/side-by-side/package.json
+++ b/packages/side-by-side/package.json
@@ -102,7 +102,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.8",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@rjsf/utils": "^5.0.1",
     "deep-equal": "^2.0.5",

--- a/packages/video-player/package.json
+++ b/packages/video-player/package.json
@@ -106,7 +106,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.7",
+    "@concord-consortium/lara-interactive-api": "^1.9.3-pre.8",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@rjsf/utils": "^5.0.1",


### PR DESCRIPTION
This upgrade is necessary because in 1.9.3.-pre.1 + above of lara-interactive-api, iframe-phone was being imported from the incorrect place. This was causing interactive state saving to be cancelled when the drawing tool dialog was opened after trying to upload an image or take a snapshot in image question.