### PR TITLE
fix(IframeAuthoring): handle case when formData is undefined [PT-185560197]

### DIFF
--- a/packages/carousel/src/components/iframe-authoring.tsx
+++ b/packages/carousel/src/components/iframe-authoring.tsx
@@ -17,7 +17,7 @@ const availableInteractives = libraryInteractives;
 export const IframeAuthoring: React.FC<FieldProps> = props => {
   const { onChange, formData } = props;
   const { tokenServiceClient } = props.formContext as IFormContext<unknown>;
-  const { libraryInteractiveId, authoredState, id, navImageUrl, navImageAltText } = formData;
+  const { libraryInteractiveId, authoredState, id, navImageUrl, navImageAltText } = formData || {};
   const [ iframeHeight, setIframeHeight ] = useState(300);
   const [ authoringOpened, setAuthoringOpened ] = useState(false);
   const interactiveWrapperClass = authoringOpened ? `${css.iframeAuthoring} ${css.open}` : css.iframeAuthoring;

--- a/packages/scaffolded-question/src/components/iframe-authoring.tsx
+++ b/packages/scaffolded-question/src/components/iframe-authoring.tsx
@@ -11,7 +11,7 @@ import css from "./iframe-authoring.scss";
 
 export const IframeAuthoring: React.FC<FieldProps> = props => {
   const { onChange, formData } = props;
-  const { libraryInteractiveId, authoredState, id } = formData;
+  const { libraryInteractiveId, authoredState, id } = formData || {};
   const [ iframeHeight, setIframeHeight ] = useState(300);
   const [ authoringOpened, setAuthoringOpened ] = useState(false);
   const interactiveWrapperClass = authoringOpened ? `${css.iframeAuthoring} ${css.open}` : css.iframeAuthoring;

--- a/packages/side-by-side/src/components/iframe-authoring.tsx
+++ b/packages/side-by-side/src/components/iframe-authoring.tsx
@@ -17,7 +17,7 @@ export const LocalLinkedInteractiveId = "Side-by-side Data";
 
 export const IframeAuthoring: React.FC<FieldProps> = props => {
   const { onChange, formData } = props;
-  const { libraryInteractiveId, authoredState, id, navImageUrl, navImageAltText } = formData;
+  const { libraryInteractiveId, authoredState, id, navImageUrl, navImageAltText } = formData || {};
   const [ iframeHeight, setIframeHeight ] = useState(300);
   const [ authoringOpened, setAuthoringOpened ] = useState(false);
   const interactiveWrapperClass = authoringOpened ? `${css.iframeAuthoring} ${css.open}` : css.iframeAuthoring;


### PR DESCRIPTION
I've verified manually that the previous version of reactjson-schema-form was providing `formData={}` while now it's `formData=undefined`. I don't know where this change originated, but this PR should maintain the old behavior.