### PR TITLE
fix: Drawing Tool question is cropped in Dashboard (CLASSDASH-77)

### DIFF
--- a/packages/drawing-tool/package.json
+++ b/packages/drawing-tool/package.json
@@ -95,6 +95,7 @@
     "sass": "^1.56.2",
     "sass-loader": "^10.4.1",
     "script-loader": "^0.7.2",
+    "semver": "^7.3.8",
     "style-loader": "^1.3.0",
     "ts-jest": "^26.5.6",
     "ts-loader": "^8.3.0",

--- a/packages/drawing-tool/src/components/report-item/app.test.tsx
+++ b/packages/drawing-tool/src/components/report-item/app.test.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { act, render } from "@testing-library/react";
+import { useInitMessage, useReportItem, useAutoSetHeight } from "@concord-consortium/lara-interactive-api";
+import { AppComponent } from "./app";
+import { IAuthoredState, IInteractiveState } from "../types";
+import { reportItemHandler } from "./report-item";
+
+jest.mock("@concord-consortium/lara-interactive-api", () => ({
+  useInitMessage: jest.fn(),
+  useAutoSetHeight: jest.fn(),
+  useReportItem: jest.fn()
+}));
+
+const useInitMessageMock = useInitMessage as jest.Mock;
+const useAutoSetHeightMock = useAutoSetHeight as jest.Mock;
+const useReportItemMock = useReportItem as jest.Mock;
+
+const authoredState = {
+  version: 1,
+  questionType: "iframe_interactive",
+  prompt: "Test prompt",
+  hint: "hint",
+  required: false,
+  defaultAnswer: ""
+} as IAuthoredState;
+
+const interactiveState = {
+  answerType: "interactive_state",
+  answerText: "Test answer",
+} as IInteractiveState;
+
+describe.only("Drawing Tool question report item", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders a 'Loading...' message if initMessage is not yet defined", async () => {
+    useInitMessageMock.mockReturnValue(undefined);
+    const { container } = render(<AppComponent />);
+    expect(container).toBeDefined();
+    await act(async () => {
+      expect(container.innerHTML).toEqual(expect.stringContaining("Loading..."));
+    });
+  });
+
+  it("renders an error message if mode is not reportItem", async () => {
+    useInitMessageMock.mockReturnValue({
+      version: 1,
+      mode: "authoring",
+      authoredState
+    });
+
+    const { container } = render(<AppComponent />);
+    expect(container).toBeDefined();
+    await act(async () => {
+      expect(container.innerHTML).toContain("This interactive is only available in 'reportItem' mode but 'authoring' was given.");
+    });
+  });
+
+  it("calls useReportItem with correct arguments", () => {
+    render(<AppComponent />);
+    expect(useReportItemMock).toHaveBeenCalledWith({
+      metadata: {
+        compactAnswerReportItemsAvailable: true
+      },
+      handler: reportItemHandler
+    });
+  });
+
+  it("calls useAutoSetHeight", () => {
+    render(<AppComponent />);
+    expect(useAutoSetHeightMock).toHaveBeenCalled();
+  });
+
+  it("renders nothing if initMessage is set and mode is reportItem", async () => {
+    useInitMessageMock.mockReturnValue({
+      version: 1,
+      mode: "reportItem",
+      authoredState,
+      interactiveState
+    });
+
+    const { container } = render(<AppComponent />);
+    expect(container).toBeDefined();
+    await act(async () => {
+      expect(container.innerHTML).toEqual("");
+    });
+  });
+
+  it("renders nothing if initMessage is set with reportItem mode but no interactiveState", async () => {
+    useInitMessageMock.mockReturnValue({
+      version: 1,
+      mode: "reportItem",
+      authoredState
+    });
+
+    const { container } = render(<AppComponent />);
+    expect(container).toBeDefined();
+    await act(async () => {
+      expect(container.innerHTML).toEqual("");
+    });
+  });
+});

--- a/packages/drawing-tool/src/components/report-item/app.tsx
+++ b/packages/drawing-tool/src/components/report-item/app.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { useInitMessage, useAutoSetHeight, IReportItemInitInteractive, useReportItem } from "@concord-consortium/lara-interactive-api";
+import { reportItemHandler } from "./report-item";
+import { IAuthoredState, IInteractiveState } from "../types";
+
+interface Props {}
+
+export const AppComponent: React.FC<Props> = (props) => {
+  const initMessage = useInitMessage<IReportItemInitInteractive<Record<string, unknown>, Record<string, unknown>>, Record<string, unknown>>();
+
+  useAutoSetHeight();
+
+  useReportItem<IInteractiveState, IAuthoredState>({
+    metadata: {
+      compactAnswerReportItemsAvailable: true
+    },
+    handler: reportItemHandler
+  });
+
+  if (!initMessage) {
+    return (
+      <div className="centered">
+        <div className="progress">
+          Loading...
+        </div>
+      </div>
+    );
+  }
+
+  if (initMessage.mode !== "reportItem") {
+    return (
+      <div>
+        <h1>Oops!</h1>
+        <p>
+        ¯\_(ツ)_/¯
+        </p>
+        <p>
+          This interactive is only available in &apos;reportItem&apos; mode but &apos;{initMessage.mode}&apos; was given.
+        </p>
+      </div>
+    );
+  }
+
+  return null;
+};

--- a/packages/drawing-tool/src/components/report-item/get-report-item-html.test.tsx
+++ b/packages/drawing-tool/src/components/report-item/get-report-item-html.test.tsx
@@ -1,0 +1,49 @@
+import { getReportItemHtml } from "./get-report-item-html";
+import { IAuthoredState, IInteractiveState } from "../types";
+
+describe("getReportItemHtml", () => {
+  const authoredState = {
+    version: 1,
+    questionType: "iframe_interactive",
+    prompt: "Test prompt",
+    hint: "hint",
+    required: false,
+    defaultAnswer: ""
+  } as IAuthoredState;
+
+  const interactiveState = {
+    answerType: "interactive_state",
+    answerText: "Test answer",
+    drawingState: JSON.stringify({
+      dt: { width: 600, height: 600 },
+      canvas: {
+        objects: [],
+        background: "#ffffff"
+      }
+    })
+  } as IInteractiveState;
+
+  it("returns empty string when there is no drawingState", () => {
+    const stateWithoutDrawing = { ...interactiveState, drawingState: undefined };
+    const result = getReportItemHtml({ interactiveState: stateWithoutDrawing, authoredState });
+    expect(result).toBe("");
+  });
+
+  it("returns the correct HTML structure with both tall and wide views", () => {
+    const result = getReportItemHtml({ interactiveState, authoredState });
+    expect(result).toContain("<style>");
+    expect(result).toContain("</style>");
+    expect(result).toContain(".tall {");
+    expect(result).toContain(".wide {");
+    expect(result).toContain('<div class="tall">');
+    expect(result).toContain('<div class="wide">');
+  });
+
+  it("includes the StaticDrawing component in both views", () => {
+    const result = getReportItemHtml({ interactiveState, authoredState });
+    expect(result).toContain("<svg");
+    expect(result).toContain("</svg>");
+    expect(result).toContain('viewBox="0 0 600 600"');
+    expect(result).toContain("background:#ffffff");
+  });
+});

--- a/packages/drawing-tool/src/components/report-item/get-report-item-html.tsx
+++ b/packages/drawing-tool/src/components/report-item/get-report-item-html.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { IAuthoredState, IInteractiveState } from "../types";
+import { StaticDrawing } from "./static-drawing";
+
+export const getReportItemHtml = ({ interactiveState }: { interactiveState: IInteractiveState; authoredState: IAuthoredState; }) => {
+  if (!interactiveState.drawingState) return "";
+
+  const staticMarkup = renderToStaticMarkup(
+    <StaticDrawing drawingState={interactiveState.drawingState} />
+  );
+
+  return `
+    <style>
+      .tall {
+        max-width: 378px;
+      }
+      .wide {
+        max-width: 100px;
+      }
+    </style>
+    <div class="tall">
+      ${staticMarkup}
+    </div>
+    <div class="wide">
+      ${staticMarkup}
+    </div>
+  `;
+};

--- a/packages/drawing-tool/src/components/report-item/render-utils.test.tsx
+++ b/packages/drawing-tool/src/components/report-item/render-utils.test.tsx
@@ -1,0 +1,169 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { fabricPathToSvg, renderObject } from "./render-utils";
+import type { FabricObject } from "./types";
+
+describe("fabricPathToSvg", () => {
+  it("should convert a fabric path to an SVG path string", () => {
+    const fabricPath = [
+      ["M", 10, 10],
+      ["L", 20, 20]
+    ];
+    const svgPath = fabricPathToSvg(fabricPath);
+    expect(svgPath).toBe("M 10 10 L 20 20");
+  });
+
+  it("should handle empty paths", () => {
+    expect(fabricPathToSvg([])).toBe("");
+    expect(fabricPathToSvg([[]])).toBe("");
+  });
+});
+
+describe("renderObject", () => {
+  it("should render an ellipse", () => {
+    const obj: FabricObject = {
+      type: "ellipse",
+      left: 100,
+      top: 100,
+      rx: 50,
+      ry: 30,
+      fill: "red",
+      stroke: "black",
+      strokeWidth: 2,
+      opacity: 0.8
+    };
+    const { container } = render(<>{renderObject(obj, 0)}</>);
+    const ellipse = container.querySelector("ellipse");
+    expect(ellipse).toHaveAttribute("cx", "100");
+    expect(ellipse).toHaveAttribute("cy", "100");
+    expect(ellipse).toHaveAttribute("rx", "50");
+    expect(ellipse).toHaveAttribute("ry", "30");
+    expect(ellipse).toHaveAttribute("fill", "red");
+    expect(ellipse).toHaveAttribute("stroke", "black");
+    expect(ellipse).toHaveAttribute("stroke-width", "2");
+    expect(ellipse).toHaveAttribute("opacity", "0.8");
+  });
+
+  it("should render text", () => {
+    const obj: FabricObject = {
+      type: "i-text",
+      left: 100,
+      top: 100,
+      text: "Hello",
+      fontSize: 16,
+      fontFamily: "Arial",
+      fontWeight: "bold",
+      fill: "blue"
+    };
+    const { container } = render(<>{renderObject(obj, 0)}</>);
+    const text = container.querySelector("text");
+    expect(text).toHaveAttribute("x", "100");
+    expect(text).toHaveAttribute("y", "116"); // top + fontSize
+    expect(text).toHaveAttribute("font-family", "Arial");
+    expect(text).toHaveAttribute("font-size", "16");
+    expect(text).toHaveAttribute("font-weight", "bold");
+    expect(text).toHaveAttribute("fill", "blue");
+    expect(text).toHaveTextContent("Hello");
+  });
+
+  it("should render a line", () => {
+    const obj: FabricObject = {
+      type: "line",
+      left: 100,
+      top: 100,
+      x1: 0,
+      y1: 0,
+      x2: 50,
+      y2: 50,
+      stroke: "black",
+      strokeWidth: 2,
+      opacity: 0.8
+    };
+    const { container } = render(<>{renderObject(obj, 0)}</>);
+    const line = container.querySelector("line");
+    expect(line).toHaveAttribute("x1", "100");
+    expect(line).toHaveAttribute("y1", "100");
+    expect(line).toHaveAttribute("x2", "150");
+    expect(line).toHaveAttribute("y2", "150");
+    expect(line).toHaveAttribute("stroke", "black");
+    expect(line).toHaveAttribute("stroke-width", "2");
+    expect(line).toHaveAttribute("opacity", "0.8");
+  });
+
+  it("should render a path", () => {
+    const obj: FabricObject = {
+      type: "path",
+      left: 100,
+      top: 100,
+      path: [["M", 10, 10, "L", 20, 20]],
+      fill: "red",
+      stroke: "black",
+      strokeWidth: 2,
+      opacity: 0.8
+    };
+    const { container } = render(<>{renderObject(obj, 0)}</>);
+    const path = container.querySelector("path");
+    expect(path).toHaveAttribute("d", "M 10 10 L 20 20");
+    expect(path).toHaveAttribute("fill", "red");
+    expect(path).toHaveAttribute("stroke", "black");
+    expect(path).toHaveAttribute("stroke-width", "2");
+    expect(path).toHaveAttribute("opacity", "0.8");
+  });
+
+  it("should render a rectangle with center origin", () => {
+    const obj: FabricObject = {
+      type: "rect",
+      left: 100,
+      top: 100,
+      width: 50,
+      height: 30,
+      originX: "center",
+      originY: "center",
+      fill: "red",
+      stroke: "black",
+      strokeWidth: 2,
+      opacity: 0.8
+    };
+    const { container } = render(<>{renderObject(obj, 0)}</>);
+    const rect = container.querySelector("rect");
+    expect(rect).toHaveAttribute("x", "75"); // left - width/2
+    expect(rect).toHaveAttribute("y", "85"); // top - height/2
+    expect(rect).toHaveAttribute("width", "50");
+    expect(rect).toHaveAttribute("height", "30");
+    expect(rect).toHaveAttribute("fill", "red");
+    expect(rect).toHaveAttribute("stroke", "black");
+    expect(rect).toHaveAttribute("stroke-width", "2");
+    expect(rect).toHaveAttribute("opacity", "0.8");
+  });
+
+  it("should render a rectangle with left/top origin", () => {
+    const obj: FabricObject = {
+      type: "rect",
+      left: 100,
+      top: 100,
+      width: 50,
+      height: 30,
+      originX: "left",
+      originY: "top",
+      fill: "red",
+      stroke: "black",
+      strokeWidth: 2,
+      opacity: 0.8
+    };
+    const { container } = render(<>{renderObject(obj, 0)}</>);
+    const rect = container.querySelector("rect");
+    expect(rect).toHaveAttribute("x", "100");
+    expect(rect).toHaveAttribute("y", "100");
+    expect(rect).toHaveAttribute("width", "50");
+    expect(rect).toHaveAttribute("height", "30");
+  });
+
+  it("should return null for unknown object types", () => {
+    const obj = { 
+      type: "unknown",
+      left: 0,
+      top: 0
+    } as unknown as FabricObject;
+    expect(renderObject(obj, 0)).toBeNull();
+  });
+});

--- a/packages/drawing-tool/src/components/report-item/render-utils.tsx
+++ b/packages/drawing-tool/src/components/report-item/render-utils.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import type { FabricObject } from "./types";
+
+export const fabricPathToSvg = (path: (string | number)[][]): string => {
+  if (path.length === 0) return "";
+  const segments = path.map(([cmd, ...coords]) => cmd ? `${cmd} ${coords.join(" ")}` : "").filter(Boolean);
+  return segments.join(" ").trim();
+};
+
+export const renderObject = (obj: FabricObject, i: number): JSX.Element | null => {
+  switch (obj.type) {
+    case "ellipse":
+      return (
+        <ellipse
+          key={i}
+          fill={obj.fill || "none"}
+          cx={obj.left}
+          cy={obj.top}
+          opacity={obj.opacity}
+          rx={obj.rx}
+          ry={obj.ry}
+          stroke={obj.stroke}
+          strokeWidth={obj.strokeWidth}
+        />
+      );
+    case "i-text":
+      return (
+        <text
+          key={i}
+          fill={obj.fill || "none"}
+          fontFamily={obj.fontFamily}
+          fontSize={obj.fontSize}
+          fontWeight={obj.fontWeight}
+          x={obj.left}
+          y={obj.top + obj.fontSize}
+        >
+          {obj.text}
+        </text>
+      );
+    case "line":
+      return (
+        <line
+          key={i}
+          opacity={obj.opacity}
+          stroke={obj.stroke}
+          strokeWidth={obj.strokeWidth}
+          x1={obj.left + obj.x1}
+          y1={obj.top + obj.y1}
+          x2={obj.left + obj.x2}
+          y2={obj.top + obj.y2}
+        />
+      );
+    case "path":
+      return (
+        <path
+          key={i}
+          d={fabricPathToSvg(obj.path)}
+          fill={obj.fill || "none"}
+          opacity={obj.opacity}
+          stroke={obj.stroke}
+          strokeWidth={obj.strokeWidth}
+        />
+      );
+    case "rect": {
+      // Fabric rectangles are positioned based on originX / originY, which can be "left" / "top" or "center".
+      // SVG rect elements, however, always use the top-left corner as the origin, so we adjust the position
+      // here as needed to ensure correct rendering in the SVG.
+      const originX = obj.originX ?? "left";
+      const originY = obj.originY ?? "top";
+      const x = originX === "center" ? obj.left - obj.width / 2 : obj.left;
+      const y = originY === "center" ? obj.top - obj.height / 2 : obj.top;
+    
+      return (
+        <rect
+          key={i}
+          height={obj.height}
+          fill={obj.fill || "none"}
+          opacity={obj.opacity}
+          stroke={obj.stroke}
+          strokeWidth={obj.strokeWidth}
+          width={obj.width}
+          x={x}
+          y={y}
+        />
+      );
+    }
+    default:
+      return null;
+  }
+};

--- a/packages/drawing-tool/src/components/report-item/report-item.test.tsx
+++ b/packages/drawing-tool/src/components/report-item/report-item.test.tsx
@@ -1,0 +1,81 @@
+import { reportItemHandler } from "./report-item";
+import { IAuthoredState, IInteractiveState } from "../types";
+import { IReportItemAnswer, sendReportItemAnswer, IReportItemAnswerItem } from "@concord-consortium/lara-interactive-api";
+
+jest.mock("@concord-consortium/lara-interactive-api", () => ({
+  sendReportItemAnswer: jest.fn()
+}));
+
+const authoredState = {
+  version: 1,
+  questionType: "iframe_interactive",
+  prompt: "Test prompt",
+  hint: "hint",
+  required: false,
+  defaultAnswer: ""
+} as IAuthoredState;
+
+const interactiveState = {
+  answerType: "interactive_state",
+  answerText: "Test answer",
+  drawingState: JSON.stringify({
+    dt: { width: 600, height: 600 },
+    canvas: {
+      objects: [],
+      background: "#ffffff"
+    }
+  })
+} as IInteractiveState;
+
+describe("reportItemHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("sends links and html items for version 2.x", () => {
+    reportItemHandler({
+      version: "2.1.0",
+      platformUserId: "user1",
+      authoredState,
+      interactiveState,
+      itemsType: "fullAnswer",
+      requestId: 1
+    });
+
+    expect(sendReportItemAnswer).toHaveBeenCalledTimes(1);
+    const response: IReportItemAnswer = (sendReportItemAnswer as jest.Mock).mock.calls[0][0];
+
+    expect(response.items).toHaveLength(2);
+    expect(response.items[0]).toEqual({
+      type: "links",
+      hideViewInline: true
+    });
+    const htmlItem = response.items[1] as IReportItemAnswerItem & { html: string };
+    expect(htmlItem.type).toBe("html");
+    expect(htmlItem.html).toContain('<div class="tall">');
+    expect(htmlItem.html).toContain('<div class="wide">');
+  });
+
+  it("handles missing drawingState gracefully", () => {
+    const stateWithoutDrawing = { ...interactiveState, drawingState: undefined };
+    
+    reportItemHandler({
+      version: "2.1.0",
+      platformUserId: "user1",
+      authoredState,
+      interactiveState: stateWithoutDrawing,
+      itemsType: "fullAnswer",
+      requestId: 1
+    });
+
+    expect(sendReportItemAnswer).toHaveBeenCalledTimes(1);
+    const response: IReportItemAnswer = (sendReportItemAnswer as jest.Mock).mock.calls[0][0];
+    const htmlItem = response.items[1] as IReportItemAnswerItem & { html: string };
+    expect(htmlItem.html).toBe("");
+  });
+});

--- a/packages/drawing-tool/src/components/report-item/report-item.tsx
+++ b/packages/drawing-tool/src/components/report-item/report-item.tsx
@@ -1,0 +1,35 @@
+import * as semver from "semver";
+import { sendReportItemAnswer, IReportItemAnswerItem, IGetReportItemAnswerHandler } from "@concord-consortium/lara-interactive-api";
+import { IAuthoredState, IInteractiveState } from "../types";
+import { getReportItemHtml } from "./get-report-item-html";
+
+export const reportItemHandler: IGetReportItemAnswerHandler<IInteractiveState, IAuthoredState> = request => {
+  const {interactiveState, authoredState, platformUserId, version, itemsType} = request;
+
+  if (!version) {
+    // for hosts sending older, unversioned requests
+    // tslint:disable-next-line:no-console
+    console.error("Drawing Tool Report Item Interactive: Missing version in getReportItemAnswer request.");
+  }
+  else if (semver.satisfies(version, "2.x")) {
+
+    const items: IReportItemAnswerItem[] = [
+      {
+        type: "links",
+        hideViewInline: true,
+      },
+      {
+        type: "html",
+        html: getReportItemHtml({interactiveState, authoredState})
+      }
+    ];
+
+    sendReportItemAnswer({version, platformUserId, items, itemsType});
+  } else {
+    // tslint:disable-next-line:no-console
+    console.error(
+      "Drawing Tool Report Item Interactive: Unsupported version in getReportItemAnswer request:",
+      version
+    );
+  }
+};

--- a/packages/drawing-tool/src/components/report-item/static-drawing.test.tsx
+++ b/packages/drawing-tool/src/components/report-item/static-drawing.test.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { StaticDrawing } from "./static-drawing";
+import { renderObject } from "./render-utils";
+
+jest.mock("./render-utils", () => ({
+  renderObject: jest.fn()
+}));
+
+const mockRenderObject = renderObject as jest.Mock;
+
+describe("StaticDrawing", () => {
+  const drawingState = JSON.stringify({
+    dt: { width: 600, height: 600 },
+    canvas: {
+      objects: [
+        { type: "rect", left: 10, top: 10, width: 50, height: 50 },
+        { type: "circle", left: 100, top: 100, radius: 25 }
+      ],
+      background: "#fff"
+    }
+  });
+
+  beforeEach(() => {
+    mockRenderObject.mockClear();
+    mockRenderObject.mockImplementation((obj, i) => <div key={i} data-testid={`object-${i}`}>{obj.type}</div>);
+  });
+
+  it("renders an SVG with correct dimensions and background", () => {
+    const { container } = render(<StaticDrawing drawingState={drawingState} />);
+    const svg = container.querySelector("svg");
+    
+    expect(svg).toHaveAttribute("width", "100%");
+    expect(svg).toHaveAttribute("height", "100%");
+    expect(svg).toHaveAttribute("viewBox", "0 0 600 600");
+    expect(svg).toHaveStyle({ background: "#fff", display: "block" });
+  });
+
+  it("renders a container div with correct aspect ratio and styling", () => {
+    const { container } = render(<StaticDrawing drawingState={drawingState} />);
+    const div = container.firstChild as HTMLElement;
+
+    expect(div.style.aspectRatio).toBe("600 / 600");
+    expect(div.style.border).toBe("1px solid #777");
+    expect(div.style.maxWidth).toBe("600px");
+    expect(div.style.width).toBe("100%");
+  });
+
+  it("calls renderObject for each canvas object", () => {
+    render(<StaticDrawing drawingState={drawingState} />);
+    
+    expect(mockRenderObject).toHaveBeenCalledTimes(2);
+    expect(mockRenderObject.mock.calls[0][0]).toEqual(
+      { type: "rect", left: 10, top: 10, width: 50, height: 50 }
+    );
+    expect(mockRenderObject.mock.calls[0][1]).toBe(0);
+    expect(mockRenderObject.mock.calls[1][0]).toEqual(
+      { type: "circle", left: 100, top: 100, radius: 25 }
+    );
+    expect(mockRenderObject.mock.calls[1][1]).toBe(1);
+  });
+
+  it("renders objects returned by renderObject", () => {
+    const { getByTestId } = render(<StaticDrawing drawingState={drawingState} />);
+    
+    expect(getByTestId("object-0")).toHaveTextContent("rect");
+    expect(getByTestId("object-1")).toHaveTextContent("circle");
+  });
+
+  it("handles missing drawingState", () => {
+    const { container } = render(<StaticDrawing />);
+    const svg = container.querySelector("svg");
+    
+    expect(svg).toHaveAttribute("viewBox", "0 0 600 600");
+    expect(svg).toHaveStyle({ background: "#fff" });
+    expect(mockRenderObject).not.toHaveBeenCalled();
+  });
+
+  it("uses default values when properties are missing", () => {
+    const minimalState = JSON.stringify({
+      canvas: {}
+    });
+    const { container } = render(<StaticDrawing drawingState={minimalState} />);
+    const svg = container.querySelector("svg");
+    
+    expect(svg).toHaveAttribute("viewBox", "0 0 600 600");
+    expect(svg).toHaveStyle({ background: "#fff" });
+  });
+});

--- a/packages/drawing-tool/src/components/report-item/static-drawing.tsx
+++ b/packages/drawing-tool/src/components/report-item/static-drawing.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { FabricObject } from "./types";
+import { renderObject } from "./render-utils";
+
+interface IDrawingProps {
+  drawingState?: string;
+}
+
+export const StaticDrawing = ({ drawingState }: IDrawingProps) => {
+  const { dt = {}, canvas = {} } = drawingState ? JSON.parse(drawingState) : {};
+  const width = dt.width ?? 600;
+  const height = dt.height ?? 600;
+  const objects: FabricObject[] = canvas.objects ?? [];
+  const background = canvas.background ?? "#fff";
+
+  return (
+    <div style={{ aspectRatio: `${width} / ${height}`, border: "solid 1px #777", maxWidth: "600px", width: "100%" }}>
+      <svg
+        width="100%"
+        height="100%"
+        viewBox={`0 0 ${width} ${height}`}
+        style={{ background, display: "block" }}
+      >
+        {objects.map(renderObject)}
+      </svg>
+    </div>
+  );
+};

--- a/packages/drawing-tool/src/components/report-item/types.ts
+++ b/packages/drawing-tool/src/components/report-item/types.ts
@@ -1,0 +1,45 @@
+type FabricBase = {
+  fill?: string;
+  left: number;
+  opacity?: number;
+  stroke?: string;
+  strokeWidth?: number;
+  top: number;
+};
+
+type FabricEllipse = FabricBase & {
+  rx: number;
+  ry: number;
+  type: "ellipse";
+};
+
+type FabricLine = FabricBase & {
+  x1: number;
+  x2: number;
+  y1: number;
+  y2: number;
+  type: "line";
+};
+
+type FabricPath = FabricBase & {
+  path: (string | number)[][];
+  type: "path";
+};
+
+type FabricRect = FabricBase & {
+  height: number;
+  originX?: string;
+  originY?: string;
+  type: "rect";
+  width: number;
+};
+
+type FabricText = FabricBase & {
+  fontFamily: string;
+  fontSize: number;
+  fontWeight: string;
+  type: "i-text";
+  text: string;
+};
+
+export type FabricObject = FabricEllipse | FabricLine | FabricPath | FabricText | FabricRect;

--- a/packages/drawing-tool/src/report-item-index.tsx
+++ b/packages/drawing-tool/src/report-item-index.tsx
@@ -1,0 +1,5 @@
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import { AppComponent } from "./components/report-item/app";
+
+ReactDOM.render(<AppComponent />, document.getElementById("app"));

--- a/packages/drawing-tool/webpack.config.js
+++ b/packages/drawing-tool/webpack.config.js
@@ -5,6 +5,8 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const webpackCommon = require('../../shared/webpack-common.config.js');
 
+const DEPLOY_PATH = process.env.DEPLOY_PATH;
+
 module.exports = (env, argv) => {
   const interactiveName = path.basename(__dirname); // e.g. "open-response"
 
@@ -12,6 +14,7 @@ module.exports = (env, argv) => {
     // Add custom webpack configuration here
     entry: {
       [`${interactiveName}`]: './src/index.tsx',
+      [`${interactiveName}/report-item`]: './src/report-item-index.tsx',
       [`${interactiveName}/demo`]: './src/demo.tsx'
     },
     plugins: [
@@ -21,10 +24,21 @@ module.exports = (env, argv) => {
         template: '../../shared/index.html'
       }),
       new HtmlWebpackPlugin({
+        chunks: [`${interactiveName}/report-item`],
+        filename: `${interactiveName}/report-item/index.html`,
+        template: '../../shared/index.html'
+      }),
+      new HtmlWebpackPlugin({
         chunks: [`${interactiveName}/demo`],
         filename: `${interactiveName}/demo.html`,
         template: '../../shared/index.html'
       }),
+      ...(DEPLOY_PATH ? [new HtmlWebpackPlugin({
+        chunks: [`${interactiveName}/report-item`],
+        filename: `${interactiveName}/report-item/index-top.html`,
+        template: '../../shared/index.html',
+        publicPath: `../${DEPLOY_PATH}/`,
+      })] : []),
     ]
   });
 };


### PR DESCRIPTION
[CLASSDASH-77](https://concord-consortium.atlassian.net/browse/CLASSDASH-77)

Adds a report item for Drawing Tool. The report item returns a static `svg` version of the drawing that will be scaled appropriately and not get cropped in the Class Dashboard. (The full view of the actual drawing is still accessible via the "Open in new tab" link above the drawing image.)

If you want to test it out, there's [this activity on Learn Portal Staging](https://learn.portal.staging.concord.org/eresources/459/) that includes a branch version of the Drawing Tool. Assign that activity to a class, run it as a student, then check the Class Dashboard view as the teacher.

[CLASSDASH-77]: https://concord-consortium.atlassian.net/browse/CLASSDASH-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ