### PR TITLE
fix: Hide submit button when draw tool dialog showing [PT-188398397]

### DIFF
--- a/packages/image-question/src/components/app.tsx
+++ b/packages/image-question/src/components/app.tsx
@@ -5,6 +5,7 @@ import { Runtime } from "./runtime";
 import { IAuthoredState, IInteractiveState } from "./types";
 import { baseAuthoringProps as drawingToolBaseAuthoringProps, exportToMediaLibrary } from "drawing-tool-interactive/src/components/app";
 import deepmerge from "deepmerge";
+import { hasDrawingToolDialogUrlParam } from "../utils/url-param";
 
 const baseAuthoringProps = deepmerge(drawingToolBaseAuthoringProps, {
   schema: {
@@ -64,5 +65,6 @@ export const App = () => (
     baseAuthoringProps={baseAuthoringProps}
     isAnswered={isAnswered}
     linkedInteractiveProps={[{ label: "snapshotTarget", supportsSnapshots: true }]}
+    disableSubmitBtnRendering={hasDrawingToolDialogUrlParam()}
   />
 );

--- a/packages/image-question/src/components/runtime.tsx
+++ b/packages/image-question/src/components/runtime.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { IRuntimeQuestionComponentProps } from "@concord-consortium/question-interactives-helpers/src/components/base-question-app";
 import { IMediaLibrary, closeModal, showModal, useInitMessage } from "@concord-consortium/lara-interactive-api";
-import { getURLParam } from "@concord-consortium/question-interactives-helpers/src/utilities/get-url-param";
 import { drawingToolCanvasSelector } from "drawing-tool-interactive/src/components/drawing-tool";
 import { UpdateFunc } from "@concord-consortium/question-interactives-helpers/src/components/base-app";
 import Shutterbug from "shutterbug";
@@ -10,10 +9,9 @@ import { UploadFromMediaLibraryDialog } from "../../../helpers/src/components/me
 import { DrawingToolDialog } from "./drawing-tool-dialog";
 import { InlineContent } from "./inline-content";
 import { IAuthoredState, IInteractiveState } from "./types";
+import { hasDrawingToolDialogUrlParam, urlWithDrawingToolDialogUrlParam } from "../utils/url-param";
 
 interface IProps extends IRuntimeQuestionComponentProps<IAuthoredState, IInteractiveState> {}
-
-const drawingToolDialogUrlParam = "drawingToolDialog";
 
 export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, report }) => {
   const {required, backgroundSource, backgroundImageUrl, allowUploadFromMediaLibrary} = authoredState;
@@ -33,7 +31,6 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     }
   }, [initMessage]);
 
-  const drawingToolDialog = getURLParam(drawingToolDialogUrlParam);
   const authoredBgCorsError = useCorsImageErrorCheck({
     performTest: backgroundSource === "url" && !!backgroundImageUrl,
     imgSrc: backgroundImageUrl
@@ -50,9 +47,8 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   const openDrawingToolDialog = () => {
     // notCloseable: true disabled click-to-close backdrop and X icon in the corner.
     // Dialog can be closed only via closeModal API.
-    const url = new URL(window.location.href);
-    url.searchParams.append(drawingToolDialogUrlParam, "true");
-    showModal({ type: "dialog", url: url.toString(), notCloseable: true });
+    const url = urlWithDrawingToolDialogUrlParam();
+    showModal({ type: "dialog", url, notCloseable: true });
   };
 
   const handleDrawingToolSetIntState = (updateFunc: UpdateFunc<IInteractiveState>) => {
@@ -135,7 +131,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
             handleCloseModal={() => setShowUploadModal(false)}
           />
         </> :
-        drawingToolDialog ?
+        hasDrawingToolDialogUrlParam() ?
           <DrawingToolDialog
             authoredState={authoredState}
             interactiveState={interactiveState}

--- a/packages/image-question/src/utils/url-param.ts
+++ b/packages/image-question/src/utils/url-param.ts
@@ -1,0 +1,12 @@
+import { getURLParam } from "@concord-consortium/question-interactives-helpers/src/utilities/get-url-param";
+
+const drawingToolDialogUrlParam = "drawingToolDialog";
+
+export const hasDrawingToolDialogUrlParam = () => !!getURLParam(drawingToolDialogUrlParam);
+
+export const urlWithDrawingToolDialogUrlParam = () => {
+  const url = new URL(window.location.href);
+  url.searchParams.append(drawingToolDialogUrlParam, "true");
+  return url.toString();
+};
+


### PR DESCRIPTION
The submit button, rendered in the BaseQuestionApp component, was showing at the bottom of the draw tool dialog in the image question app.

This fix centralizes the url param code that is used to construct the url show in the drawing tool dialog and then sets the existing (optional) disableSubmitBtnRendering prop to the BaseQuestionApp to hide the submit button when the current url has the drawingToolDialog url param present.

This can be tested using the built branch with this activity that has both the branch and the master branch image questions:

https://activity-player.concord.org/branch/master/?activity=https%3A%2F%2Fauthoring.lara.staging.concord.org%2Fapi%2Fv1%2Factivities%2F1187.json&author-preview=true