### PR TITLE
feat: blockly starter programs (QI-135)

### DIFF
--- a/packages/blockly/docs/authoring.md
+++ b/packages/blockly/docs/authoring.md
@@ -253,3 +253,12 @@ Check example simulations for ideas on how to use action blocks.
 ### Condition Blocks
 
 Custom condition blocks allow authors to create conditions that can be used within if, when, or many other types of blocks. Like action blocks, they require authors to write their own custom code to generate.
+
+## Starter Program
+
+The authoring form includes an embedded Blockly workspace for defining an optional **Starter Program**. Any blocks you place here become the initial program a student sees the first time they open the interactive. The three top-level blocks (`setup`, `go`, `onclick`) are always present and cannot be deleted. You can nest any other built-in or custom block inside them, just as a student would.
+
+- **When students see the starter.** The first time a student opens the interactive with no saved work, their workspace is seeded from the authored starter. If no starter is authored, they see the three empty top-level blocks.
+- **New models re-seed.** When a student creates a new model via `File → New`, the new model starts from the authored starter. `File → Copy` duplicates the state of the student's current model rather than re-seeding.
+- **Student work is never clobbered.** Once a student has saved any work, re-authoring the starter has no effect on their existing models. The starter is consulted only when a model has no saved state.
+- **Deleted custom blocks are pruned automatically.** If you delete a custom block that the starter references, the stale block is removed from the starter on save. For safety, if a removed block sits in the middle of a chain of connected blocks, the tail of that chain (everything connected after the removed block) is also dropped rather than re-wired. This avoids leaving orphaned references to variables or state that the removed block was responsible for creating.

--- a/packages/blockly/src/components/app.tsx
+++ b/packages/blockly/src/components/app.tsx
@@ -4,6 +4,7 @@ import React from "react";
 
 import { CustomBlockEditor } from "./custom-block-editor";
 import { Runtime } from "./runtime";
+import { StarterProgramEditor } from "./starter-program-editor";
 import { DefaultAuthoredState, IAuthoredState, IInteractiveState } from "./types";
 
 const baseAuthoringProps = {
@@ -50,6 +51,10 @@ const baseAuthoringProps = {
           }
         }
       },
+      starterBlocklyState: {
+        type: "string",
+        default: ""
+      },
       toolbox: {
         default: DefaultAuthoredState.toolbox || "",
         title: "Toolbox",
@@ -62,6 +67,11 @@ const baseAuthoringProps = {
     "ui:order": [
       "prompt",
       "required",
+      "hint",
+      "simulationCode",
+      "customBlocks",
+      "starterBlocklyState",
+      "toolbox",
       "*"
     ],
     version: {
@@ -84,6 +94,9 @@ const baseAuthoringProps = {
     },
     customBlocks: {
       "ui:field": "customBlockEditor"
+    },
+    starterBlocklyState: {
+      "ui:field": "starterProgramEditor"
     },
     toolbox: {
       "ui:widget": "textarea",
@@ -109,12 +122,24 @@ export const App = () => (
           const value = Array.isArray(props.formData) ? props.formData : [];
           const authoredState = props.registry?.formContext?.authoredState || {};
           const toolbox = authoredState.toolbox || "";
-          
+
           return (
             <CustomBlockEditor
               customBlocks={value}
               onChange={props.onChange}
               toolbox={toolbox}
+            />
+          );
+        },
+        starterProgramEditor: (props: FieldProps<any, RJSFSchema, any>) => {
+          const value = typeof props.formData === "string" ? props.formData : "";
+          const authoredState = props.registry?.formContext?.authoredState || {};
+          return (
+            <StarterProgramEditor
+              customBlocks={authoredState.customBlocks || []}
+              starterBlocklyState={value}
+              toolbox={authoredState.toolbox || ""}
+              onChange={props.onChange}
             />
           );
         }

--- a/packages/blockly/src/components/blockly.test.tsx
+++ b/packages/blockly/src/components/blockly.test.tsx
@@ -11,6 +11,26 @@ import {
   validToolboxAuthoredState
 } from "./__mocks__/fixtures";
 import { BlocklyComponent } from "./blockly";
+import { IAuthoredState } from "./types";
+
+const starterStateWithNestedIf = JSON.stringify({
+  blocks: {
+    languageVersion: 0,
+    blocks: [
+      {
+        type: "setup", x: 10, y: 10, deletable: false,
+        inputs: { statements: { block: { type: "controls_if", id: "starter-if" } } }
+      },
+      { type: "go", x: 10, y: 80, deletable: false },
+      { type: "onclick", x: 10, y: 150, deletable: false }
+    ]
+  }
+});
+
+const authoredStateWithStarter: IAuthoredState = {
+  ...generalToolboxAuthoredState,
+  starterBlocklyState: starterStateWithNestedIf
+};
 
 describe("BlocklyComponent", () => {
   it("shows error message when no toolbox is provided", () => {
@@ -146,6 +166,86 @@ describe("BlocklyComponent", () => {
       const setupBlock = container.querySelector('.setup');
       expect(setupBlock).toBeInTheDocument();
       expect(setupBlock?.classList.contains('blocklyDisabled')).toBe(false);
+    });
+  });
+
+  describe("starter programs", () => {
+    it("renders the three seed blocks when there is no starter and no student state", () => {
+      render(<BlocklyComponent
+        authoredState={generalToolboxAuthoredState}
+        interactiveState={defaultInteractiveState}
+        report={false}
+        setInteractiveState={() => { /* no-op */ }}
+      />);
+      expect(document.querySelector(".setup.blocklyNotDeletable")).toBeInTheDocument();
+      expect(document.querySelector(".go.blocklyNotDeletable")).toBeInTheDocument();
+      expect(document.querySelector(".onclick.blocklyNotDeletable")).toBeInTheDocument();
+      expect(document.querySelector(".controls_if")).not.toBeInTheDocument();
+    });
+
+    it("loads the starter and persists it when not in report mode", async () => {
+      const setInteractiveState = jest.fn();
+      const { container } = render(
+        <BlocklyComponent
+          authoredState={authoredStateWithStarter}
+          interactiveState={defaultInteractiveState}
+          report={false}
+          setInteractiveState={setInteractiveState}
+        />
+      );
+
+      await waitFor(() => {
+        expect(container.querySelector("g.controls_if")).toBeInTheDocument();
+      });
+
+      expect(setInteractiveState).toHaveBeenCalled();
+      const lastCall = setInteractiveState.mock.calls.at(-1)?.[0];
+      const result = (lastCall as (prev: { answerType: string }) => { blocklyState?: string })({ answerType: "interactive_state" });
+      expect(result.blocklyState).toBeTruthy();
+      expect(result.blocklyState).toContain("controls_if");
+    });
+
+    it("loads the starter in report mode without persisting", async () => {
+      const setInteractiveState = jest.fn();
+      const { container } = render(<BlocklyComponent
+        authoredState={authoredStateWithStarter}
+        interactiveState={defaultInteractiveState}
+        report={true}
+        setInteractiveState={setInteractiveState}
+      />);
+
+      await waitFor(() => {
+        expect(container.querySelector("g.controls_if")).toBeInTheDocument();
+      });
+
+      // No persistence call should include a blocklyState — the save listener
+      // only runs on non-report mutations.
+      const persistedWithBlocklyState = setInteractiveState.mock.calls.some(([arg]: [any]) => {
+        if (typeof arg !== "function") return false;
+        const result = arg({ answerType: "interactive_state" });
+        return !!result.blocklyState;
+      });
+      expect(persistedWithBlocklyState).toBe(false);
+    });
+
+    it("prefers existing student state over the starter", async () => {
+      const { container } = render(<BlocklyComponent
+        authoredState={authoredStateWithStarter}
+        interactiveState={savedInteractiveState}
+        report={false}
+        setInteractiveState={() => { /* no-op */ }}
+      />);
+
+      await waitFor(() => {
+        // savedInteractiveState has a controls_if block at top level (no setup parent).
+        // The starter's controls_if is nested inside setup. Look for the one that is NOT nested.
+        const ifBlocks = container.querySelectorAll("g.controls_if");
+        expect(ifBlocks.length).toBe(1);
+      });
+
+      // The seed blocks setup/go/onclick from the starter should NOT be present because
+      // savedInteractiveState won (it has no seed blocks).
+      expect(document.querySelector(".setup.blocklyNotDeletable")).not.toBeInTheDocument();
     });
   });
 

--- a/packages/blockly/src/components/blockly.tsx
+++ b/packages/blockly/src/components/blockly.tsx
@@ -9,14 +9,17 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { registerCustomBlocks } from "../blocks/block-factory";
 import "../blocks/block-registration";
 import { saveEvents } from "../utils/block-utils";
+import { hasAuthoredStarterContent, parseStarterProgram } from "../utils/starter-utils";
 import { injectCustomBlocksIntoToolbox } from "../utils/toolbox-utils";
-import { IAuthoredState, IInteractiveState } from "./types";
+import { IAuthoredState, IInteractiveState, INITIAL_SEED_BLOCKS, SEED_BLOCK_TYPES } from "./types";
 import { FileModal, Header } from "./header";
 import { MaybeFileModal } from "./maybe-file-modal";
 
 import css from "./blockly.scss";
 
 interface IProps extends IRuntimeQuestionComponentProps<IAuthoredState, IInteractiveState> {}
+
+const DEFAULT_INTERACTIVE_STATE: IInteractiveState = { answerType: "interactive_state" };
 
 export const BlocklyComponent: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, report }) => {
   const { customBlocks = [], simulationCode, toolbox } = authoredState;
@@ -59,20 +62,11 @@ export const BlocklyComponent: React.FC<IProps> = ({ authoredState, interactiveS
 
       registerCustomBlocks(safeCustomBlocks);
 
-      const initialBlocks = [
-        { deletable: false, type: "setup", x: 10, y: 10 },
-        { deletable: false, type: "go", x: 10, y: 80 },
-        { deletable: false, type: "onclick", x: 10, y: 150 }
-      ];
-
       try {
         // Inject custom blocks into toolbox based on their assigned categories
         const enhancedToolbox = injectCustomBlocksIntoToolbox(toolbox, safeCustomBlocks);
         const newWorkspace = inject(blocklyDivRef.current, {
           readOnly: report, toolbox: JSON.parse(enhancedToolbox), trashcan: true
-        });
-        initialBlocks.forEach(block => {
-          serialization.blocks.append(block, newWorkspace);
         });
         workspaceRef.current = newWorkspace;
         setError(null);
@@ -108,17 +102,18 @@ export const BlocklyComponent: React.FC<IProps> = ({ authoredState, interactiveS
             log(eventName, eventParams);
           } catch (e) {
             console.error("Error stringifying blockly change event for logging:", e);
-            log(eventName, { error: e.message || String(e) });
+            log(eventName, { error: (e instanceof Error ? e.message : String(e)) });
           }
         });
 
         // Set up automatic saving
         const saveState = (event: Events.Abstract) => {
+          if (report) return;
           if (saveEvents.includes(event.type)) {
             const {code, blocklyState} = getWorkspaceCodeAndState();
-            setInteractiveState?.((prevState: IInteractiveState) => {
+            setInteractiveState?.((prevState: IInteractiveState | null) => {
               const newState = {
-                ...prevState,
+                ...(prevState ?? DEFAULT_INTERACTIVE_STATE),
                 code,
                 blocklyState
               };
@@ -130,14 +125,37 @@ export const BlocklyComponent: React.FC<IProps> = ({ authoredState, interactiveS
 
         return () => newWorkspace.removeChangeListener(saveState);
       } catch (e) {
-        setError(e);
+        setError(e instanceof Error ? e : new Error(String(e)));
       }
     }
   }, [getWorkspaceCodeAndState, report, safeCustomBlocks, setInteractiveState, toolbox]);
 
-  useEffect(() => {
-    initWorkspace();
-  }, [initWorkspace]);
+  const starterProgram = useMemo(
+    () => parseStarterProgram(authoredState.starterBlocklyState),
+    [authoredState.starterBlocklyState]
+  );
+
+  const seedWorkspace = useCallback(() => {
+    const ws = workspaceRef.current;
+    if (!ws) return;
+    let loaded = false;
+    if (hasAuthoredStarterContent(starterProgram)) {
+      try {
+        serialization.workspaces.load(starterProgram, ws);
+        loaded = true;
+      } catch (e) {
+        console.warn("Failed to load authored starter program. Falling back to seed blocks only:", e);
+      }
+    }
+    if (!loaded) {
+      INITIAL_SEED_BLOCKS.forEach(b => serialization.blocks.append(b, ws));
+    }
+    ws.render();
+    // Ensure the three seed blocks remain non-deletable regardless of how Blockly round-trips the deletable flag.
+    ws.getTopBlocks(false).forEach(b => {
+      if ((SEED_BLOCK_TYPES as readonly string[]).includes(b.type)) b.setDeletable(false);
+    });
+  }, [starterProgram]);
 
   const loadWorkspaceState = (state: string) => {
     if (!workspaceRef.current) {
@@ -157,6 +175,32 @@ export const BlocklyComponent: React.FC<IProps> = ({ authoredState, interactiveS
     }
   };
 
+  // Refs used by the re-init restore path so we don't need to add fast-changing values
+  // (interactiveState, seedWorkspace) to the useEffect deps and cause churn.
+  const interactiveStateRef = useRef(interactiveState);
+  const seedWorkspaceRef = useRef(seedWorkspace);
+  useEffect(() => { interactiveStateRef.current = interactiveState; });
+  useEffect(() => { seedWorkspaceRef.current = seedWorkspace; });
+
+  useEffect(() => {
+    initWorkspace();
+    // A re-init (caused by toolbox/customBlocks/report/simulationCode changing) leaves the
+    // newly-created workspace empty. Restore its content so the save listener doesn't
+    // persist blank state. First-load is handled by the dedicated effect below.
+    if (hasLoadedRef.current && workspaceRef.current) {
+      const savedState = interactiveStateRef.current?.blocklyState;
+      if (savedState) {
+        try {
+          loadWorkspaceState(savedState);
+        } catch (e) {
+          console.warn("Failed to restore workspace state on re-init:", e);
+        }
+      } else {
+        seedWorkspaceRef.current();
+      }
+    }
+  }, [initWorkspace]);
+
   // Load saved state on initial load
   useEffect(() => {
     if (hasLoadedRef.current || !workspaceRef.current) {
@@ -166,11 +210,18 @@ export const BlocklyComponent: React.FC<IProps> = ({ authoredState, interactiveS
 
     if (interactiveState?.blocklyState) {
       loadWorkspaceState(interactiveState.blocklyState);
+    } else {
+      seedWorkspace();
+      if (!report && hasAuthoredStarterContent(starterProgram)) {
+        // Persist the seeded starter so future loads follow the "has saved state" path.
+        const { code, blocklyState } = getWorkspaceCodeAndState();
+        setInteractiveState?.((prevState: IInteractiveState | null) => ({ ...(prevState ?? DEFAULT_INTERACTIVE_STATE), code, blocklyState }));
+      }
     }
     if (interactiveState?.name) {
       setName(interactiveState.name);
     }
-  }, [interactiveState]);
+  }, [interactiveState, starterProgram, report, seedWorkspace, getWorkspaceCodeAndState, setInteractiveState]);
 
   const validateModelName = useCallback((newName: string, { renaming, opening } = { renaming: false, opening: false }): boolean => {
     if (newName.length === 0) {
@@ -218,15 +269,16 @@ export const BlocklyComponent: React.FC<IProps> = ({ authoredState, interactiveS
       alert("Workspace is not initialized.");
       return false;
     }
+    seedWorkspace();
     const {code, blocklyState} = getWorkspaceCodeAndState();
 
     const newBlocklyStates = [...updatedSavedBlocklyStates, { name: newName, blocklyState }];
     setSavedBlocklyStates(newBlocklyStates);
 
     setName(newName);
-    setInteractiveState?.((prevState: IInteractiveState) => {
+    setInteractiveState?.((prevState: IInteractiveState | null) => {
       const newState = {
-        ...prevState,
+        ...(prevState ?? DEFAULT_INTERACTIVE_STATE),
         name: newName,
         code,
         blocklyState,
@@ -236,7 +288,7 @@ export const BlocklyComponent: React.FC<IProps> = ({ authoredState, interactiveS
     });
 
     return true;
-  }, [validateModelName, ensureUpdatedSavedBlocklyStates, initWorkspace, getWorkspaceCodeAndState, setInteractiveState]);
+  }, [validateModelName, ensureUpdatedSavedBlocklyStates, initWorkspace, seedWorkspace, getWorkspaceCodeAndState, setInteractiveState]);
 
   const handleFileOpen = useCallback((selectedName: string): boolean => {
     if (!validateModelName(selectedName, { opening: true })) {
@@ -261,9 +313,9 @@ export const BlocklyComponent: React.FC<IProps> = ({ authoredState, interactiveS
     setSavedBlocklyStates(updatedSavedBlocklyStates);
 
     setName(selectedName);
-    setInteractiveState?.((prevState: IInteractiveState) => {
+    setInteractiveState?.((prevState: IInteractiveState | null) => {
       const newState = {
-        ...prevState,
+        ...(prevState ?? DEFAULT_INTERACTIVE_STATE),
         name: selectedName,
         code,
         blocklyState,
@@ -287,9 +339,9 @@ export const BlocklyComponent: React.FC<IProps> = ({ authoredState, interactiveS
     setSavedBlocklyStates(newBlocklyStates);
 
     setName(newName);
-    setInteractiveState?.((prevState: IInteractiveState) => {
+    setInteractiveState?.((prevState: IInteractiveState | null) => {
       const newState = {
-        ...prevState,
+        ...(prevState ?? DEFAULT_INTERACTIVE_STATE),
         name: newName,
         savedBlocklyStates: newBlocklyStates
       };
@@ -314,9 +366,9 @@ export const BlocklyComponent: React.FC<IProps> = ({ authoredState, interactiveS
     setSavedBlocklyStates(updatedSavedBlocklyStates);
 
     setName(newName);
-    setInteractiveState?.((prevState: IInteractiveState) => {
+    setInteractiveState?.((prevState: IInteractiveState | null) => {
       const newState = {
-        ...prevState,
+        ...(prevState ?? DEFAULT_INTERACTIVE_STATE),
         name: newName,
         savedBlocklyStates: updatedSavedBlocklyStates
       };
@@ -345,6 +397,7 @@ export const BlocklyComponent: React.FC<IProps> = ({ authoredState, interactiveS
         alert("Workspace is not initialized.");
         return false;
       }
+      seedWorkspace();
       const {code, blocklyState} = getWorkspaceCodeAndState();
 
       const newName = "Model 1";
@@ -352,9 +405,9 @@ export const BlocklyComponent: React.FC<IProps> = ({ authoredState, interactiveS
       setSavedBlocklyStates(newBlocklyStates);
 
       setName(newName);
-      setInteractiveState?.((prevState: IInteractiveState) => {
+      setInteractiveState?.((prevState: IInteractiveState | null) => {
         const newState = {
-          ...prevState,
+          ...(prevState ?? DEFAULT_INTERACTIVE_STATE),
           name: newName,
           code,
           blocklyState,
@@ -367,7 +420,7 @@ export const BlocklyComponent: React.FC<IProps> = ({ authoredState, interactiveS
     setSavedBlocklyStates(updatedSavedBlocklyStates);
 
     return true;
-  }, [ensureUpdatedSavedBlocklyStates, getWorkspaceCodeAndState, handleFileOpen, initWorkspace, name, setInteractiveState]);
+  }, [ensureUpdatedSavedBlocklyStates, getWorkspaceCodeAndState, handleFileOpen, initWorkspace, seedWorkspace, name, setInteractiveState]);
 
   return (
     <div className={css.blockly}>

--- a/packages/blockly/src/components/blockly.tsx
+++ b/packages/blockly/src/components/blockly.tsx
@@ -57,7 +57,11 @@ export const BlocklyComponent: React.FC<IProps> = ({ authoredState, interactiveS
     }
 
     if (blocklyDivRef.current) {
-      // Empty existing container before creating a new workspace to avoid duplication.
+      // Dispose previous workspace to release Blockly's internal listeners and timers.
+      if (workspaceRef.current) {
+        workspaceRef.current.dispose();
+        workspaceRef.current = null;
+      }
       blocklyDivRef.current.innerHTML = "";
 
       registerCustomBlocks(safeCustomBlocks);
@@ -122,8 +126,6 @@ export const BlocklyComponent: React.FC<IProps> = ({ authoredState, interactiveS
           }
         };
         newWorkspace.addChangeListener(saveState);
-
-        return () => newWorkspace.removeChangeListener(saveState);
       } catch (e) {
         setError(e instanceof Error ? e : new Error(String(e)));
       }
@@ -135,19 +137,21 @@ export const BlocklyComponent: React.FC<IProps> = ({ authoredState, interactiveS
     [authoredState.starterBlocklyState]
   );
 
-  const seedWorkspace = useCallback(() => {
+  /** Seeds the workspace with the authored starter (if valid) or the three default seed blocks.
+   *  Returns true if the authored starter was loaded successfully. */
+  const seedWorkspace = useCallback((): boolean => {
     const ws = workspaceRef.current;
-    if (!ws) return;
-    let loaded = false;
+    if (!ws) return false;
+    let loadedStarter = false;
     if (hasAuthoredStarterContent(starterProgram)) {
       try {
         serialization.workspaces.load(starterProgram, ws);
-        loaded = true;
+        loadedStarter = true;
       } catch (e) {
         console.warn("Failed to load authored starter program. Falling back to seed blocks only:", e);
       }
     }
-    if (!loaded) {
+    if (!loadedStarter) {
       INITIAL_SEED_BLOCKS.forEach(b => serialization.blocks.append(b, ws));
     }
     ws.render();
@@ -155,6 +159,8 @@ export const BlocklyComponent: React.FC<IProps> = ({ authoredState, interactiveS
     ws.getTopBlocks(false).forEach(b => {
       if ((SEED_BLOCK_TYPES as readonly string[]).includes(b.type)) b.setDeletable(false);
     });
+
+    return loadedStarter;
   }, [starterProgram]);
 
   const loadWorkspaceState = (state: string) => {
@@ -199,6 +205,15 @@ export const BlocklyComponent: React.FC<IProps> = ({ authoredState, interactiveS
         seedWorkspaceRef.current();
       }
     }
+
+    // Dispose on unmount so Blockly's global listeners and timers are cleaned up.
+    // Re-init disposal is handled inside initWorkspace itself.
+    return () => {
+      if (workspaceRef.current) {
+        workspaceRef.current.dispose();
+        workspaceRef.current = null;
+      }
+    };
   }, [initWorkspace]);
 
   // Load saved state on initial load
@@ -211,9 +226,12 @@ export const BlocklyComponent: React.FC<IProps> = ({ authoredState, interactiveS
     if (interactiveState?.blocklyState) {
       loadWorkspaceState(interactiveState.blocklyState);
     } else {
-      seedWorkspace();
-      if (!report && hasAuthoredStarterContent(starterProgram)) {
+      const starterLoaded = seedWorkspace();
+      if (!report && starterLoaded) {
         // Persist the seeded starter so future loads follow the "has saved state" path.
+        // Only persist when the authored starter actually loaded. If seedWorkspace fell back
+        // to default seed blocks (e.g. due to a transient load error), we must not create a
+        // saved state that would prevent the real starter from being retried later.
         const { code, blocklyState } = getWorkspaceCodeAndState();
         setInteractiveState?.((prevState: IInteractiveState | null) => ({ ...(prevState ?? DEFAULT_INTERACTIVE_STATE), code, blocklyState }));
       }

--- a/packages/blockly/src/components/runtime.test.tsx
+++ b/packages/blockly/src/components/runtime.test.tsx
@@ -52,7 +52,8 @@ describe("Blockly runtime", () => {
     const blocklyComponent = wrapper.find(BlocklyComponent);
     const expectedAuthoredState = {
       ...customBlocksAuthoredState,
-      hint: ""
+      hint: "",
+      starterBlocklyState: ""
     };
     expect(blocklyComponent.prop("authoredState")).toEqual(expectedAuthoredState);
   });

--- a/packages/blockly/src/components/starter-program-editor.scss
+++ b/packages/blockly/src/components/starter-program-editor.scss
@@ -1,0 +1,19 @@
+@import "./variables.scss";
+
+.starterEditor {
+  border: 1px solid $border-medium;
+  border-radius: $border-radius-md;
+  margin-top: $spacing-lg;
+  padding: $spacing-md;
+
+  h4 {
+    font-size: $font-size-md;
+    margin: 0;
+  }
+
+  .starterEditor_container {
+    height: 400px;
+    margin-top: $spacing-md;
+    overflow: auto;
+  }
+}

--- a/packages/blockly/src/components/starter-program-editor.test.tsx
+++ b/packages/blockly/src/components/starter-program-editor.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+
+import { ICustomBlock, SEED_BLOCK_TYPES } from "./types";
+import { StarterProgramEditor } from "./starter-program-editor";
+
+const validToolbox = JSON.stringify({
+  kind: "categoryToolbox",
+  contents: [
+    { kind: "category", name: "General", colour: "#00836B", contents: [] }
+  ]
+});
+
+const wrap = (blocks: Record<string, any>[]) => JSON.stringify({ blocks: { blocks } });
+
+const starterWithNested = wrap([
+  {
+    type: "setup", x: 10, y: 10, deletable: false,
+    inputs: { statements: { block: { type: "controls_if", id: "starter-if" } } }
+  },
+  { type: "go", x: 10, y: 80, deletable: false },
+  { type: "onclick", x: 10, y: 150, deletable: false }
+]);
+
+describe("StarterProgramEditor", () => {
+  it("renders with seed blocks when starterBlocklyState is empty", () => {
+    render(
+      <StarterProgramEditor
+        customBlocks={[]}
+        starterBlocklyState=""
+        toolbox={validToolbox}
+        onChange={jest.fn()}
+      />
+    );
+    expect(screen.getByTestId("starter-program-editor")).toBeInTheDocument();
+    expect(screen.getByText("Starter Program")).toBeInTheDocument();
+    expect(document.querySelector(".injectionDiv")).toBeInTheDocument();
+    SEED_BLOCK_TYPES.forEach(type => {
+      expect(document.querySelector(`.${type}`)).toBeInTheDocument();
+    });
+  });
+
+  it("loads existing starterBlocklyState", async () => {
+    render(
+      <StarterProgramEditor
+        customBlocks={[]}
+        starterBlocklyState={starterWithNested}
+        toolbox={validToolbox}
+        onChange={jest.fn()}
+      />
+    );
+    await waitFor(() => {
+      expect(document.querySelector(".controls_if")).toBeInTheDocument();
+    });
+  });
+
+  it("falls back to seed blocks on malformed input", () => {
+    render(
+      <StarterProgramEditor
+        customBlocks={[]}
+        starterBlocklyState="not json"
+        toolbox={validToolbox}
+        onChange={jest.fn()}
+      />
+    );
+    expect(document.querySelector(".injectionDiv")).toBeInTheDocument();
+    SEED_BLOCK_TYPES.forEach(type => {
+      expect(document.querySelector(`.${type}`)).toBeInTheDocument();
+    });
+  });
+
+  it("calls onChange with pruned value when a custom block is removed", async () => {
+    const customBlock: ICustomBlock = {
+      category: "General",
+      color: "#FF0000",
+      config: { canHaveChildren: false, previousStatement: true, nextStatement: true },
+      id: "custom_test_block",
+      name: "test",
+      type: "action"
+    };
+
+    const starterWithCustom = wrap([
+      {
+        type: "setup", x: 10, y: 10, deletable: false,
+        inputs: { statements: { block: { type: "custom_test_block", id: "c1" } } }
+      },
+      { type: "go", x: 10, y: 80, deletable: false },
+      { type: "onclick", x: 10, y: 150, deletable: false }
+    ]);
+
+    const onChange = jest.fn<void, [string]>();
+
+    const { rerender } = render(
+      <StarterProgramEditor
+        customBlocks={[customBlock]}
+        starterBlocklyState={starterWithCustom}
+        toolbox={validToolbox}
+        onChange={onChange}
+      />
+    );
+
+    // Remove the custom block from the list
+    rerender(
+      <StarterProgramEditor
+        customBlocks={[]}
+        starterBlocklyState={starterWithCustom}
+        toolbox={validToolbox}
+        onChange={onChange}
+      />
+    );
+
+    // onChange fires multiple times (initial load, seed events, prune-persist).
+    // Find a coherent "pruned" call: the stale custom block reference is gone AND the three
+    // seed blocks are all still present.
+    const isCoherentPrunedCall = (serialized: string) => {
+      const blocks = JSON.parse(serialized)?.blocks?.blocks;
+      if (!Array.isArray(blocks)) return false;
+      const byType = new Map(blocks.map((b: Record<string, any>) => [b.type, b]));
+      const setup = byType.get("setup");
+      if (!setup || setup.inputs) return false; // setup must exist, and must no longer have the stale child
+      return byType.has("go") && byType.has("onclick");
+    };
+    await waitFor(() => {
+      const prunedCalls = onChange.mock.calls.filter(([serialized]) => isCoherentPrunedCall(serialized));
+      expect(prunedCalls.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("does not render workspace when toolbox is empty", () => {
+    render(
+      <StarterProgramEditor
+        customBlocks={[]}
+        starterBlocklyState=""
+        toolbox=""
+        onChange={jest.fn()}
+      />
+    );
+    expect(screen.getByTestId("starter-program-editor")).toBeInTheDocument();
+    expect(document.querySelector(".injectionDiv")).not.toBeInTheDocument();
+  });
+});

--- a/packages/blockly/src/components/starter-program-editor.tsx
+++ b/packages/blockly/src/components/starter-program-editor.tsx
@@ -79,15 +79,33 @@ export const StarterProgramEditor: React.FC<IProps> = ({ customBlocks, starterBl
     // Match runtime behavior: orphaned blocks should render disabled.
     workspace.addChangeListener(Events.disableOrphans);
 
-    const save = (event: Events.Abstract) => {
-      if (!saveEvents.includes(event.type)) return;
+    // Suppress saves while a block is being dragged. The RJSF re-render
+    // triggered by onChange interrupts Blockly's drag tracking, so we defer
+    // the save until the drag completes.
+    let needsSave = false;
+    const performSave = () => {
       const json = JSON.stringify(serialization.workspaces.save(workspace));
       onChangeRef.current(json);
     };
-    workspace.addChangeListener(save);
+    const listener = (event: Events.Abstract) => {
+      if (event.type === Events.BLOCK_DRAG) {
+        if (!(event as any).isStart && needsSave) {
+          needsSave = false;
+          performSave();
+        }
+        return;
+      }
+      if (!saveEvents.includes(event.type)) return;
+      if (workspace.isDragging()) {
+        needsSave = true;
+        return;
+      }
+      performSave();
+    };
+    workspace.addChangeListener(listener);
 
     return () => {
-      workspace.removeChangeListener(save);
+      workspace.removeChangeListener(listener);
       workspace.dispose();
       container.innerHTML = "";
     };

--- a/packages/blockly/src/components/starter-program-editor.tsx
+++ b/packages/blockly/src/components/starter-program-editor.tsx
@@ -50,31 +50,32 @@ export const StarterProgramEditor: React.FC<IProps> = ({ customBlocks, starterBl
 
     registerCustomBlocks(customBlocks, false);
     const enhancedToolbox = injectCustomBlocksIntoToolbox(toolbox, customBlocks);
-    let parsedToolbox;
-    try {
-      parsedToolbox = JSON.parse(enhancedToolbox);
-    } catch (e) {
-      console.warn("Starter program editor: could not parse toolbox JSON. Workspace not rendered.", e);
-      return;
-    }
-    const workspace = inject(container, {
-      readOnly: false, toolbox: parsedToolbox, trashcan: true
-    });
 
-    if (effectiveStarter) {
-      try {
-        serialization.workspaces.load(JSON.parse(effectiveStarter), workspace);
-      } catch {
+    let workspace: ReturnType<typeof inject>;
+    try {
+      const parsedToolbox = JSON.parse(enhancedToolbox);
+      workspace = inject(container, {
+        readOnly: false, toolbox: parsedToolbox, trashcan: true
+      });
+
+      if (effectiveStarter) {
+        try {
+          serialization.workspaces.load(JSON.parse(effectiveStarter), workspace);
+        } catch {
+          INITIAL_SEED_BLOCKS.forEach(b => serialization.blocks.append(b, workspace));
+        }
+      } else {
         INITIAL_SEED_BLOCKS.forEach(b => serialization.blocks.append(b, workspace));
       }
-    } else {
-      INITIAL_SEED_BLOCKS.forEach(b => serialization.blocks.append(b, workspace));
-    }
-    workspace.render();
+      workspace.render();
 
-    workspace.getTopBlocks(false).forEach(b => {
-      if ((SEED_BLOCK_TYPES as readonly string[]).includes(b.type)) b.setDeletable(false);
-    });
+      workspace.getTopBlocks(false).forEach(b => {
+        if ((SEED_BLOCK_TYPES as readonly string[]).includes(b.type)) b.setDeletable(false);
+      });
+    } catch (e) {
+      console.warn("Starter program editor: toolbox or starter state could not be loaded. Check that toolbox JSON is valid.", e);
+      return;
+    }
 
     // Match runtime behavior: orphaned blocks should render disabled.
     workspace.addChangeListener(Events.disableOrphans);

--- a/packages/blockly/src/components/starter-program-editor.tsx
+++ b/packages/blockly/src/components/starter-program-editor.tsx
@@ -1,0 +1,102 @@
+import { Events, inject, serialization } from "blockly";
+import React, { useEffect, useMemo, useRef } from "react";
+
+import "../blocks/block-registration";
+import { registerCustomBlocks } from "../blocks/block-factory";
+import { saveEvents } from "../utils/block-utils";
+import { buildValidTypeSet, pruneStarterState } from "../utils/starter-utils";
+import { injectCustomBlocksIntoToolbox } from "../utils/toolbox-utils";
+import { ICustomBlock, INITIAL_SEED_BLOCKS, SEED_BLOCK_TYPES } from "./types";
+
+import css from "./starter-program-editor.scss";
+
+interface IProps {
+  customBlocks: ICustomBlock[];
+  starterBlocklyState: string;
+  toolbox: string;
+  onChange: (value: string) => void;
+}
+
+export const StarterProgramEditor: React.FC<IProps> = ({ customBlocks, starterBlocklyState, toolbox, onChange }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Hold onChange in a ref so its identity (which RJSF is not guaranteed to keep stable across
+  // renders) does not force the injection effect to tear down and rebuild the workspace.
+  const onChangeRef = useRef(onChange);
+  useEffect(() => { onChangeRef.current = onChange; });
+
+  const effectiveStarter = useMemo(() => {
+    if (!starterBlocklyState) return "";
+    try {
+      const valid = buildValidTypeSet(customBlocks);
+      return pruneStarterState(starterBlocklyState, valid);
+    } catch {
+      console.warn("Failed to parse or prune starterBlocklyState, falling back to empty state");
+      return "";
+    }
+  }, [starterBlocklyState, customBlocks]);
+
+  // Persist pruned value back to form state when pruning removes stale block references.
+  useEffect(() => {
+    if (effectiveStarter && effectiveStarter !== starterBlocklyState) {
+      onChangeRef.current(effectiveStarter);
+    }
+  }, [effectiveStarter, starterBlocklyState]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !toolbox) return;
+    container.innerHTML = "";
+
+    registerCustomBlocks(customBlocks, false);
+    const enhancedToolbox = injectCustomBlocksIntoToolbox(toolbox, customBlocks);
+    let parsedToolbox;
+    try {
+      parsedToolbox = JSON.parse(enhancedToolbox);
+    } catch (e) {
+      console.warn("Starter program editor: could not parse toolbox JSON. Workspace not rendered.", e);
+      return;
+    }
+    const workspace = inject(container, {
+      readOnly: false, toolbox: parsedToolbox, trashcan: true
+    });
+
+    if (effectiveStarter) {
+      try {
+        serialization.workspaces.load(JSON.parse(effectiveStarter), workspace);
+      } catch {
+        INITIAL_SEED_BLOCKS.forEach(b => serialization.blocks.append(b, workspace));
+      }
+    } else {
+      INITIAL_SEED_BLOCKS.forEach(b => serialization.blocks.append(b, workspace));
+    }
+    workspace.render();
+
+    workspace.getTopBlocks(false).forEach(b => {
+      if ((SEED_BLOCK_TYPES as readonly string[]).includes(b.type)) b.setDeletable(false);
+    });
+
+    // Match runtime behavior: orphaned blocks should render disabled.
+    workspace.addChangeListener(Events.disableOrphans);
+
+    const save = (event: Events.Abstract) => {
+      if (!saveEvents.includes(event.type)) return;
+      const json = JSON.stringify(serialization.workspaces.save(workspace));
+      onChangeRef.current(json);
+    };
+    workspace.addChangeListener(save);
+
+    return () => {
+      workspace.removeChangeListener(save);
+      workspace.dispose();
+      container.innerHTML = "";
+    };
+  }, [toolbox, customBlocks, effectiveStarter]);
+
+  return (
+    <div className={css.starterEditor} data-testid="starter-program-editor">
+      <h4>Starter Program</h4>
+      <div className={css.starterEditor_container} ref={containerRef} />
+    </div>
+  );
+};

--- a/packages/blockly/src/components/types.ts
+++ b/packages/blockly/src/components/types.ts
@@ -24,6 +24,15 @@ export const REQUIRED_BLOCK_FIELDS = [
   "type"
 ] as const;
 
+export const SEED_BLOCK_TYPES = ["setup", "go", "onclick"] as const;
+export type SeedBlockType = typeof SEED_BLOCK_TYPES[number];
+
+export const INITIAL_SEED_BLOCKS: { deletable: false; type: SeedBlockType; x: number; y: number }[] = [
+  { deletable: false, type: "setup", x: 10, y: 10 },
+  { deletable: false, type: "go", x: 10, y: 80 },
+  { deletable: false, type: "onclick", x: 10, y: 150 }
+];
+
 export type CustomBlockType = typeof VALID_BLOCK_TYPES[number];
 export type ParameterKind = "select" | "number";
 
@@ -97,6 +106,7 @@ export interface IAuthoredState extends IAuthoringInteractiveMetadata {
   customBlocks?: ICustomBlock[];
   hint?: string;
   simulationCode: string;
+  starterBlocklyState?: string;
   toolbox: string;
   version: number;
 }
@@ -150,6 +160,7 @@ export const DefaultAuthoredState: Omit<Required<IAuthoredState>, "questionSubTy
   hint: "",
   questionType: "iframe_interactive",
   simulationCode: predatorPreyCode,
+  starterBlocklyState: "",
   toolbox: defaultToolbox ? JSON.stringify(defaultToolbox, null, 2) : "",
   version: 1
 };

--- a/packages/blockly/src/utils/starter-utils.test.ts
+++ b/packages/blockly/src/utils/starter-utils.test.ts
@@ -1,0 +1,146 @@
+import { BLOCKLY_BUILT_IN_BLOCKS } from "../blocks/blockly-built-in-registry";
+import { CUSTOM_BUILT_IN_BLOCKS } from "../blocks/custom-built-in-blocks";
+import { ICustomBlock, SEED_BLOCK_TYPES } from "../components/types";
+import { buildValidTypeSet, hasAuthoredStarterContent, parseStarterProgram, pruneStarterState } from "./starter-utils";
+
+const wrap = (blocks: Record<string, any>[]) => JSON.stringify({ blocks: { blocks } });
+
+const seedOnly = () => wrap(SEED_BLOCK_TYPES.map((type, i) => ({
+  type, x: 10, y: 10 + i * 70
+})));
+
+describe("starter-utils", () => {
+  describe("parseStarterProgram", () => {
+    it("returns null for undefined/empty", () => {
+      expect(parseStarterProgram(undefined)).toBeNull();
+      expect(parseStarterProgram("")).toBeNull();
+    });
+    it("returns null for malformed JSON", () => {
+      expect(parseStarterProgram("not json")).toBeNull();
+    });
+    it("returns null when structure is missing blocks.blocks", () => {
+      expect(parseStarterProgram(JSON.stringify({ foo: "bar" }))).toBeNull();
+      expect(parseStarterProgram(JSON.stringify({ blocks: {} }))).toBeNull();
+    });
+    it("returns the full program when well-formed", () => {
+      const blocks = [{ type: "setup" }];
+      expect(parseStarterProgram(wrap(blocks))).toEqual({ blocks: { blocks } });
+    });
+  });
+
+  describe("hasAuthoredStarterContent", () => {
+    it("returns false for null", () => {
+      expect(hasAuthoredStarterContent(null)).toBe(false);
+    });
+    it("returns false for undefined/empty input (via parseStarterProgram)", () => {
+      expect(hasAuthoredStarterContent(parseStarterProgram(undefined))).toBe(false);
+      expect(hasAuthoredStarterContent(parseStarterProgram(""))).toBe(false);
+    });
+    it("returns false for malformed JSON (via parseStarterProgram)", () => {
+      expect(hasAuthoredStarterContent(parseStarterProgram("not json"))).toBe(false);
+    });
+    it("returns false for seed-only content", () => {
+      expect(hasAuthoredStarterContent(parseStarterProgram(seedOnly()))).toBe(false);
+    });
+    it("returns true when a seed block has nested input content", () => {
+      const raw = wrap([
+        { type: "setup", inputs: { DO: { block: { type: "someChild" } } } }
+      ]);
+      expect(hasAuthoredStarterContent(parseStarterProgram(raw))).toBe(true);
+    });
+    it("returns true when a seed block has a next chain", () => {
+      const raw = wrap([
+        { type: "go", next: { block: { type: "someChild" } } }
+      ]);
+      expect(hasAuthoredStarterContent(parseStarterProgram(raw))).toBe(true);
+    });
+    it("returns true when a non-seed top block is present", () => {
+      const raw = wrap([{ type: "customBlock123" }]);
+      expect(hasAuthoredStarterContent(parseStarterProgram(raw))).toBe(true);
+    });
+  });
+
+  describe("buildValidTypeSet", () => {
+    it("includes seed types, built-ins, and custom block ids", () => {
+      const customBlocks: ICustomBlock[] = [
+        { id: "custom_1", name: "", category: "", color: "", type: "action", config: { canHaveChildren: false } }
+      ];
+      const set = buildValidTypeSet(customBlocks);
+      SEED_BLOCK_TYPES.forEach(t => expect(set.has(t)).toBe(true));
+      BLOCKLY_BUILT_IN_BLOCKS.forEach(b => expect(set.has(b.id)).toBe(true));
+      CUSTOM_BUILT_IN_BLOCKS.forEach(b => expect(set.has(b.id)).toBe(true));
+      expect(set.has("custom_1")).toBe(true);
+      expect(set.has("unknown_block_id")).toBe(false);
+    });
+  });
+
+  describe("pruneStarterState", () => {
+    const valid = new Set<string>([...SEED_BLOCK_TYPES, "ok"]);
+
+    it("leaves a valid-only state unchanged (structurally)", () => {
+      const raw = wrap([
+        { type: "setup", inputs: { DO: { block: { type: "ok" } } } }
+      ]);
+      const out = JSON.parse(pruneStarterState(raw, valid));
+      expect(out.blocks.blocks).toEqual([
+        { type: "setup", inputs: { DO: { block: { type: "ok" } } } }
+      ]);
+    });
+
+    it("drops an unknown top-level block but preserves siblings", () => {
+      const raw = wrap([
+        { type: "setup" },
+        { type: "gone" },
+        { type: "go" }
+      ]);
+      const out = JSON.parse(pruneStarterState(raw, valid));
+      expect(out.blocks.blocks.map((b: any) => b.type)).toEqual(["setup", "go"]);
+    });
+
+    it("drops an unknown inner block and removes the now-empty inputs key", () => {
+      const raw = wrap([
+        { type: "setup", inputs: { DO: { block: { type: "gone" } } } }
+      ]);
+      const out = JSON.parse(pruneStarterState(raw, valid));
+      expect(out.blocks.blocks[0].inputs).toBeUndefined();
+    });
+
+    it("preserves sibling inputs when one is pruned", () => {
+      const raw = wrap([
+        {
+          type: "setup",
+          inputs: {
+            A: { block: { type: "gone" } },
+            B: { block: { type: "ok" } }
+          }
+        }
+      ]);
+      const out = JSON.parse(pruneStarterState(raw, valid));
+      expect(out.blocks.blocks[0].inputs).toEqual({ B: { block: { type: "ok" } } });
+    });
+
+    it("drops the tail of a next chain after an unknown link", () => {
+      const raw = wrap([
+        {
+          type: "go",
+          next: {
+            block: {
+              type: "ok",
+              next: {
+                block: {
+                  type: "gone",
+                  next: { block: { type: "ok" } }
+                }
+              }
+            }
+          }
+        }
+      ]);
+      const out = JSON.parse(pruneStarterState(raw, valid));
+      const go = out.blocks.blocks[0];
+      expect(go.type).toBe("go");
+      expect(go.next.block.type).toBe("ok");
+      expect(go.next.block.next).toBeUndefined();
+    });
+  });
+});

--- a/packages/blockly/src/utils/starter-utils.ts
+++ b/packages/blockly/src/utils/starter-utils.ts
@@ -61,15 +61,14 @@ export function buildValidTypeSet(customBlocks: ICustomBlock[]): Set<string> {
  * that a starter program may still reference until the form is saved.
  */
 export function pruneStarterState(raw: string, validTypes: Set<string>): string {
-  const parsed = JSON.parse(raw);
-  const top: BlockState[] = parsed?.blocks?.blocks ?? [];
-  const prunedTop = top.map(b => pruneBlock(b, validTypes)).filter(Boolean);
+  const parsed: unknown = JSON.parse(raw);
+  if (!isStarterProgram(parsed)) return raw;
+  const prunedTop = parsed.blocks.blocks
+    .map(b => pruneBlock(b, validTypes))
+    .filter((block): block is BlockState => block !== null);
   return JSON.stringify({
     ...parsed,
-    blocks: {
-      ...(parsed?.blocks ?? {}),
-      blocks: prunedTop
-    }
+    blocks: { ...parsed.blocks, blocks: prunedTop }
   });
 }
 

--- a/packages/blockly/src/utils/starter-utils.ts
+++ b/packages/blockly/src/utils/starter-utils.ts
@@ -1,0 +1,110 @@
+import { serialization } from "blockly";
+import { BLOCKLY_BUILT_IN_BLOCKS } from "../blocks/blockly-built-in-registry";
+import { CUSTOM_BUILT_IN_BLOCKS } from "../blocks/custom-built-in-blocks";
+import { ICustomBlock, SEED_BLOCK_TYPES } from "../components/types";
+
+type BlockState = serialization.blocks.State;
+type ConnectionState = serialization.blocks.ConnectionState;
+type StarterProgram = { blocks: { blocks: BlockState[] } };
+
+const SEED_SET = new Set<string>(SEED_BLOCK_TYPES);
+
+function isStarterProgram(value: unknown): value is StarterProgram {
+  return Array.isArray((value as { blocks?: { blocks?: unknown } })?.blocks?.blocks);
+}
+
+/**
+ * Parses a serialized starter program into its in-memory shape, or returns null if the input
+ * is empty, malformed, or structurally invalid. The returned value can be passed directly
+ * to `serialization.workspaces.load` (after being narrowed by `hasAuthoredStarterContent`).
+ */
+export function parseStarterProgram(raw: string | undefined): StarterProgram | null {
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return isStarterProgram(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A starter counts as "authored" only when it contains at least one non-seed block, or a
+ * seed block with nested blocks.
+ */
+export function hasAuthoredStarterContent(program: StarterProgram | null): program is StarterProgram {
+  if (!program) return false;
+  return program.blocks.blocks.some(b => !SEED_SET.has(b.type) || blockHasChildren(b));
+}
+
+function blockHasChildren(block: BlockState): boolean {
+  if (block.inputs && Object.keys(block.inputs).length > 0) {
+    for (const input of Object.values(block.inputs)) {
+      if (input?.block || input?.shadow) return true;
+    }
+  }
+  if (block.next?.block) return true;
+  return false;
+}
+
+export function buildValidTypeSet(customBlocks: ICustomBlock[]): Set<string> {
+  const set = new Set<string>(SEED_BLOCK_TYPES);
+  BLOCKLY_BUILT_IN_BLOCKS.forEach(b => set.add(b.id));
+  CUSTOM_BUILT_IN_BLOCKS.forEach(b => set.add(b.id));
+  customBlocks.forEach(b => set.add(b.id));
+  return set;
+}
+
+/**
+ * Returns a serialized starter state with any blocks whose types are not in `validTypes`
+ * removed. Used to protect the authoring editor against deleted custom block definitions
+ * that a starter program may still reference until the form is saved.
+ */
+export function pruneStarterState(raw: string, validTypes: Set<string>): string {
+  const parsed = JSON.parse(raw);
+  const top: BlockState[] = parsed?.blocks?.blocks ?? [];
+  const prunedTop = top.map(b => pruneBlock(b, validTypes)).filter(Boolean);
+  return JSON.stringify({
+    ...parsed,
+    blocks: {
+      ...(parsed?.blocks ?? {}),
+      blocks: prunedTop
+    }
+  });
+}
+
+function pruneBlock(block: BlockState, valid: Set<string>): BlockState | null {
+  if (!valid.has(block.type)) return null;
+
+  const result: BlockState = { ...block };
+
+  if (block.inputs) {
+    const newInputs: Record<string, ConnectionState> = {};
+    for (const [key, input] of Object.entries(block.inputs)) {
+      const prunedBlock  = input.block  ? pruneBlock(input.block,  valid) : undefined;
+      const prunedShadow = input.shadow ? pruneBlock(input.shadow, valid) : undefined;
+      if (prunedBlock || prunedShadow) {
+        newInputs[key] = {
+          ...(prunedBlock && { block: prunedBlock }),
+          ...(prunedShadow && { shadow: prunedShadow })
+        };
+      }
+    }
+    if (Object.keys(newInputs).length) {
+      result.inputs = newInputs;
+    } else {
+      delete result.inputs;
+    }
+  }
+
+  if (block.next?.block) {
+    const prunedNext = pruneBlock(block.next.block, valid);
+    if (prunedNext) {
+      result.next = { block: prunedNext };
+    } else {
+      delete result.next;
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
[QI-135](https://concord-consortium.atlassian.net/browse/QI-135)

Adds a Starter Program authoring feature to the Blockly interactive, allowing authors to pre-populate the student workspace with blocks that appear on first load and when creating new models.

- Introduces a `StarterProgramEditor` component embedded in the authoring form as a full Blockly workspace where authors can arrange starter blocks
- Automatically prunes stale references to deleted custom blocks from the saved starter program, dropping the deleted block and any child blocks to avoid orphaned variable references
- Adds a `seedWorkspace` helper to the runtime that loads the authored starter (or falls back to the three default seed blocks), used on first load, File → New, and the empty-fallback of File → Delete
- Restores workspace content when `initWorkspace` re-runs due to dependency changes (e.g. toolbox or custom block edits), preventing the save listener from persisting blank state



[QI-135]: https://concord-consortium.atlassian.net/browse/QI-135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ