### PR TITLE
ImageQuestion: fix Cancel button behavior

### DIFF
--- a/packages/image-question/src/components/runtime.tsx
+++ b/packages/image-question/src/components/runtime.tsx
@@ -84,15 +84,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     }));
   };
 
-  const handleCancel = () => {
-    setInteractiveState?.((prevState: IInteractiveState) => ({
-      ...prevState,
-      userBackgroundImageUrl: undefined,
-      answerType: "image_question_answer"
-    }));
-    closeModal({});
-    return;
-  };
+  const handleCancel = () => closeModal({});
 
   const handleClose = () => {
     if (!drawingStateUpdated) {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187941022

Setting `userBackgroundImageUrl: undefined` made sense when the dialog was opened right after upload, but it didn't make much sense in other cases, e.g., when the dialog was opened multiple times and "Cancel" was not related to the upload action.
