### PR TITLE
fix: Update multiple choice to use lara-interactive-api 1.9.3.pre.8 [PT-185302126]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30827,7 +30827,7 @@
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "1.9.0.pre-1",
+        "@concord-consortium/lara-interactive-api": "1.9.3.pre.8",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@concord-consortium/text-decorator": "^1.0.2",
         "@rjsf/utils": "^5.0.1",
@@ -48803,7 +48803,7 @@
       "version": "file:packages/multiple-choice",
       "requires": {
         "@concord-consortium/dynamic-text": "^1.0.2",
-        "@concord-consortium/lara-interactive-api": "1.9.0.pre-1",
+        "@concord-consortium/lara-interactive-api": "1.9.3.pre.8",
         "@concord-consortium/question-interactives-helpers": "^1.14.0",
         "@concord-consortium/text-decorator": "^1.0.2",
         "@rjsf/utils": "^5.0.1",

--- a/packages/multiple-choice/package.json
+++ b/packages/multiple-choice/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@concord-consortium/dynamic-text": "^1.0.2",
-    "@concord-consortium/lara-interactive-api": "1.9.0.pre-1",
+    "@concord-consortium/lara-interactive-api": "1.9.3.pre.8",
     "@concord-consortium/question-interactives-helpers": "^1.14.0",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@rjsf/utils": "^5.0.1",


### PR DESCRIPTION
The dependency was out out of date in this package.