### PR TITLE
feat: Authors can customize image question drawing tools [PT-182016906]

### DIFF
--- a/packages/drawing-tool/src/components/app.tsx
+++ b/packages/drawing-tool/src/components/app.tsx
@@ -5,6 +5,7 @@ import { BaseQuestionApp } from "@concord-consortium/question-interactives-helpe
 import { exportToMediaLibraryAuthoringProps } from "@concord-consortium/question-interactives-helpers/src/utilities/media-library";
 import { IAuthoredState, IInteractiveState } from "./types";
 import { FormValidation } from "@rjsf/utils";
+import { HideDrawingToolsWidget, defaultHideDrawingToolWidgetButtons } from "./hide-drawing-tools-widget";
 
 // Note that TS interfaces should match JSON schema. Currently there"s no way to generate one from the other.
 // TS interfaces are not available in runtime in contrast to JSON schema.
@@ -158,6 +159,16 @@ export const baseAuthoringProps = {
         title: "Hint",
         type: "string"
       },
+      hideDrawingTools: {
+        type: "array",
+        title: "Hide Toolbar Buttons",
+        hint: "Check the boxes below to hide draw tool buttons from the toolbar:",
+        items: {
+          type: "string",
+          enum: defaultHideDrawingToolWidgetButtons,
+        },
+        uniqueItems: true,
+      },
       stampCollections: {
         type: "array",
         title: "Stamp collections",
@@ -249,7 +260,7 @@ export const baseAuthoringProps = {
   uiSchema: {
     "ui:order": [
       "prompt", "required", "predictionFeedback", "hint", "backgroundSource", "snapshotTarget", "backgroundImageUrl",
-      "imageFit", "imagePosition",  "stampCollections", "version", "questionType", ...exportToMediaLibrary.uiOrder
+      "imageFit", "imagePosition", "hideDrawingTools", "stampCollections", "version", "questionType", ...exportToMediaLibrary.uiOrder
     ],
     version: {
       "ui:widget": "hidden"
@@ -272,6 +283,9 @@ export const baseAuthoringProps = {
     },
     snapshotTarget: {
       "ui:enumDisabled": []
+    },
+    hideDrawingTools: {
+      "ui:widget": HideDrawingToolsWidget
     },
     ...exportToMediaLibrary.uiSchema
   },

--- a/packages/drawing-tool/src/components/app.tsx
+++ b/packages/drawing-tool/src/components/app.tsx
@@ -3,9 +3,9 @@ import { Runtime } from "./runtime";
 import { RJSFSchema } from "@rjsf/utils";
 import { BaseQuestionApp } from "@concord-consortium/question-interactives-helpers/src/components/base-question-app";
 import { exportToMediaLibraryAuthoringProps } from "@concord-consortium/question-interactives-helpers/src/utilities/media-library";
-import { IAuthoredState, IInteractiveState } from "./types";
+import { IAuthoredState, IInteractiveState, defaultHideableDrawingTools } from "./types";
 import { FormValidation } from "@rjsf/utils";
-import { HideDrawingToolsWidget, defaultHideDrawingToolWidgetButtons } from "./hide-drawing-tools-widget";
+import { HideDrawingToolsWidget } from "./hide-drawing-tools-widget";
 
 // Note that TS interfaces should match JSON schema. Currently there"s no way to generate one from the other.
 // TS interfaces are not available in runtime in contrast to JSON schema.
@@ -165,7 +165,7 @@ export const baseAuthoringProps = {
         hint: "Check the boxes below to hide draw tool buttons from the toolbar:",
         items: {
           type: "string",
-          enum: defaultHideDrawingToolWidgetButtons,
+          enum: defaultHideableDrawingTools,
         },
         uniqueItems: true,
       },

--- a/packages/drawing-tool/src/components/drawing-tool.tsx
+++ b/packages/drawing-tool/src/components/drawing-tool.tsx
@@ -12,6 +12,8 @@ const kToolbarWidth = 40; // Drawing Tool buttons are 40x40
 const kDrawingToolPreferredWidth = 600; // in practice it can be smaller if there's not enough space
 const kDrawingToolHeight = 600;
 
+const kDrawingToolButtons = ["select","free","linesPalette","shapesPalette","text","stamp","strokeColorPalette","fillColorPalette","strokeWidthPalette","clone","sendToBack","sendToFront","undo","redo","trash"];
+
 // Use LARA image proxy to avoid tainting canvas when external image URL is used.
 export const LARA_IMAGE_PROXY = "https://authoring.concord.org/image-proxy?url=";
 
@@ -134,6 +136,13 @@ export const DrawingTool: React.FC<IProps> = ({ authoredState, interactiveState,
         }
       });
 
+      // optionally hide buttons
+      const finalButtons = (buttons ?? kDrawingToolButtons).slice();
+      const hideButtons = authoredState.hideDrawingTools ?? [];
+      hideButtons.forEach(button => {
+        finalButtons.splice(finalButtons.indexOf(button), 1);
+      });
+
       // window.innerWidth should never be used in practice. It's here just to make TypeScript happy
       // and/or handle some unexpected edge case where containerRef is really undefined.
       const availableWidth = containerRef.current?.clientWidth || window.innerWidth;
@@ -142,7 +151,7 @@ export const DrawingTool: React.FC<IProps> = ({ authoredState, interactiveState,
         width: width || Math.min(kDrawingToolPreferredWidth, availableWidth - kToolbarWidth),
         height: height || kDrawingToolHeight,
         canvasScale,
-        buttons,
+        buttons: finalButtons,
         onDrawingChanged,
         wideLayout
       };

--- a/packages/drawing-tool/src/components/hide-drawing-tools-widget.tsx
+++ b/packages/drawing-tool/src/components/hide-drawing-tools-widget.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { WidgetProps } from "@rjsf/utils";
+
+export const hideDrawingToolWidgetButtons = ["free", "linesPalette", "shapesPalette", "annotation", "text", "strokeColorPalette", "fillColorPalette", "strokeWidthPalette", "clone", "sendToBack", "sendToFront"] as const;
+
+// remove the annotation tool, as it is only used in the labbook
+export const defaultHideDrawingToolWidgetButtons = hideDrawingToolWidgetButtons.filter(b => b !== "annotation");
+
+type HideDrawingToolWidgetButton = typeof hideDrawingToolWidgetButtons[number];
+type HideDrawingToolWidgetButtonMap = Record<HideDrawingToolWidgetButton, string>;
+
+const drawingToolWidgetButtonMap: HideDrawingToolWidgetButtonMap = {
+  free: "Free hand drawing tool",
+  linesPalette: "Line tool",
+  shapesPalette: "Basic shape tool",
+  text: "Text tool",
+  strokeColorPalette: "Stroke color",
+  fillColorPalette: "Fill color",
+  strokeWidthPalette: "Stroke Width",
+  clone: "Clone tool",
+  sendToBack: "Send selected objects to back",
+  sendToFront: "Send selected objects to front",
+  annotation: "Annotation tool"
+};
+
+export const HideDrawingToolsWidget = function (props: WidgetProps) {
+  const itemValues = (props.schema.items as any).enum as HideDrawingToolWidgetButton[];
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const {value, checked} = e.target;
+    const values = props.value.slice() as string[];
+    const index = values.indexOf(value);
+    if (checked && (index === -1)) {
+      props.onChange([...values, value]);
+    } else if (!checked && (index !== -1)) {
+      values.splice(index, 1);
+      props.onChange(values);
+    }
+  };
+
+  return (
+    <div className="checkboxes" id="root_drawingTools">
+      <div>{props.schema.hint}</div>
+      {itemValues.map((value, index) => {
+        const checked = props.value.indexOf(value) !== -1;
+        return (
+          <div key={value} className="checkbox">
+            <label>
+              <span>
+                <input type="checkbox" id={`root_drawingTools-${index}`} name="root_drawingTools" value={value} checked={checked} onChange={handleChange} />
+                <span>{drawingToolWidgetButtonMap[value]}</span>
+              </span>
+            </label>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/packages/drawing-tool/src/components/hide-drawing-tools-widget.tsx
+++ b/packages/drawing-tool/src/components/hide-drawing-tools-widget.tsx
@@ -1,15 +1,8 @@
 import React from "react";
 import { WidgetProps } from "@rjsf/utils";
+import { HideableDrawingTools } from "./types";
 
-export const hideDrawingToolWidgetButtons = ["free", "linesPalette", "shapesPalette", "annotation", "text", "strokeColorPalette", "fillColorPalette", "strokeWidthPalette", "clone", "sendToBack", "sendToFront"] as const;
-
-// remove the annotation tool, as it is only used in the labbook
-export const defaultHideDrawingToolWidgetButtons = hideDrawingToolWidgetButtons.filter(b => b !== "annotation");
-
-type HideDrawingToolWidgetButton = typeof hideDrawingToolWidgetButtons[number];
-type HideDrawingToolWidgetButtonMap = Record<HideDrawingToolWidgetButton, string>;
-
-const drawingToolWidgetButtonMap: HideDrawingToolWidgetButtonMap = {
+const hideableDrawingToolLabels: Record<HideableDrawingTools, string> = {
   free: "Free hand drawing tool",
   linesPalette: "Line tool",
   shapesPalette: "Basic shape tool",
@@ -24,7 +17,7 @@ const drawingToolWidgetButtonMap: HideDrawingToolWidgetButtonMap = {
 };
 
 export const HideDrawingToolsWidget = function (props: WidgetProps) {
-  const itemValues = (props.schema.items as any).enum as HideDrawingToolWidgetButton[];
+  const itemValues = (props.schema.items as any).enum as HideableDrawingTools[];
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const {value, checked} = e.target;
@@ -48,7 +41,7 @@ export const HideDrawingToolsWidget = function (props: WidgetProps) {
             <label>
               <span>
                 <input type="checkbox" id={`root_drawingTools-${index}`} name="root_drawingTools" value={value} checked={checked} onChange={handleChange} />
-                <span>{drawingToolWidgetButtonMap[value]}</span>
+                <span>{hideableDrawingToolLabels[value]}</span>
               </span>
             </label>
           </div>

--- a/packages/drawing-tool/src/components/types.ts
+++ b/packages/drawing-tool/src/components/types.ts
@@ -19,6 +19,7 @@ export interface IAuthoredState extends IAuthoringInteractiveMetadata {
   imagePosition?: string;
   stampCollections?: StampCollection[];
   allowUploadFromMediaLibrary?: boolean;
+  hideDrawingTools?: string[];
 }
 
 export interface IInteractiveState extends IRuntimeInteractiveMetadata {
@@ -34,3 +35,10 @@ export type IGenericInteractiveState = Omit<IInteractiveState, "answerType"> & {
 
 export const getAnswerType = (questionType: "image_question" | "iframe_interactive") =>
   questionType === "image_question" ? "image_question_answer" : "interactive_state";
+
+export const DemoAuthoredState: IAuthoredState = {
+  version: 1,
+  questionType: "iframe_interactive",
+  hint: "",
+  predictionFeedback: "",
+};

--- a/packages/drawing-tool/src/components/types.ts
+++ b/packages/drawing-tool/src/components/types.ts
@@ -1,5 +1,12 @@
 import { IAuthoringInteractiveMetadata, IRuntimeInteractiveMetadata } from "@concord-consortium/lara-interactive-api";
 
+export const hideableDrawingTools = ["free", "linesPalette", "shapesPalette", "annotation", "text", "strokeColorPalette", "fillColorPalette", "strokeWidthPalette", "clone", "sendToBack", "sendToFront"] as const;
+
+// remove the annotation tool, as it is only used in the labbook
+export const defaultHideableDrawingTools = hideableDrawingTools.filter(b => b !== "annotation");
+
+export type HideableDrawingTools = typeof hideableDrawingTools[number];
+
 export interface StampCollection {
   collection: "molecules" | "ngsaObjects" | "custom";
   name?: string;
@@ -19,7 +26,7 @@ export interface IAuthoredState extends IAuthoringInteractiveMetadata {
   imagePosition?: string;
   stampCollections?: StampCollection[];
   allowUploadFromMediaLibrary?: boolean;
-  hideDrawingTools?: string[];
+  hideDrawingTools?: HideableDrawingTools[];
 }
 
 export interface IInteractiveState extends IRuntimeInteractiveMetadata {

--- a/packages/drawing-tool/src/demo.tsx
+++ b/packages/drawing-tool/src/demo.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { DemoComponent } from "@concord-consortium/question-interactives-helpers/src/components/demo";
+import { App } from "./components/app";
+import { IAuthoredState, IInteractiveState, DemoAuthoredState } from "./components/types";
+
+const DemoContainer = () => {
+  const interactiveState: IInteractiveState = {
+    answerType: "interactive_state"
+  };
+
+  return (
+    <DemoComponent<IAuthoredState, IInteractiveState>
+      title="Drawing Tool Demo"
+      App={<App />}
+      authoredState={DemoAuthoredState}
+      interactiveState={interactiveState}
+    />
+  );
+};
+
+ReactDOM.render(
+  <DemoContainer />,
+  document.getElementById("app")
+);

--- a/packages/drawing-tool/src/global.d.ts
+++ b/packages/drawing-tool/src/global.d.ts
@@ -2,3 +2,4 @@ declare module "*.scss";
 declare module "*.svg";
 declare module "shutterbug";
 declare module "drawing-tool";
+declare module "iframe-phone";

--- a/packages/drawing-tool/webpack.config.js
+++ b/packages/drawing-tool/webpack.config.js
@@ -11,14 +11,20 @@ module.exports = (env, argv) => {
   return webpackCommon(env, argv, __dirname, {
     // Add custom webpack configuration here
     entry: {
-      [`${interactiveName}`]: './src/index.tsx'
+      [`${interactiveName}`]: './src/index.tsx',
+      [`${interactiveName}/demo`]: './src/demo.tsx'
     },
     plugins: [
       new HtmlWebpackPlugin({
         chunks: [interactiveName],
         filename: `${interactiveName}/index.html`,
         template: '../../shared/index.html'
-      })
+      }),
+      new HtmlWebpackPlugin({
+        chunks: [`${interactiveName}/demo`],
+        filename: `${interactiveName}/demo.html`,
+        template: '../../shared/index.html'
+      }),
     ]
   });
 };

--- a/packages/image-question/src/components/app.tsx
+++ b/packages/image-question/src/components/app.tsx
@@ -35,7 +35,7 @@ const baseAuthoringProps = deepmerge(drawingToolBaseAuthoringProps, {
   uiSchema: {
     "ui:order": [
       "prompt", "required", "predictionFeedback", "hint", "backgroundSource", "snapshotTarget", "backgroundImageUrl",
-      "imageFit", "imagePosition",  "stampCollections", "answerPrompt", "defaultAnswer", "version", "questionType",
+      "imageFit", "imagePosition", "hideDrawingTools", "stampCollections", "answerPrompt", "defaultAnswer", "version", "questionType",
       ...exportToMediaLibrary.uiOrder
     ],
     answerPrompt: {

--- a/packages/labbook/src/components/app.tsx
+++ b/packages/labbook/src/components/app.tsx
@@ -5,6 +5,7 @@ import { Runtime } from "./runtime";
 import { IAuthoredState, IInteractiveState } from "./types";
 import { baseAuthoringProps as drawingToolBaseAuthoringProps, exportToMediaLibrary } from "drawing-tool-interactive/src/components/app";
 import deepmerge from "deepmerge";
+import { migrateAuthoredState } from "./state-migrations";
 
 const baseAuthoringProps = deepmerge(drawingToolBaseAuthoringProps, {
   schema: {
@@ -87,5 +88,6 @@ export const App = () => (
     disableAutoHeight={false}
     isAnswered={isAnswered}
     linkedInteractiveProps={[{ label: "snapshotTarget", supportsSnapshots: true }]}
+    migrateAuthoredState={migrateAuthoredState}
   />
 );

--- a/packages/labbook/src/components/app.tsx
+++ b/packages/labbook/src/components/app.tsx
@@ -6,19 +6,6 @@ import { IAuthoredState, IInteractiveState } from "./types";
 import { baseAuthoringProps as drawingToolBaseAuthoringProps, exportToMediaLibrary } from "drawing-tool-interactive/src/components/app";
 import deepmerge from "deepmerge";
 
-export const ToolbarModificationsWidget = (props: any) => {
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => props.onChange(e.target.checked);
-
-  return (
-    <div className="checkbox">
-      <label>
-        <input type="checkbox" id={props.id} checked={!!props.value} onChange={handleChange} />
-        <span>{props.schema.customLabel}</span>
-      </label>
-    </div>
-  );
-};
-
 const baseAuthoringProps = deepmerge(drawingToolBaseAuthoringProps, {
   schema: {
     properties: {
@@ -42,12 +29,6 @@ const baseAuthoringProps = deepmerge(drawingToolBaseAuthoringProps, {
         title: "Background source",
         type: "string",
         default: "snapshot"
-      },
-      hideAnnotationTool: {
-        title: "Toolbar Modifications",
-        customLabel: "Hide Annotation Tool",
-        type: "boolean",
-        default: false
       }
     }
   } as RJSFSchema,
@@ -65,18 +46,21 @@ const baseAuthoringProps = deepmerge(drawingToolBaseAuthoringProps, {
     questionType: {
       "ui:widget": "hidden"
     },
-    hideAnnotationTool: {
-      "ui:widget": ToolbarModificationsWidget
-    },
   },
   // Just overwrite array, don't merge values.
   arrayMerge: (destinationArray:any, sourceArray:any) => sourceArray
 });
 
+// set the available drawing tools
+const hideDrawingTools = baseAuthoringProps.schema.properties?.hideDrawingTools as any;
+if (hideDrawingTools) {
+  hideDrawingTools.items.enum = ['free', 'shapesPalette', 'annotation'];
+}
+
 // This list combines all the fields from drawing-tool app and custom ones specified by Labbook.
 baseAuthoringProps.uiSchema["ui:order"] = [
   "prompt", "required", "predictionFeedback", "hint", "backgroundSource", "showUploadImageButton", "snapshotTarget",
-  "backgroundImageUrl", "imageFit", "imagePosition", "hideAnnotationTool",  "stampCollections", "maxItems", "showItems", "version", "questionType",
+  "backgroundImageUrl", "imageFit", "imagePosition", "hideDrawingTools", "stampCollections", "maxItems", "showItems", "version", "questionType",
   ...exportToMediaLibrary.uiOrder
 ];
 

--- a/packages/labbook/src/components/runtime.tsx
+++ b/packages/labbook/src/components/runtime.tsx
@@ -274,9 +274,13 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     setImageType(type);
   };
 
-  const drawingToolButtons = ['select', 'free', 'shapesPalette', 'stamp']
-    .concat(hideAnnotationTool ? [] : ['annotation'])
-    .concat('trash');
+  const drawingToolButtons = ['select', 'free', 'shapesPalette', 'stamp', 'annotation', 'trash'];
+
+  // hideAnnotationTool used to be its own option but now should be part of the hidden tools array
+  if (hideAnnotationTool) {
+    authoredState.hideDrawingTools = authoredState.hideDrawingTools ?? [];
+    authoredState.hideDrawingTools.push('annotation');
+  }
 
   const uploadImageMode = (backgroundSource === "upload" || showUploadImageButton);
   const selectedItemHasImageUrl = !!(selectedItem?.data?.userBackgroundImageUrl);

--- a/packages/labbook/src/components/runtime.tsx
+++ b/packages/labbook/src/components/runtime.tsx
@@ -71,7 +71,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     return result;
   };
 
-  const {showUploadImageButton, backgroundSource, allowUploadFromMediaLibrary, hideAnnotationTool } = authoredState;
+  const {showUploadImageButton, backgroundSource, allowUploadFromMediaLibrary } = authoredState;
   const [mediaLibrary, setMediaLibrary] = useState<IMediaLibrary|undefined>(undefined);
 
   const initMessage = useInitMessage();
@@ -275,12 +275,6 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   };
 
   const drawingToolButtons = ['select', 'free', 'shapesPalette', 'stamp', 'annotation', 'trash'];
-
-  // hideAnnotationTool used to be its own option but now should be part of the hidden tools array
-  if (hideAnnotationTool) {
-    authoredState.hideDrawingTools = authoredState.hideDrawingTools ?? [];
-    authoredState.hideDrawingTools.push('annotation');
-  }
 
   const uploadImageMode = (backgroundSource === "upload" || showUploadImageButton);
   const selectedItemHasImageUrl = !!(selectedItem?.data?.userBackgroundImageUrl);

--- a/packages/labbook/src/components/state-migrations.test.ts
+++ b/packages/labbook/src/components/state-migrations.test.ts
@@ -1,0 +1,56 @@
+import { migrateAuthoredState } from "./state-migrations";
+import { IAuthoredState, IAuthoredStateV1 } from "./types";
+import deepmerge from "deepmerge";
+
+describe("authored state migration", () => {
+  it("leave the current version unaffected", () => {
+    const state: IAuthoredState = {
+      version: 2,
+      questionType: "iframe_interactive",
+      maxItems: 10,
+      showItems: 3,
+      showUploadImageButton: false,
+    };
+    const stateCopy = deepmerge({}, state);
+    expect(migrateAuthoredState(state)).toEqual(stateCopy);
+  });
+
+  it("should convert hideAnnotationTool when true", () => {
+    const stateV1: IAuthoredStateV1 = {
+      version: 1,
+      questionType: "iframe_interactive",
+      maxItems: 10,
+      showItems: 3,
+      showUploadImageButton: false,
+      hideAnnotationTool: true,
+    };
+    const stateV2: IAuthoredState = {
+      version: 2,
+      questionType: "iframe_interactive",
+      maxItems: 10,
+      showItems: 3,
+      showUploadImageButton: false,
+      hideDrawingTools: ["annotation"],
+    };
+    expect(migrateAuthoredState(stateV1)).toEqual(stateV2);
+  });
+
+  it("should convert hideAnnotationTool when false", () => {
+    const stateV1: IAuthoredStateV1 = {
+      version: 1,
+      questionType: "iframe_interactive",
+      maxItems: 10,
+      showItems: 3,
+      showUploadImageButton: false,
+      hideAnnotationTool: false,
+    };
+    const stateV2: IAuthoredState = {
+      version: 2,
+      questionType: "iframe_interactive",
+      maxItems: 10,
+      showItems: 3,
+      showUploadImageButton: false
+    };
+    expect(migrateAuthoredState(stateV1)).toEqual(stateV2);
+  });
+});

--- a/packages/labbook/src/components/state-migrations.ts
+++ b/packages/labbook/src/components/state-migrations.ts
@@ -1,0 +1,18 @@
+import { IAuthoredState, IAuthoredStateV1 } from "./types";
+
+export const migrateAuthoredState = (authoredState: IAuthoredStateV1 | IAuthoredState) => {
+
+  if (authoredState.version === 1) {
+    // add hide annotation setting to drawing tools to hide
+    const {hideAnnotationTool} = authoredState;
+    delete (authoredState as any).hideAnnotationTool;
+    const newState: IAuthoredState = {...authoredState, version: 2};
+    if (hideAnnotationTool) {
+      newState.hideDrawingTools = newState.hideDrawingTools ?? [];
+      newState.hideDrawingTools.push("annotation");
+    }
+    return newState;
+  }
+
+  return authoredState;
+};

--- a/packages/labbook/src/components/state-migrations.ts
+++ b/packages/labbook/src/components/state-migrations.ts
@@ -9,7 +9,9 @@ export const migrateAuthoredState = (authoredState: IAuthoredStateV1 | IAuthored
     const newState: IAuthoredState = {...authoredState, version: 2};
     if (hideAnnotationTool) {
       newState.hideDrawingTools = newState.hideDrawingTools ?? [];
-      newState.hideDrawingTools.push("annotation");
+      if (newState.hideDrawingTools.indexOf("annotation") === -1) {
+        newState.hideDrawingTools.push("annotation");
+      }
     }
     return newState;
   }

--- a/packages/labbook/src/components/types.ts
+++ b/packages/labbook/src/components/types.ts
@@ -7,6 +7,17 @@ import {
 } from "@concord-consortium/lara-interactive-api";
 
 export interface IAuthoredState extends IDrawingToolAuthoredState {
+  version: 2;
+  // IAuthoringLabbookMetadata adds:
+  answerPrompt?: string;
+  maxItems: number;
+  showItems: number;
+  showUploadImageButton: boolean;
+  // hideAnnotationTool: boolean; <-- removed in version 2
+}
+
+export interface IAuthoredStateV1 extends IDrawingToolAuthoredState {
+  version: 1;
   // IAuthoringLabbookMetadata adds:
   answerPrompt?: string;
   maxItems: number;
@@ -32,7 +43,7 @@ export interface IBaseInteractiveState extends IRuntimeInteractiveMetadata {
 export type IInteractiveState = IBaseInteractiveState;
 
 export const DemoAuthoredState: IAuthoredState = {
-  version: 1,
+  version: 2,
   questionType: "iframe_interactive",
   hint: "",
   predictionFeedback: "",
@@ -40,5 +51,4 @@ export const DemoAuthoredState: IAuthoredState = {
   showItems: 4,
   showUploadImageButton: false,
   backgroundSource: "upload",
-  hideAnnotationTool: false,
 };


### PR DESCRIPTION
This adds a list of checkboxes that can be used to hide drawing tools.

These checkboxes are showing in the drawing tool, the lab book and the image question.

The hide annotation tool option in the labbook has been removed and added to this new control.

This also adds a demo to the drawing tool for ease of development.

Screenshot:
---

![image](https://github.com/concord-consortium/question-interactives/assets/112938/39f8ba51-c970-4e50-9663-abec2ae4bf58)
