### PR TITLE
fix: delete of hideAnnotationTool in labbook authoredState

### DIFF
--- a/packages/labbook/src/components/state-migrations.ts
+++ b/packages/labbook/src/components/state-migrations.ts
@@ -5,7 +5,9 @@ export const migrateAuthoredState = (authoredState: IAuthoredStateV1 | IAuthored
   if (authoredState.version === 1) {
     // add hide annotation setting to drawing tools to hide
     const {hideAnnotationTool} = authoredState;
-    delete (authoredState as any).hideAnnotationTool;
+    if (hideAnnotationTool !== undefined) {
+      delete (authoredState as any).hideAnnotationTool;
+    }
     const newState: IAuthoredState = {...authoredState, version: 2};
     if (hideAnnotationTool) {
       newState.hideDrawingTools = newState.hideDrawingTools ?? [];


### PR DESCRIPTION
Adds conditional to ensure the property exists before it is deleted to prevent an error from being thrown.