### PR TITLE
feat: Add authoring option to disable the Labbook annotation tool [PT-185699750]

### DIFF
--- a/packages/labbook/src/components/app.tsx
+++ b/packages/labbook/src/components/app.tsx
@@ -6,6 +6,19 @@ import { IAuthoredState, IInteractiveState } from "./types";
 import { baseAuthoringProps as drawingToolBaseAuthoringProps, exportToMediaLibrary } from "drawing-tool-interactive/src/components/app";
 import deepmerge from "deepmerge";
 
+export const ToolbarModificationsWidget = (props: any) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => props.onChange(e.target.checked);
+
+  return (
+    <div className="checkbox">
+      <label>
+        <input type="checkbox" id={props.id} checked={!!props.value} onChange={handleChange} />
+        <span>{props.schema.customLabel}</span>
+      </label>
+    </div>
+  );
+};
+
 const baseAuthoringProps = deepmerge(drawingToolBaseAuthoringProps, {
   schema: {
     properties: {
@@ -29,6 +42,12 @@ const baseAuthoringProps = deepmerge(drawingToolBaseAuthoringProps, {
         title: "Background source",
         type: "string",
         default: "snapshot"
+      },
+      hideAnnotationTool: {
+        title: "Toolbar Modifications",
+        customLabel: "Hide Annotation Tool",
+        type: "boolean",
+        default: false
       }
     }
   } as RJSFSchema,
@@ -45,7 +64,10 @@ const baseAuthoringProps = deepmerge(drawingToolBaseAuthoringProps, {
     },
     questionType: {
       "ui:widget": "hidden"
-    }
+    },
+    hideAnnotationTool: {
+      "ui:widget": ToolbarModificationsWidget
+    },
   },
   // Just overwrite array, don't merge values.
   arrayMerge: (destinationArray:any, sourceArray:any) => sourceArray
@@ -54,7 +76,7 @@ const baseAuthoringProps = deepmerge(drawingToolBaseAuthoringProps, {
 // This list combines all the fields from drawing-tool app and custom ones specified by Labbook.
 baseAuthoringProps.uiSchema["ui:order"] = [
   "prompt", "required", "predictionFeedback", "hint", "backgroundSource", "showUploadImageButton", "snapshotTarget",
-  "backgroundImageUrl", "imageFit", "imagePosition",  "stampCollections", "maxItems", "showItems", "version", "questionType",
+  "backgroundImageUrl", "imageFit", "imagePosition", "hideAnnotationTool",  "stampCollections", "maxItems", "showItems", "version", "questionType",
   ...exportToMediaLibrary.uiOrder
 ];
 

--- a/packages/labbook/src/components/runtime.tsx
+++ b/packages/labbook/src/components/runtime.tsx
@@ -71,7 +71,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     return result;
   };
 
-  const {showUploadImageButton, backgroundSource, allowUploadFromMediaLibrary } = authoredState;
+  const {showUploadImageButton, backgroundSource, allowUploadFromMediaLibrary, hideAnnotationTool } = authoredState;
   const [mediaLibrary, setMediaLibrary] = useState<IMediaLibrary|undefined>(undefined);
 
   const initMessage = useInitMessage();
@@ -272,14 +272,9 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     setShowUploadModal(true);
   };
 
-  const drawingToolButtons = [
-    'select',
-    'free',
-    'shapesPalette',
-    'stamp',
-    'annotation',
-    'trash',
-  ];
+  const drawingToolButtons = ['select', 'free', 'shapesPalette', 'stamp']
+    .concat(hideAnnotationTool ? [] : ['annotation'])
+    .concat('trash');
 
   const uploadImageMode = (backgroundSource === "upload" || showUploadImageButton);
   const selectedItemHasImageUrl = !!(selectedItem?.data?.userBackgroundImageUrl);

--- a/packages/labbook/src/components/types.ts
+++ b/packages/labbook/src/components/types.ts
@@ -12,6 +12,7 @@ export interface IAuthoredState extends IDrawingToolAuthoredState {
   maxItems: number;
   showItems: number;
   showUploadImageButton: boolean;
+  hideAnnotationTool: boolean;
 }
 
 export interface ILabbookEntry {
@@ -39,4 +40,5 @@ export const DemoAuthoredState: IAuthoredState = {
   showItems: 4,
   showUploadImageButton: false,
   backgroundSource: "upload",
+  hideAnnotationTool: false,
 };


### PR DESCRIPTION
The new authoring option defaults to false.  When set to true the annotation tool is not shown in the labbook toolbar.

The new authoring option looks like this, as requested:

![image](https://github.com/concord-consortium/question-interactives/assets/112938/347e19da-cf98-41c7-9d76-c2bcf489534e)
