### PR TITLE
Image media library QA fixes (PT-184813641)

### DIFF
--- a/packages/drawing-tool/src/components/runtime.tsx
+++ b/packages/drawing-tool/src/components/runtime.tsx
@@ -80,14 +80,18 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
         <TakeSnapshot authoredState={authoredState} interactiveState={interactiveState} setInteractiveState={setInteractiveState} />
       }
       { showUploadModal &&
-        <UploadFromMediaLibraryDialog
-          onUploadImage={handleUploadImage}
-          onUploadStart={handleUploadStart}
-          mediaLibraryItems={mediaLibraryItems}
-          uploadInProgress={uploadInProgress}
-          setUploadInProgress={setUploadInProgress}
-          handleCloseModal={() => setShowUploadModal(false)}
-        />
+        <>
+          {/*create an empty div with needed height so modal can overlay properly*/}
+          <div style={{height: "600px"}}/>
+          <UploadFromMediaLibraryDialog
+            onUploadImage={handleUploadImage}
+            onUploadStart={handleUploadStart}
+            mediaLibraryItems={mediaLibraryItems}
+            uploadInProgress={uploadInProgress}
+            setUploadInProgress={setUploadInProgress}
+            handleCloseModal={() => setShowUploadModal(false)}
+          />
+        </>
       }
       {
         !readOnly && useUpload && !showUploadModal &&

--- a/packages/helpers/src/components/media-library/drag-to-upload.scss
+++ b/packages/helpers/src/components/media-library/drag-to-upload.scss
@@ -7,11 +7,12 @@
 
   .dropArea {
     padding: 13px 25px;
-    width: 197px;
+    width: 300px;
     height: 126px;
     display: flex;
     align-content: center;
     align-items: center;
+    text-align: center;
     justify-content: center;
     background-color: #ddd;
     border-radius: 8px;
@@ -21,7 +22,7 @@
     width: fit-content;
     display: flex;
     align-items: center;
-    margin: 5px 10px;
+    margin: 10px 10px;
     padding: 1px 2px;
     border-radius: 4px;
     border: solid 1.5px var(--cc-charcoal-light-1);

--- a/packages/helpers/src/components/media-library/media-library-picker.scss
+++ b/packages/helpers/src/components/media-library/media-library-picker.scss
@@ -1,16 +1,13 @@
 .container {
-  display: flex;
-  flex-direction: column;
-
   .instructions {
     font-weight: bold;
-    font-size: 16px;
+    font-size: 1rem;
     margin-bottom: 8px;
   }
 
   .mediaLibraryPicker {
     max-width: 400px;
-    max-height: 277px;
+    max-height: 300px;
     overflow: auto;
     border-radius: 8px;
     display: flex;
@@ -24,10 +21,8 @@
       flex-direction: row;
       flex-wrap: wrap;
       gap: 8px;
+      height: 250px;
       width: 380px;
-      ::-webkit-scrollbar-track {
-        background: red;
-      }
 
       .thumbnail {
         width: 84px;

--- a/packages/helpers/src/components/media-library/upload-from-media-library-dialog.scss
+++ b/packages/helpers/src/components/media-library/upload-from-media-library-dialog.scss
@@ -1,13 +1,17 @@
 @import "../../styles/px-to-rem.scss";
 
 .modal {
-  position: relative;
-  height: 600px;
+  position: fixed;
+  z-index: 5000;
+  left: 0;
+  top: 0;
   width: 100%;
+  height: 100%;
   background-color: rgb(0,0,0);
   background-color: rgba(0,0,0,0.4);
   display: flex;
   align-items: center;
+  justify-content: center;
   .modalContent {
     background-color: #fefefe;
     margin: 0 auto;

--- a/packages/helpers/src/components/media-library/upload-from-media-library-dialog.scss
+++ b/packages/helpers/src/components/media-library/upload-from-media-library-dialog.scss
@@ -3,7 +3,7 @@
 .modal {
   position: relative;
   height: 600px;
-  width: 960px;
+  width: 100%;
   background-color: rgb(0,0,0);
   background-color: rgba(0,0,0,0.4);
   display: flex;
@@ -14,15 +14,15 @@
     padding: 20px 15px;
     border-radius: 8px;
     width: 436px;
-    height: 570px;
+    height: 590px;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     .or {
-      font-size: 18px;
+      font-size: 1.1rem;
       font-weight: bold;
-      padding: 9px;
+      padding-bottom: 9px;
     }
   }
 }

--- a/packages/image-question/src/components/drawing-tool-dialog.scss
+++ b/packages/image-question/src/components/drawing-tool-dialog.scss
@@ -1,0 +1,45 @@
+.dialogContent {
+  width: 960px;
+  margin: 0 auto;
+  position: relative;
+
+  .drawingTool {
+    vertical-align: top;
+    margin-right: 20px;
+    width: 650px;
+    display: inline-block;
+  }
+
+  .dialogRightPanel {
+    vertical-align: top;
+    display: inline-block;
+    width: 280px;
+    color: var(--cc-charcoal);
+
+    .prompt {
+      margin-top: 5px;
+    }
+
+    .default {
+      font-style: italic;
+    }
+
+    .hasAnswer {
+      font-style: normal;
+    }
+
+    hr {
+      border-color: var(--cc-charcoal-light-1);
+    }
+
+    .closeDialogSection {
+      text-align: right;
+
+      .closeDialogButtons {
+        display: flex;
+        width: 100%;
+        justify-content: center;
+      }
+    }
+  }
+}

--- a/packages/image-question/src/components/drawing-tool-dialog.tsx
+++ b/packages/image-question/src/components/drawing-tool-dialog.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { IAuthoredState, IInteractiveState } from "./types";
+import { UpdateFunc } from "@concord-consortium/question-interactives-helpers/src/components/base-app";
+import { DrawingTool } from "drawing-tool-interactive/src/components/drawing-tool";
+import { DynamicText } from "@concord-consortium/dynamic-text";
+import { renderHTML } from "@concord-consortium/question-interactives-helpers/src/utilities/render-html";
+import CorrectIcon from "@concord-consortium/question-interactives-helpers/src/icons/correct.svg";
+import classnames from "classnames";
+
+import cssHelpers from "@concord-consortium/question-interactives-helpers/src/styles/helpers.scss";
+import css from "./drawing-tool-dialog.scss";
+
+interface IProps {
+  authoredState: IAuthoredState;
+  interactiveState?: IInteractiveState|null;
+  handleDrawingToolSetIntState: (updateFunc: UpdateFunc<IInteractiveState>) => void;
+  handleTextChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  savingAnnotatedImage: boolean;
+  handleCancel: () => void;
+  handleClose: () => void;
+}
+
+const kGlobalDefaultAnswer = "Please type your answer here.";
+
+export const DrawingToolDialog: React.FC<IProps> = ({authoredState, interactiveState, handleDrawingToolSetIntState,
+  handleTextChange, savingAnnotatedImage, handleCancel, handleClose}) => {
+  const {prompt, answerPrompt, defaultAnswer} = authoredState;
+  const bodyWidth = document.getElementsByTagName("body").item(0)?.clientWidth || window.innerWidth;
+  const onIPad = bodyWidth <= 960;
+
+  return (
+    <div className={css.dialogContent} style={{width: onIPad ? 840 : 960}}>
+      <div className={css.drawingTool} style={{width: onIPad ? 550 : 650}}>
+        <DrawingTool
+          authoredState={authoredState}
+          interactiveState={interactiveState}
+          setInteractiveState={handleDrawingToolSetIntState}
+          width={onIPad ? 500 : 600}
+        />
+      </div>
+      <div className={css.dialogRightPanel} style={{width: onIPad ? 250 : 280}}>
+        { prompt && <div className={css.prompt}><DynamicText>{renderHTML(prompt)}</DynamicText></div> }
+        { answerPrompt && <>
+          <hr />
+          <div className={css.answerPrompt}><DynamicText>{renderHTML(answerPrompt)}</DynamicText></div>
+          <textarea
+            value={interactiveState?.answerText || ""}
+            onChange={handleTextChange}
+            rows={8}
+            className={interactiveState?.answerText ? css.hasAnswer : css.default}
+            placeholder={defaultAnswer || kGlobalDefaultAnswer}
+          />
+        </> }
+        <div className={css.closeDialogSection}>
+          { savingAnnotatedImage ?
+            <div>Please wait while your drawing is being saved...</div> :
+            <div className={css.closeDialogButtons}>
+              <button className={cssHelpers.interactiveButton} onClick={handleCancel} data-test="cancel-upload-btn">
+                Cancel
+              </button>
+              <button
+                className={classnames(cssHelpers.interactiveButton, cssHelpers.withIcon)}
+                onClick={handleClose}
+                data-test="close-dialog-btn">
+                  <CorrectIcon/>
+                  <div className={cssHelpers.buttonText}>Done</div>
+              </button>
+            </div>
+          }
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/image-question/src/components/inline-content.scss
+++ b/packages/image-question/src/components/inline-content.scss
@@ -1,0 +1,40 @@
+legend.prompt { // clear bootstrap stuff
+  display: unset;
+  width: unset;
+  margin-bottom: unset;
+  font-size: 1rem;
+  border: unset;
+  padding-bottom: 5px;
+
+  img {
+    height: auto;
+    max-width: 100%;
+  }
+}
+
+.answerPrompt {
+  margin-top: 10px;
+  margin-bottom: 4px;
+}
+
+.buttonContainer {
+  display: flex;
+  align-items: center;
+}
+
+.warn {
+  color: darkred;
+}
+
+.error {
+  color: darkred;
+  font-weight: bold;
+}
+
+.studentAnswerText {
+  font-size: 0.9rem;
+}
+
+.inlineImg {
+  max-width: 100%;
+}

--- a/packages/image-question/src/components/inline-content.tsx
+++ b/packages/image-question/src/components/inline-content.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { IAuthoredState, IInteractiveState } from "./types";
+import { UpdateFunc } from "@concord-consortium/question-interactives-helpers/src/components/base-app";
+import { DynamicText } from "@concord-consortium/dynamic-text";
+import { renderHTML } from "@concord-consortium/question-interactives-helpers/src/utilities/render-html";
+import { DecorateChildren } from "@concord-consortium/text-decorator";
+import { useGlossaryDecoration } from "@concord-consortium/question-interactives-helpers/src/hooks/use-glossary-decoration";
+import { TakeSnapshot } from "drawing-tool-interactive/src/components/take-snapshot";
+import { UploadBackground } from "drawing-tool-interactive/src/components/upload-background";
+import PencilIcon from "@concord-consortium/question-interactives-helpers/src/icons/pencil.svg";
+import classnames from "classnames";
+
+import css from "./inline-content.scss";
+import cssHelpers from "@concord-consortium/question-interactives-helpers/src/styles/helpers.scss";
+
+interface IProps {
+  authoredState: IAuthoredState;
+  interactiveState?: IInteractiveState|null;
+  readOnly?: boolean;
+  authoredBgCorsError: boolean;
+  controlsHidden: boolean;
+  setInteractiveState: ((updateFunc: UpdateFunc<IInteractiveState>) => void) | undefined;
+  snapshotOrUploadFinished: ({ success }: {success: boolean;}) => void;
+  handleUploadStart: () => void;
+  setShowUploadModal: (showModal: boolean) => void;
+  mediaLibraryEnabled?: boolean;
+  setUploadInProgress: (inProgress: boolean) => void;
+  uploadInProgress: boolean;
+  openDrawingToolDialog: () => void;
+}
+
+export const InlineContent: React.FC<IProps> = ({authoredState, interactiveState, readOnly, authoredBgCorsError,
+  controlsHidden, snapshotOrUploadFinished, setInteractiveState, handleUploadStart, setUploadInProgress, setShowUploadModal,
+  mediaLibraryEnabled, uploadInProgress, openDrawingToolDialog}) => {
+  const {prompt, answerPrompt, backgroundImageUrl, backgroundSource} = authoredState;
+  const decorateOptions = useGlossaryDecoration();
+
+  const renderSnapshot = backgroundSource === "snapshot";
+  const renderUpload = backgroundSource === "upload";
+  const renderMakeDrawing = !renderSnapshot && !renderUpload;
+  const previousAnswerAvailable = interactiveState?.userBackgroundImageUrl || interactiveState?.answerImageUrl;
+  const authoredBackgroundUrl = backgroundSource === "url" && backgroundImageUrl;
+  const inlineImage = interactiveState?.answerImageUrl || interactiveState?.userBackgroundImageUrl || authoredBackgroundUrl;
+
+  // Render answer prompt and answer text in inline mode to replicate LARA's Image Question UI
+  return (
+    <>
+    { authoredBgCorsError ?
+      <div className={css.error}>
+        Authored background image is not CORS enabled. Please use a different background image URL or change configuration of the host.
+      </div> :
+      <div>
+        { prompt &&
+          <DynamicText>
+            <DecorateChildren decorateOptions={decorateOptions}>
+              <div>{renderHTML(prompt)}</div>
+            </DecorateChildren>
+          </DynamicText>
+        }
+        { inlineImage &&
+          <div>
+            <img src={inlineImage} className={css.inlineImg} alt="user work"/>
+          </div> }
+        { answerPrompt &&
+          <>
+            <div><DynamicText>{renderHTML(answerPrompt)}</DynamicText></div>
+            <div className={css.studentAnswerText}><DynamicText>{interactiveState?.answerText}</DynamicText></div>
+          </>
+        }
+        { !readOnly &&
+          <div className={css.buttonContainer}>
+            {
+              renderSnapshot &&
+              <TakeSnapshot
+                authoredState={authoredState}
+                interactiveState={interactiveState}
+                setInteractiveState={setInteractiveState}
+                onUploadStart={handleUploadStart}
+                onUploadComplete={snapshotOrUploadFinished}
+              />
+            }
+            {
+              renderUpload &&
+              <UploadBackground
+                authoredState={authoredState}
+                setInteractiveState={setInteractiveState}
+                onUploadStart={handleUploadStart}
+                onUploadComplete={snapshotOrUploadFinished}
+                setShowUploadModal={setShowUploadModal}
+                mediaLibraryEnabled={mediaLibraryEnabled}
+                setUploadInProgress={setUploadInProgress}
+                uploadInProgress={uploadInProgress}
+              />
+            }
+            {
+              !controlsHidden && (renderMakeDrawing || previousAnswerAvailable) &&
+              <button
+                className={classnames(cssHelpers.interactiveButton, {[cssHelpers.withIcon]: !previousAnswerAvailable})}
+                onClick={openDrawingToolDialog}
+                data-test="edit-btn"
+              >
+                { previousAnswerAvailable ? "Edit" :
+                  <>
+                    <PencilIcon className={cssHelpers.smallIcon}/>
+                    <div className={cssHelpers.buttonText}>Make Drawing</div>
+                  </>
+                }
+              </button>
+              }
+          </div>
+        }
+      </div>
+    }
+  </>
+  );
+};

--- a/packages/image-question/src/components/runtime.tsx
+++ b/packages/image-question/src/components/runtime.tsx
@@ -1,35 +1,22 @@
 import React, { useEffect, useState } from "react";
-import classnames from "classnames";
 import { IRuntimeQuestionComponentProps } from "@concord-consortium/question-interactives-helpers/src/components/base-question-app";
 import { IMediaLibrary, closeModal, showModal, useInitMessage } from "@concord-consortium/lara-interactive-api";
-import { TakeSnapshot } from "drawing-tool-interactive/src/components/take-snapshot";
-import CorrectIcon from "@concord-consortium/question-interactives-helpers/src/icons/correct.svg";
-import { UploadBackground } from "drawing-tool-interactive/src/components/upload-background";
 import { getURLParam } from "@concord-consortium/question-interactives-helpers/src/utilities/get-url-param";
-import { DrawingTool, drawingToolCanvasSelector } from "drawing-tool-interactive/src/components/drawing-tool";
-import { renderHTML } from "@concord-consortium/question-interactives-helpers/src/utilities/render-html";
+import { drawingToolCanvasSelector } from "drawing-tool-interactive/src/components/drawing-tool";
 import { UpdateFunc } from "@concord-consortium/question-interactives-helpers/src/components/base-app";
 import Shutterbug from "shutterbug";
-import PencilIcon from "@concord-consortium/question-interactives-helpers/src/icons/pencil.svg";
 import { useCorsImageErrorCheck } from "@concord-consortium/question-interactives-helpers/src/hooks/use-cors-image-error-check";
-import { DecorateChildren } from "@concord-consortium/text-decorator";
-import { useGlossaryDecoration } from "@concord-consortium/question-interactives-helpers/src/hooks/use-glossary-decoration";
-import { DynamicText } from "@concord-consortium/dynamic-text";
 import { UploadFromMediaLibraryDialog } from "../../../helpers/src/components/media-library/upload-from-media-library-dialog";
-
+import { DrawingToolDialog } from "./drawing-tool-dialog";
+import { InlineContent } from "./inline-content";
 import { IAuthoredState, IInteractiveState } from "./types";
-
-import css from "./runtime.scss";
-import cssHelpers from "@concord-consortium/question-interactives-helpers/src/styles/helpers.scss";
 
 interface IProps extends IRuntimeQuestionComponentProps<IAuthoredState, IInteractiveState> {}
 
-const kGlobalDefaultAnswer = "Please type your answer here.";
 const drawingToolDialogUrlParam = "drawingToolDialog";
 
 export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, report }) => {
-  const {required, backgroundSource, backgroundImageUrl, answerPrompt, prompt, allowUploadFromMediaLibrary} = authoredState;
-  const decorateOptions = useGlossaryDecoration();
+  const {required, backgroundSource, backgroundImageUrl, allowUploadFromMediaLibrary} = authoredState;
   const readOnly = report || (required && interactiveState?.submitted);
   const [ controlsHidden, setControlsHidden ] = useState(false);
   const [ drawingStateUpdated, setDrawingStateUpdated ] = useState(false);
@@ -54,6 +41,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
 
   const snapshotOrUploadFinished = ({ success }: { success: boolean }) => {
     setControlsHidden(false);
+    setShowUploadModal(false);
     if (success) {
       openDrawingToolDialog();
     }
@@ -95,7 +83,6 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     }));
   };
 
-
   const handleCancel = () => {
     setInteractiveState?.((prevState: IInteractiveState) => ({
       ...prevState,
@@ -136,135 +123,50 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   const mediaLibraryEnabled = allowUploadFromMediaLibrary && mediaLibrary?.enabled && mediaLibrary?.items.length > 0;
   const mediaLibraryItems = mediaLibraryEnabled ? mediaLibrary.items.filter((i) => i.type === "image") : undefined;
 
-  const renderInline = () => {
-    if (authoredBgCorsError) {
-      return <div className={css.error}>Authored background image is not CORS enabled. Please use a different background
-        image URL or change configuration of the host.</div>;
-    }
+  console.log({uploadInProgress});
 
-    const renderSnapshot = authoredState?.backgroundSource === "snapshot";
-    const renderUpload = authoredState?.backgroundSource === "upload";
-    const renderMakeDrawing = !renderSnapshot && !renderUpload;
-    const previousAnswerAvailable = interactiveState?.userBackgroundImageUrl || interactiveState?.answerImageUrl;
-    const authoredBackgroundUrl = authoredState?.backgroundSource === "url" && backgroundImageUrl;
-    const inlineImage = interactiveState?.answerImageUrl || interactiveState?.userBackgroundImageUrl || authoredBackgroundUrl;
-
-    // Render answer prompt and answer text in inline mode to replicate LARA's Image Question UI
-    return <div>
-      { prompt &&
-        <DynamicText>
-          <DecorateChildren decorateOptions={decorateOptions}>
-            <div>{renderHTML(prompt)}</div>
-          </DecorateChildren>
-        </DynamicText>
-      }
-      { inlineImage && <div><img src={inlineImage} className={css.inlineImg} alt="user work"/></div> }
-      { answerPrompt && <>
-        <div><DynamicText>{renderHTML(answerPrompt)}</DynamicText></div>
-        <div className={css.studentAnswerText}><DynamicText>{interactiveState?.answerText}</DynamicText></div>
-      </> }
-      {
-        !readOnly &&
-        <div className={css.buttonContainer}>
-          {
-            renderSnapshot &&
-            <TakeSnapshot
-              authoredState={authoredState}
-              interactiveState={interactiveState}
-              setInteractiveState={setInteractiveState}
-              onUploadStart={handleUploadStart}
-              onUploadComplete={snapshotOrUploadFinished}
-            />
-          }
-          {
-            renderUpload &&
-            <UploadBackground
-              authoredState={authoredState}
-              setInteractiveState={setInteractiveState}
-              onUploadStart={handleUploadStart}
-              onUploadComplete={snapshotOrUploadFinished}
-              setShowUploadModal={setShowUploadModal}
-              mediaLibraryEnabled={mediaLibraryEnabled}
-              setUploadInProgress={setUploadInProgress}
-              uploadInProgress={uploadInProgress}
-            />
-          }
-          {
-            !controlsHidden && (renderMakeDrawing || previousAnswerAvailable) &&
-            <button className={classnames(cssHelpers.interactiveButton, {[cssHelpers.withIcon]: !previousAnswerAvailable})} onClick={openDrawingToolDialog} data-test="edit-btn">
-              { previousAnswerAvailable ? "Edit" :
-                <>
-                  <PencilIcon className={cssHelpers.smallIcon}/>
-                  <div className={cssHelpers.buttonText}>Make Drawing</div>
-                </>
-              }
-            </button>
-          }
-        </div>
-      }
-    </div>;
-  };
-
-  const renderUploadModal = () => {
-    return (
-      <UploadFromMediaLibraryDialog
-        onUploadImage={handleUploadImage}
-        onUploadStart={handleUploadStart}
-        onUploadComplete={snapshotOrUploadFinished}
-        mediaLibraryItems={mediaLibraryItems}
-        uploadInProgress={uploadInProgress}
-        setUploadInProgress={setUploadInProgress}
-        handleCloseModal={() => setShowUploadModal(false)}
-      />
-    );
-  };
-
-  const renderDialog = () => {
-    // look at the body width and if it looks like we are on an iPad (960px) then reduce the drawing tool to fit
-    const bodyWidth = document.getElementsByTagName("body").item(0)?.clientWidth || window.innerWidth;
-    const onIPad = bodyWidth <= 960;
-
-    return (
-      <div className={css.dialogContent} style={{width: onIPad ? 840 : 960}}>
-        <div className={css.drawingTool} style={{width: onIPad ? 550 : 650}}>
-          <DrawingTool
+  return (
+    <>
+      { showUploadModal && !uploadInProgress ?
+        <>
+          {/*create an empty div with needed height so modal can overlay properly*/}
+          <div style={{height: "600px"}}/>
+          <UploadFromMediaLibraryDialog
+            onUploadImage={handleUploadImage}
+            onUploadStart={handleUploadStart}
+            onUploadComplete={snapshotOrUploadFinished}
+            mediaLibraryItems={mediaLibraryItems}
+            uploadInProgress={uploadInProgress}
+            setUploadInProgress={setUploadInProgress}
+            handleCloseModal={() => setShowUploadModal(false)}
+          />
+        </> :
+        drawingToolDialog ?
+          <DrawingToolDialog
             authoredState={authoredState}
             interactiveState={interactiveState}
-            setInteractiveState={handleDrawingToolSetIntState}
-            width={onIPad ? 500 : 600}
-          />
-        </div>
-        <div className={css.dialogRightPanel} style={{width: onIPad ? 250 : 280}}>
-          { authoredState.prompt && <div className={css.prompt}><DynamicText>{renderHTML(authoredState.prompt)}</DynamicText></div> }
-          { authoredState.answerPrompt && <>
-            <hr />
-            <div className={css.answerPrompt}><DynamicText>{renderHTML(authoredState.answerPrompt)}</DynamicText></div>
-            <textarea
-              value={interactiveState?.answerText || ""}
-              onChange={handleTextChange}
-              rows={8}
-              className={interactiveState?.answerText ? css.hasAnswer : css.default}
-              placeholder={authoredState.defaultAnswer || kGlobalDefaultAnswer}
-            />
-          </> }
-          <div className={css.closeDialogSection}>
-            { savingAnnotatedImage ?
-              <div>Please wait while your drawing is being saved...</div> :
-              <div className={css.closeDialogButtons}>
-                <button className={cssHelpers.interactiveButton} onClick={handleCancel} data-test="cancel-upload-btn">
-                  Cancel
-                </button>
-                <button className={classnames(cssHelpers.interactiveButton, cssHelpers.withIcon)} onClick={handleClose} data-test="close-dialog-btn">
-                  <CorrectIcon/>
-                  <div className={cssHelpers.buttonText}>Done</div>
-                </button>
-              </div>
-            }
-          </div>
-        </div>
-      </div>
-    );
-  };
-
-  return showUploadModal && !uploadInProgress ? renderUploadModal() : drawingToolDialog ? renderDialog() : renderInline();
+            handleDrawingToolSetIntState={handleDrawingToolSetIntState}
+            handleCancel={handleCancel}
+            handleClose={handleClose}
+            handleTextChange={handleTextChange}
+            savingAnnotatedImage={savingAnnotatedImage}
+          /> :
+        <InlineContent
+          authoredState={authoredState}
+          interactiveState={interactiveState}
+          readOnly={readOnly}
+          authoredBgCorsError={authoredBgCorsError}
+          controlsHidden={controlsHidden}
+          setInteractiveState={setInteractiveState}
+          snapshotOrUploadFinished={snapshotOrUploadFinished}
+          handleUploadStart={handleUploadStart}
+          setShowUploadModal={setShowUploadModal}
+          mediaLibraryEnabled={mediaLibraryEnabled}
+          setUploadInProgress={setUploadInProgress}
+          uploadInProgress={uploadInProgress}
+          openDrawingToolDialog={openDrawingToolDialog}
+        />
+      }
+    </>
+  );
 };

--- a/packages/image-question/src/components/runtime.tsx
+++ b/packages/image-question/src/components/runtime.tsx
@@ -123,8 +123,6 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   const mediaLibraryEnabled = allowUploadFromMediaLibrary && mediaLibrary?.enabled && mediaLibrary?.items.length > 0;
   const mediaLibraryItems = mediaLibraryEnabled ? mediaLibrary.items.filter((i) => i.type === "image") : undefined;
 
-  console.log({uploadInProgress});
-
   return (
     <>
       { showUploadModal && !uploadInProgress ?

--- a/packages/labbook/src/components/create-or-replace-image.scss
+++ b/packages/labbook/src/components/create-or-replace-image.scss
@@ -5,7 +5,7 @@
 }
 .thumbnails, .uploadButtons {
   display: flex;
-  width: 355px;
+  width: 100%;
   justify-content: space-around;
   align-items: center;
 

--- a/packages/labbook/src/components/create-or-replace-image.tsx
+++ b/packages/labbook/src/components/create-or-replace-image.tsx
@@ -57,7 +57,7 @@ export const CreateOrReplaceImage: React.FC<IProps> = ({onUploadImage, onUploadS
               {disabled ? "Please Wait" : "Replace Current Image"}
             </div>
           </UploadButton>
-          <UploadButton disabled={disabled} onClick={() => onUploadImage("", "create")}>
+          <UploadButton disabled={disabled || reachedMaxEntries} onClick={() => onUploadImage("", "create")}>
           <div className={css["button-text"]}>
             {disabled ? "Please Wait" : "Create New Image"}
           </div>

--- a/packages/labbook/src/components/runtime.scss
+++ b/packages/labbook/src/components/runtime.scss
@@ -65,13 +65,14 @@
     .buttons {
       display: flex;
       flex-direction: column;
-      width: 160px;
       height: 96px;
       align-items: center;
       justify-content: center;
 
-      & > * {
-        width: 152px;
+      .button-text {
+        margin: 0px 5px;
+        font-size: pxToRem(16);
+        white-space: nowrap;
       }
     }
   }

--- a/packages/labbook/src/components/runtime.tsx
+++ b/packages/labbook/src/components/runtime.tsx
@@ -283,7 +283,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
 
   const uploadImageMode = (backgroundSource === "upload" || showUploadImageButton);
   const selectedItemHasImageUrl = !!(selectedItem?.data?.userBackgroundImageUrl);
-  const mediaLibraryEnabled = allowUploadFromMediaLibrary && mediaLibrary?.enabled && mediaLibrary?.items.length;
+  const mediaLibraryEnabled = allowUploadFromMediaLibrary && mediaLibrary?.enabled && mediaLibrary?.items.length > 0;
   const mediaLibraryItems = mediaLibraryEnabled ? mediaLibrary.items.filter((i) => i.type === "image") : undefined;
 
   return (

--- a/packages/labbook/src/components/take-snapshot.tsx
+++ b/packages/labbook/src/components/take-snapshot.tsx
@@ -6,6 +6,8 @@ import { useLinkedInteractiveId } from "@concord-consortium/question-interactive
 import SnapShotIcon from "../assets/snapshot-image-icon.svg";
 import { Log } from "../labbook-logging";
 
+import css from "./upload-button.scss";
+
 export interface IProps {
   authoredState: IGenericAuthoredState; // so it works with DrawingTool and ImageQuestion
   interactiveState?: IGenericInteractiveState | null;
@@ -49,10 +51,12 @@ export const TakeSnapshot: React.FC<IProps> = ({ authoredState, interactiveState
             disabled={snapshotInProgress || disabled}
             data-testid="snapshot-btn">
                 <SnapShotIcon />
+                <div className={css["button-text"]}>
                 { snapshotInProgress || disabled
                   ? "Please Wait"
                   : "Take Snapshot"
                 }
+                </div>
           </UploadButton>
       }
     </>

--- a/packages/labbook/src/components/upload-image-modal.scss
+++ b/packages/labbook/src/components/upload-image-modal.scss
@@ -9,12 +9,14 @@
   height: 100%;
   background-color: rgb(0,0,0);
   background-color: rgba(0,0,0,0.4);
+  display: flex;
+  justify-content: center;
+  align-items: center;
   .modalContent {
     background-color: #fefefe;
-    margin: 15% auto;
     padding: 20px 15px;
     border-radius: 8px;
-    width: 436px;
+    width: 500px;
     height: 275px;
     display: flex;
     flex-direction: column;
@@ -24,7 +26,6 @@
       padding: 8px;
       max-height: 560px;
       height: fit-content;
-      margin: .5% auto;
       justify-content: space-between;
     }
     .hidden {
@@ -37,7 +38,7 @@
     }
     .thumbnails, .uploadButtons {
       display: flex;
-      width: 355px;
+      width: 100%;
       justify-content: space-around;
       align-items: center;
 

--- a/packages/labbook/src/components/upload-image-modal.tsx
+++ b/packages/labbook/src/components/upload-image-modal.tsx
@@ -62,7 +62,7 @@ export const UploadModal: React.FC<IProps> = ({onUploadImage, onUploadStart, onU
           </> :
           <CreateOrReplaceImage
             onUploadImage={mediaLibraryItems ? handleSetUploadMode : onUploadImage}
-            disabled={disabled || reachedMaxEntries}
+            disabled={disabled}
             onUploadStart={onUploadStart}
             onUploadComplete={onUploadComplete}
             onCloseModal={handleCloseModal}


### PR DESCRIPTION
This PR addresses the following issues:

-  Labbook: If media library selection option is disabled and if student reached the maximum number of entries, Replace Current Image and Create New Image buttons are disabled. Unable to proceed further. (User should be able to click on the Replace Current Image button)
- Labbook: If media library selection is enabled and if student reached the maximum number of entries, instead of Replace Current Image and Create New Image buttons, getting Please Wait button in disabled state. Unable to proceed further. (User should be able to click on the Replace Current Image button)
- In image question & drawing tool, if question is set to required, able to submit the answer when dialog is displayed. (User should not be able to click the submit button when the dialog is open)
- In Image question & drawing tool interactives, when secondary column is visible, in 60-40/40-60 layouts, dialog is getting cut off on the right & in 70-30/30-70 layouts, dialog is not center aligned. (Dialog should always be visible)
- When font size set to large, alignment issue occurs in the dialog and Upload an image from this activity: heading not supports the large font settings. 

I also compartmentalized the image-question runtime into a few different components for readability's sake. 