### PR TITLE
fix: Image question answers with no answer text save failing [PT-188258961]

### DIFF
--- a/packages/image-question/src/components/runtime.tsx
+++ b/packages/image-question/src/components/runtime.tsx
@@ -85,8 +85,8 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     if (newAnswerText !== undefined || newDrawingState !== undefined) {
       setInteractiveState?.((prevState: IInteractiveState) => ({
         ...prevState,
-        answerText: newAnswerText !== undefined ? newAnswerText : prevState.answerText,
-        drawingState: newDrawingState !== undefined ? newDrawingState : prevState.drawingState,
+        answerText: newAnswerText !== undefined ? newAnswerText : prevState?.answerText,
+        drawingState: newDrawingState !== undefined ? newDrawingState : prevState?.drawingState,
         answerType: "image_question_answer"
       }));
     }


### PR DESCRIPTION
On questions with no previous answers the previous state is undefined with cases the setInteractiveState handler to fail.  The fix is to add a optional chaining operator.