### PR TITLE
feat: Blockly custom blocks code view (QI-27)

### DIFF
--- a/packages/blockly/src/components/custom-block-editor.scss
+++ b/packages/blockly/src/components/custom-block-editor.scss
@@ -3,13 +3,14 @@
 .customBlockEditor {
   display: flex;
   flex-direction: column;
-  gap: $spacing-xxxl;
+  gap: $spacing-lg;
 
   h4 {
+    font-size: $font-size-md;
     margin: 0;
   }
   h5 {
-    font-size: $font-size-md;
+    font-size: $font-size-sm;
     margin: 0;
   }
 
@@ -105,7 +106,7 @@
     }
   }
 
-    .customBlocksActions {
+  .customBlocksActions {
     align-items: center;
     display: flex;
     gap: $spacing-md;
@@ -148,5 +149,11 @@
         overflow: auto;
       }
     }
+  }
+
+  .divider {
+    border: none;
+    border-top: solid 1px $border-medium;
+    margin: 0 0 10px;
   }
 }

--- a/packages/blockly/src/components/custom-block-editor.tsx
+++ b/packages/blockly/src/components/custom-block-editor.tsx
@@ -71,24 +71,6 @@ export const CustomBlockEditor: React.FC<IProps> = ({ value, onChange, toolbox }
     <div className={css.customBlockEditor}>
       <h4>Custom Blocks</h4>
 
-      <div className={css.codePreview}>
-        <div className={css.codePreviewHeader}>
-          <h5>Code Preview (read-only)</h5>
-          <div className={css.customBlocksActions}>
-            <button type="button" onClick={() => setShowCodePreview(prev => !prev)}>
-              {showCodePreview ? "Hide" : "Show"}
-            </button>
-          </div>
-        </div>
-        {showCodePreview && (
-          <div className={css.codePreviewBody}>
-            <pre>
-              <code>{JSON.stringify(customBlocks, null, 2)}</code>
-            </pre>
-          </div>
-        )}
-      </div>
-
       <div className={css.customBlocksSetter}>
         <div className={css.customBlocksNew}>
           <div className={css.customBlocksNewHeading}>
@@ -180,6 +162,25 @@ export const CustomBlockEditor: React.FC<IProps> = ({ value, onChange, toolbox }
           )}
         </div>
       </div>
+
+      <div className={css.codePreview}>
+        <div className={css.codePreviewHeader}>
+          <h5>Custom Block Code Preview (read-only)</h5>
+          <div className={css.customBlocksActions}>
+            <button type="button" onClick={() => setShowCodePreview(prev => !prev)}>
+              {showCodePreview ? "Hide" : "Show"}
+            </button>
+          </div>
+        </div>
+        {showCodePreview && (
+          <div className={css.codePreviewBody}>
+            <pre>
+              <code>{JSON.stringify(customBlocks, null, 2)}</code>
+            </pre>
+          </div>
+        )}
+      </div>
+      <hr className={css.divider} />
     </div>
   );
 };


### PR DESCRIPTION
[QI-27](https://concord-consortium.atlassian.net/browse/QI-27)

Adds a "Code Preview" section to the custom block editor so authors can see what the code for custom blocks looks like. This is a simple proof of concept for optionally giving authors direct access to the code for modifying the custom blocks.

[QI-27]: https://concord-consortium.atlassian.net/browse/QI-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ