### PR TITLE
186280538 fix dialog button ipad

### DIFF
--- a/packages/labbook/src/components/upload-button.scss
+++ b/packages/labbook/src/components/upload-button.scss
@@ -51,7 +51,8 @@
     &.inDialog{
       padding: 6px 4px 9px 5px;
       text-align: center;
-      text-wrap: wrap;
+      text-wrap: wrap; //only works in Chrome
+      white-space: pre-wrap; //For Safari and Firefox
     }
   }
 }

--- a/packages/labbook/src/components/upload-image.tsx
+++ b/packages/labbook/src/components/upload-image.tsx
@@ -3,7 +3,7 @@ import { StyledFileInput } from "../../../helpers/src/components/styled-file-inp
 import { copyImageToS3, copyLocalImageToS3 } from "@concord-consortium/question-interactives-helpers/src/utilities/copy-image-to-s3";
 import { Log } from "../labbook-logging";
 import UploadIcon from "../assets/upload-image-icon.svg";
-import classnames from "classnames";
+import classNames from "classnames";
 
 import css from "./upload-button.scss";
 
@@ -61,7 +61,8 @@ export const UploadImage: React.FC<IProps> = ({ onUploadImage, uploadMode, onUpl
     }
   };
 
-  const classes = classnames(css["upload-button"], {[css.disabled]: uploadInProgress||disabled, [css["in-dialog"]]: inDialog});
+  const classes = classNames(css["upload-button"], {[css.disabled]: uploadInProgress||disabled}, {[css.inDialog]: inDialog});
+  const buttonTextClasses = classNames(css["button-text"], {[css.inDialog]: inDialog});
 
   return (
     <>
@@ -71,7 +72,7 @@ export const UploadImage: React.FC<IProps> = ({ onUploadImage, uploadMode, onUpl
         id={text}
       >
         {showUploadIcon && <UploadIcon/>}
-        <div className={css["button-text"]}>
+        <div className={buttonTextClasses}>
           { uploadInProgress
             ? "Please Wait"
             : text


### PR DESCRIPTION
The css that handles text wrapping only works for Chrome.  Added additional styling that wraps text in Safari and Firefox.