### PR TITLE
feat: Updated drawing-tool dependency to 2.3.0 [PT-182016906]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12139,9 +12139,9 @@
       "link": true
     },
     "node_modules/drawing-tool": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/drawing-tool/-/drawing-tool-2.2.1.tgz",
-      "integrity": "sha512-ANh+mw0/8vOJNjqe6+PqMnyC9YbP36obppr8MuowV96iF8JQfVyW8iH+tkxRWvWg/c5dwIhxxvlkIBxFribQBg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/drawing-tool/-/drawing-tool-2.3.0.tgz",
+      "integrity": "sha512-1uMjLGoECytQ9LpH9kVJixW5FMP39rdY3ByNjcWt+eqPeIxSTpAzCpuijero7ptzPSK+n66Ojqw/XlMw/Y3Ijw==",
       "dependencies": {
         "eventemitter2": "~0.4.14",
         "fabric": "3.6.3",
@@ -29834,7 +29834,7 @@
         "@concord-consortium/text-decorator": "^1.0.2",
         "@rjsf/utils": "^5.0.1",
         "classnames": "^2.3.1",
-        "drawing-tool": "^2.2.1",
+        "drawing-tool": "^2.3.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "uuid": "^8.3.0"
@@ -40469,9 +40469,9 @@
       }
     },
     "drawing-tool": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/drawing-tool/-/drawing-tool-2.2.1.tgz",
-      "integrity": "sha512-ANh+mw0/8vOJNjqe6+PqMnyC9YbP36obppr8MuowV96iF8JQfVyW8iH+tkxRWvWg/c5dwIhxxvlkIBxFribQBg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/drawing-tool/-/drawing-tool-2.3.0.tgz",
+      "integrity": "sha512-1uMjLGoECytQ9LpH9kVJixW5FMP39rdY3ByNjcWt+eqPeIxSTpAzCpuijero7ptzPSK+n66Ojqw/XlMw/Y3Ijw==",
       "requires": {
         "eventemitter2": "~0.4.14",
         "fabric": "3.6.3",
@@ -40528,7 +40528,7 @@
         "autoprefixer": "^9.8.8",
         "classnames": "^2.3.1",
         "css-loader": "^4.3.0",
-        "drawing-tool": "^2.2.1",
+        "drawing-tool": "^2.3.0",
         "enzyme": "^3.11.0",
         "eslint": "^8.29.0",
         "eslint-plugin-eslint-comments": "^3.2.0",

--- a/packages/drawing-tool/package.json
+++ b/packages/drawing-tool/package.json
@@ -112,7 +112,7 @@
     "@concord-consortium/text-decorator": "^1.0.2",
     "@rjsf/utils": "^5.0.1",
     "classnames": "^2.3.1",
-    "drawing-tool": "^2.2.1",
+    "drawing-tool": "^2.3.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "uuid": "^8.3.0"


### PR DESCRIPTION
This brings in the fix to show the text, stroke color, stroke width and fill color palettes when buttons are hidden.