### PR TITLE
build: Update drawing-tool dependency to 2.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12157,9 +12157,9 @@
       "link": true
     },
     "node_modules/drawing-tool": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/drawing-tool/-/drawing-tool-2.3.1.tgz",
-      "integrity": "sha512-cdeBuuvpo0xLiJVYOuQDUrvokcI6MhXvbQnDT1NBKtbDzCri5UCBnjOvTXepFyjF1vqHaXj2ttLG2GNB74ZCOg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/drawing-tool/-/drawing-tool-2.3.2.tgz",
+      "integrity": "sha512-SElU+v8iE8Vxph8gcZIXPYBNpgCAF9BdTpKsAkswooeoyK5OLkACVrfaD7EPZTqlu2qcmWc9X10YstDfskqitA==",
       "dependencies": {
         "eventemitter2": "~0.4.14",
         "fabric": "3.6.3",
@@ -29852,7 +29852,7 @@
         "@concord-consortium/text-decorator": "^1.0.2",
         "@rjsf/utils": "^5.0.1",
         "classnames": "^2.3.1",
-        "drawing-tool": "^2.3.1",
+        "drawing-tool": "^2.3.2",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "uuid": "^8.3.0"
@@ -40499,9 +40499,9 @@
       }
     },
     "drawing-tool": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/drawing-tool/-/drawing-tool-2.3.1.tgz",
-      "integrity": "sha512-cdeBuuvpo0xLiJVYOuQDUrvokcI6MhXvbQnDT1NBKtbDzCri5UCBnjOvTXepFyjF1vqHaXj2ttLG2GNB74ZCOg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/drawing-tool/-/drawing-tool-2.3.2.tgz",
+      "integrity": "sha512-SElU+v8iE8Vxph8gcZIXPYBNpgCAF9BdTpKsAkswooeoyK5OLkACVrfaD7EPZTqlu2qcmWc9X10YstDfskqitA==",
       "requires": {
         "eventemitter2": "~0.4.14",
         "fabric": "3.6.3",
@@ -40558,7 +40558,7 @@
         "autoprefixer": "^9.8.8",
         "classnames": "^2.3.1",
         "css-loader": "^4.3.0",
-        "drawing-tool": "^2.3.1",
+        "drawing-tool": "^2.3.2",
         "enzyme": "^3.11.0",
         "eslint": "^8.29.0",
         "eslint-plugin-eslint-comments": "^3.2.0",

--- a/packages/drawing-tool/package.json
+++ b/packages/drawing-tool/package.json
@@ -112,7 +112,7 @@
     "@concord-consortium/text-decorator": "^1.0.2",
     "@rjsf/utils": "^5.0.1",
     "classnames": "^2.3.1",
-    "drawing-tool": "^2.3.1",
+    "drawing-tool": "^2.3.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "uuid": "^8.3.0"


### PR DESCRIPTION
The 2.3.2 version adds support for deleting annotations via the keyboard.