### PR TITLE
feat: integrate log-monitor sidebar into demo harness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2932,9 +2932,9 @@
       }
     },
     "node_modules/@concord-consortium/log-monitor": {
-      "version": "1.0.0-pre.1",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/log-monitor/-/log-monitor-1.0.0-pre.1.tgz",
-      "integrity": "sha512-sBqVF1yzmX1lHcICPVuRyRvPDF/uyPqzEYLRYOfgKGkxACmwsGWeqqJFcY4zqGlzYw1SeyzcpvlW40Iu37m43g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/log-monitor/-/log-monitor-1.0.0.tgz",
+      "integrity": "sha512-3eGS2jkil8MdEYMSaW/lJV2OYaW+kQsPoRUx086D+XaYdC3sRwIGq+Laqh7/qPCApnL+tj/ZA27bWZ5u4oSF9w==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8.0"
@@ -32145,7 +32145,7 @@
         "@concord-consortium/dynamic-text": "^1.0.6",
         "@concord-consortium/interactive-api-host": "^0.11.0",
         "@concord-consortium/lara-interactive-api": "1.13.0",
-        "@concord-consortium/log-monitor": "1.0.0-pre.1",
+        "@concord-consortium/log-monitor": "^1.0.0",
         "@concord-consortium/object-storage": "1.0.0-pre.8",
         "@concord-consortium/slate-editor": "^0.8.2",
         "@concord-consortium/text-decorator": "^1.0.2",
@@ -35058,9 +35058,9 @@
       }
     },
     "@concord-consortium/log-monitor": {
-      "version": "1.0.0-pre.1",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/log-monitor/-/log-monitor-1.0.0-pre.1.tgz",
-      "integrity": "sha512-sBqVF1yzmX1lHcICPVuRyRvPDF/uyPqzEYLRYOfgKGkxACmwsGWeqqJFcY4zqGlzYw1SeyzcpvlW40Iu37m43g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/log-monitor/-/log-monitor-1.0.0.tgz",
+      "integrity": "sha512-3eGS2jkil8MdEYMSaW/lJV2OYaW+kQsPoRUx086D+XaYdC3sRwIGq+Laqh7/qPCApnL+tj/ZA27bWZ5u4oSF9w==",
       "requires": {}
     },
     "@concord-consortium/object-storage": {
@@ -35079,7 +35079,7 @@
         "@concord-consortium/dynamic-text": "^1.0.6",
         "@concord-consortium/interactive-api-host": "^0.11.0",
         "@concord-consortium/lara-interactive-api": "1.13.0",
-        "@concord-consortium/log-monitor": "1.0.0-pre.1",
+        "@concord-consortium/log-monitor": "^1.0.0",
         "@concord-consortium/object-storage": "1.0.0-pre.8",
         "@concord-consortium/slate-editor": "^0.8.2",
         "@concord-consortium/text-decorator": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2931,6 +2931,15 @@
         "react-dom": ">=16.9.0"
       }
     },
+    "node_modules/@concord-consortium/log-monitor": {
+      "version": "1.0.0-pre.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/log-monitor/-/log-monitor-1.0.0-pre.1.tgz",
+      "integrity": "sha512-sBqVF1yzmX1lHcICPVuRyRvPDF/uyPqzEYLRYOfgKGkxACmwsGWeqqJFcY4zqGlzYw1SeyzcpvlW40Iu37m43g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/@concord-consortium/object-storage": {
       "version": "1.0.0-pre.8",
       "resolved": "https://registry.npmjs.org/@concord-consortium/object-storage/-/object-storage-1.0.0-pre.8.tgz",
@@ -32136,6 +32145,7 @@
         "@concord-consortium/dynamic-text": "^1.0.6",
         "@concord-consortium/interactive-api-host": "^0.11.0",
         "@concord-consortium/lara-interactive-api": "1.13.0",
+        "@concord-consortium/log-monitor": "1.0.0-pre.1",
         "@concord-consortium/object-storage": "1.0.0-pre.8",
         "@concord-consortium/slate-editor": "^0.8.2",
         "@concord-consortium/text-decorator": "^1.0.2",
@@ -35047,6 +35057,12 @@
         "nanoid": "^3.3.7"
       }
     },
+    "@concord-consortium/log-monitor": {
+      "version": "1.0.0-pre.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/log-monitor/-/log-monitor-1.0.0-pre.1.tgz",
+      "integrity": "sha512-sBqVF1yzmX1lHcICPVuRyRvPDF/uyPqzEYLRYOfgKGkxACmwsGWeqqJFcY4zqGlzYw1SeyzcpvlW40Iu37m43g==",
+      "requires": {}
+    },
     "@concord-consortium/object-storage": {
       "version": "1.0.0-pre.8",
       "resolved": "https://registry.npmjs.org/@concord-consortium/object-storage/-/object-storage-1.0.0-pre.8.tgz",
@@ -35063,6 +35079,7 @@
         "@concord-consortium/dynamic-text": "^1.0.6",
         "@concord-consortium/interactive-api-host": "^0.11.0",
         "@concord-consortium/lara-interactive-api": "1.13.0",
+        "@concord-consortium/log-monitor": "1.0.0-pre.1",
         "@concord-consortium/object-storage": "1.0.0-pre.8",
         "@concord-consortium/slate-editor": "^0.8.2",
         "@concord-consortium/text-decorator": "^1.0.2",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -96,6 +96,7 @@
     "@concord-consortium/dynamic-text": "^1.0.6",
     "@concord-consortium/interactive-api-host": "^0.11.0",
     "@concord-consortium/lara-interactive-api": "1.13.0",
+    "@concord-consortium/log-monitor": "1.0.0-pre.1",
     "@concord-consortium/object-storage": "1.0.0-pre.8",
     "@concord-consortium/slate-editor": "^0.8.2",
     "@concord-consortium/text-decorator": "^1.0.2",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -96,7 +96,7 @@
     "@concord-consortium/dynamic-text": "^1.0.6",
     "@concord-consortium/interactive-api-host": "^0.11.0",
     "@concord-consortium/lara-interactive-api": "1.13.0",
-    "@concord-consortium/log-monitor": "1.0.0-pre.1",
+    "@concord-consortium/log-monitor": "^1.0.0",
     "@concord-consortium/object-storage": "1.0.0-pre.8",
     "@concord-consortium/slate-editor": "^0.8.2",
     "@concord-consortium/text-decorator": "^1.0.2",

--- a/packages/helpers/src/components/demo.scss
+++ b/packages/helpers/src/components/demo.scss
@@ -23,16 +23,16 @@
   flex: auto;
   min-height: 0;
 
+  .demoContent {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
   &.withLogMonitor {
     flex-direction: row;
-
-    .demoContent {
-      flex: 1;
-      min-width: 0;
-      display: flex;
-      flex-direction: column;
-      min-height: 0;
-    }
 
     :global(.log-monitor) {
       width: 300px;

--- a/packages/helpers/src/components/demo.scss
+++ b/packages/helpers/src/components/demo.scss
@@ -23,6 +23,23 @@
   flex: auto;
   min-height: 0;
 
+  &.withLogMonitor {
+    flex-direction: row;
+
+    .demoContent {
+      flex: 1;
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+    }
+
+    :global(.log-monitor) {
+      width: 300px;
+      flex-shrink: 0;
+    }
+  }
+
   .header {
     padding: 10px;
     color: white;

--- a/packages/helpers/src/components/demo.tsx
+++ b/packages/helpers/src/components/demo.tsx
@@ -5,6 +5,7 @@ import { IframeRuntime } from "../components/iframe-runtime";
 import { DemoAuthoringComponent } from "./demo-authoring";
 import { DynamicTextContext, useDynamicTextProxy } from "@concord-consortium/dynamic-text";
 import { demoJobManager } from "../utilities/demo-job-manager";
+import { LogMonitor, emitLogEvent } from "@concord-consortium/log-monitor";
 
 import css from "./demo.scss";
 
@@ -21,6 +22,7 @@ const iframe = params.get("iframe");
 params.delete("iframe");
 
 const rootDemo = !iframe;
+const logMonitorEnabled = params.get("logMonitor") === "true";
 
 const demoUrl = (newIframe: string) => `demo.html?iframe=${newIframe}&${params.toString()}`
 
@@ -124,6 +126,13 @@ export const DemoComponent = <IAuthoredState, IInteractiveState>(props: IProps<I
         case "log":
           if (rootDemo) {
             console.log("DEMO LOG:", JSON.stringify(data.content));
+            if (logMonitorEnabled) {
+              emitLogEvent({
+                event: data.content.action,
+                data: data.content.data,
+                timestamp: Date.now()
+              });
+            }
           }
           break;
       }
@@ -238,12 +247,15 @@ export const DemoComponent = <IAuthoredState, IInteractiveState>(props: IProps<I
 
     default:
       return (
-        <div className={css.demo}>
-          <div className={css.header}><h1>{title}</h1></div>
-          <div className={css.split}>
-            <div className={css.authoring}><iframe src={demoUrl("authoring-container")} /></div>
-            <div className={css.runtime}><iframe src={demoUrl("runtime-container")} /></div>
+        <div className={`${css.demo} ${logMonitorEnabled ? css.withLogMonitor : ""}`}>
+          <div className={css.demoContent}>
+            <div className={css.header}><h1>{title}</h1></div>
+            <div className={css.split}>
+              <div className={css.authoring}><iframe src={demoUrl("authoring-container")} /></div>
+              <div className={css.runtime}><iframe src={demoUrl("runtime-container")} /></div>
+            </div>
           </div>
+          {logMonitorEnabled && <LogMonitor logFilePrefix={`${title.toLowerCase().replace(/\s+/g, "-")}-log-events`} />}
         </div>
       );
   }

--- a/packages/helpers/src/components/demo.tsx
+++ b/packages/helpers/src/components/demo.tsx
@@ -6,6 +6,7 @@ import { DemoAuthoringComponent } from "./demo-authoring";
 import { DynamicTextContext, useDynamicTextProxy } from "@concord-consortium/dynamic-text";
 import { demoJobManager } from "../utilities/demo-job-manager";
 import { LogMonitor, emitLogEvent } from "@concord-consortium/log-monitor";
+import { slugify } from "../utilities/slugify";
 
 import css from "./demo.scss";
 
@@ -255,7 +256,7 @@ export const DemoComponent = <IAuthoredState, IInteractiveState>(props: IProps<I
               <div className={css.runtime}><iframe src={demoUrl("runtime-container")} /></div>
             </div>
           </div>
-          {logMonitorEnabled && <LogMonitor logFilePrefix={`${title.toLowerCase().replace(/\s+/g, "-")}-log-events`} />}
+          {logMonitorEnabled && <LogMonitor logFilePrefix={`${slugify(title)}-log-events`} />}
         </div>
       );
   }

--- a/packages/helpers/src/utilities/slugify.test.ts
+++ b/packages/helpers/src/utilities/slugify.test.ts
@@ -1,0 +1,40 @@
+import { slugify } from "./slugify";
+
+describe("slugify", () => {
+  it("converts spaces to hyphens", () => {
+    expect(slugify("Hello World")).toBe("hello-world");
+  });
+
+  it("removes non-alphanumeric characters", () => {
+    expect(slugify("Hello: World!")).toBe("hello-world");
+  });
+
+  it("collapses consecutive special characters into a single hyphen", () => {
+    expect(slugify("foo --- bar")).toBe("foo-bar");
+  });
+
+  it("trims leading and trailing hyphens", () => {
+    expect(slugify("--hello--")).toBe("hello");
+    expect(slugify("!hello!")).toBe("hello");
+  });
+
+  it("returns fallback for empty string", () => {
+    expect(slugify("")).toBe("demo");
+  });
+
+  it("returns fallback for string with only special characters", () => {
+    expect(slugify("!@#$%")).toBe("demo");
+  });
+
+  it("accepts a custom fallback", () => {
+    expect(slugify("", "default")).toBe("default");
+  });
+
+  it("handles mixed case", () => {
+    expect(slugify("FooBar")).toBe("foobar");
+  });
+
+  it("preserves numbers", () => {
+    expect(slugify("test 123")).toBe("test-123");
+  });
+});

--- a/packages/helpers/src/utilities/slugify.ts
+++ b/packages/helpers/src/utilities/slugify.ts
@@ -1,0 +1,3 @@
+export const slugify = (text: string, fallback = "demo"): string => {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || fallback;
+};


### PR DESCRIPTION
Add @concord-consortium/log-monitor to the helpers package. Forward postMessage log events to emitLogEvent when logMonitor=true query param is present. Render LogMonitor as a sidebar using a flex-row layout wrapper with CSS scoped to .withLogMonitor.