### PR TITLE
fix: Labbook comment text layout in reports [PT-185471385]

### DIFF
--- a/packages/labbook/src/components/comment-field.scss
+++ b/packages/labbook/src/components/comment-field.scss
@@ -12,13 +12,20 @@
     margin-right: 0px;
   }
 
+  &.readOnly {
+    // take up the full width in the portal reports
+    width: 100%;
+  }
+
   &:focus, &:focus-visible {
     border: solid 1.5px var(--cc-charcoal-light-3);
   }
 
   .comment-field-text {
-    padding-left: 32px;
-    white-space: pre;
+    padding: 10px 10px 10px 32px;
+    // add line breaks to keep the text within the outer comment-field container
+    // but preserve the user entered newlines in the comment.
+    white-space: pre-line;
     max-height: 100%;
     min-height: 56px;
   }

--- a/packages/labbook/src/components/comment-field.tsx
+++ b/packages/labbook/src/components/comment-field.tsx
@@ -44,7 +44,7 @@ export const CommentField = (props: ICommentFieldProps) => {
   }, [comment, setComment]);
 
   return (
-      <div className={classnames(css["comment-field"], {[css.wide]: wideLayout})} data-testid="comment-field">
+      <div className={classnames(css["comment-field"], {[css.wide]: wideLayout, [css.readOnly]: readOnly})} data-testid="comment-field">
         <ThumbnailTitle title={title} empty={empty}/>
         {readOnly ? <div className={css["comment-field-text"]} data-testid="comment-field-text">{comment.length === 0 ? <em>No comment.</em> : comment}</div> : null}
         {!readOnly ? <textarea disabled={empty} placeholder={placeholder} value={comment} onChange={handleTextAreaChange} onBlur={logCommentChange} data-testid="comment-field-textarea"></textarea> : null}


### PR DESCRIPTION
This fixes an issue in the portal reports where long comments did not wrap when displayed.  This also makes the comments 100% of the width in the reports and adds more padding as requested.