### PR TITLE
fix: Remove trailing comma in scorebot feedback report [QI-13]

### DIFF
--- a/packages/score-bot/src/components/report-item/report-item.tsx
+++ b/packages/score-bot/src/components/report-item/report-item.tsx
@@ -28,7 +28,7 @@ export const reportItemHandler: IGetReportItemAnswerHandler<IInteractiveState, I
       const isOutdated = isFeedbackOutdated(interactiveState);
       const feedbackHtml = renderStyledComponentToString(
         <DynamicTextContext.Provider value={fakeDynamicTextContext}>
-          <FeedbackReport score={score} maxScore={maxScore} attempts={attempts} feedback={feedback} outdated={isOutdated} />,
+          <FeedbackReport score={score} maxScore={maxScore} attempts={attempts} feedback={feedback} outdated={isOutdated} />
         </DynamicTextContext.Provider>
       );
       items.push({ type: "html", html: feedbackHtml });


### PR DESCRIPTION
This fixes a trailing comma that has been in the code that generates the scorebot feedback report for a couple of years but just now noticed.