### PR TITLE
fix: Set submitted on ScoreBot text change [QI-13]

### DIFF
--- a/packages/score-bot/src/components/runtime.test.tsx
+++ b/packages/score-bot/src/components/runtime.test.tsx
@@ -50,7 +50,7 @@ describe("Runtime", () => {
     render(<DynamicTextTester><Runtime authoredState={authoredState} interactiveState={interactiveState} setInteractiveState={setState} /></DynamicTextTester>);
     fireEvent.change(screen.getByTestId("response-textarea"), { target: { value: "new answer" } });
     const newState = setState.mock.calls[0][0](interactiveState);
-    expect(newState).toEqual({answerType: "interactive_state", answerText: "new answer", score: undefined, submitted: false});
+    expect(newState).toEqual({answerType: "interactive_state", answerText: "new answer", score: undefined, submitted: true});
   });
 
   describe("report mode", () => {

--- a/packages/score-bot/src/components/runtime.tsx
+++ b/packages/score-bot/src/components/runtime.tsx
@@ -7,7 +7,7 @@ import { DynamicText } from "@concord-consortium/dynamic-text";
 
 import { Feedback } from "./feedback";
 import { IAuthoredState, IInteractiveState } from "./types";
-import { getLastAttemptAnswerText, getLastFeedback, getLastScore, getMaxScore, getValidScoreMapping, isFeedbackOutdated } from "../utils";
+import { getLastFeedback, getLastScore, getMaxScore, getValidScoreMapping, isFeedbackOutdated } from "../utils";
 
 import css from "./runtime.scss";
 
@@ -41,8 +41,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
       ...prevState,
       answerType: "interactive_state",
       answerText: value,
-      // If user typed something and then reverted to the previously submitted answer, there's no need to resubmit.
-      submitted: value === getLastAttemptAnswerText(interactiveState)
+      submitted: true
     }));
   };
 


### PR DESCRIPTION
This was missed when the ScoreBot scoring was removed.  The old code set submitted to true when the text stayed the same as the last scored text but since scoring was removed this always returned false and the student's answer was never displayed in the class dashboard.  The new code always set submitted to true.

NOTE: it may seem weird that we are not checking the value and returning false it if an empty string but this mimics the open response behavior.