### PR TITLE
Add "answerPrompt" class to drawing-tool-dialog css.

### DIFF
--- a/packages/image-question/src/components/drawing-tool-dialog.scss
+++ b/packages/image-question/src/components/drawing-tool-dialog.scss
@@ -16,6 +16,11 @@
     width: 280px;
     color: var(--cc-charcoal);
 
+    .answerPrompt {
+      margin-top: 10px;
+      margin-bottom: 4px;
+    }
+
     .prompt {
       margin-top: 5px;
     }


### PR DESCRIPTION
Add this css class to the drawing-tool-dialog css file, so the AP cypress test can find the element.