### PR TITLE
fix(ImageQuestion/DrawingTool): set answerImageUrl after snapshot is taken

### DIFF
--- a/packages/drawing-tool/src/components/upload-background.tsx
+++ b/packages/drawing-tool/src/components/upload-background.tsx
@@ -43,6 +43,7 @@ export const UploadBackground: React.FC<IProps> = ({ authoredState, setInteracti
         setInteractiveState?.(prevState => ({
           ...prevState,
           userBackgroundImageUrl: url,
+          answerImageUrl: url, // necessary metadata for ImageQuestion
           answerType: getAnswerType(authoredState.questionType)
         }));
         onUploadComplete?.({ success: true });

--- a/packages/image-question/src/components/runtime.tsx
+++ b/packages/image-question/src/components/runtime.tsx
@@ -79,6 +79,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     setInteractiveState?.(prevState => ({
       ...prevState,
       userBackgroundImageUrl: url,
+      answerImageUrl: url, // necessary metadata for ImageQuestion
       answerType: "image_question_answer"
     }));
   };


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187929118
https://www.pivotaltracker.com/story/show/187929269

This PR fixes two `setInteractiveState` calls that were not setting `answerImageUrl`. This was causing the Activity Player code:
https://github.com/concord-consortium/activity-player/blob/master/src/utilities/embeddable-utils.ts#L139-L146
to set `answer: {text: undefined, image_url: undefined}`. Since Firestore doesn't save empty documents like that, we ended up with no `answer` field in the docs.

It fixes the linked bugs. We didn't see this issue in other cases because once the user clicked "Done" in the drawing tool dialog, the state was updated in a different way, and `answerImageUrl` was provided.


This PR also fixed the sharing scenario:
https://www.pivotaltracker.com/story/show/187929236

When a user initially shares an empty answer, it’s all fine. However, what was crashing the report was the fact that after uploading an image and leaving the page (as described in the scenario above), the answer type was already updated to "image_question_answer." Yet, the generic content of the `answer` field was not getting updated due to the exact same reason as described above (`answer: {text: undefined, image_url: undefined}` was not updating in Firestore). And the report code was assuming that it deals with image question answer, but it was receiving generic "answer" response, not matching the expected format.
