### PR TITLE
fix: Agent Sim canvas shrinks when recording stopped (QI-137)

### DIFF
--- a/packages/agent-simulation/src/components/agent-simulation.scss
+++ b/packages/agent-simulation/src/components/agent-simulation.scss
@@ -147,9 +147,8 @@
       position: absolute;
       top: 0;
       left: 0;
-      width: 450px;
-      height: 450px;
-      object-fit: contain;
+      transform-origin: left top;
+      transition: transform 0.2s ease-out;
     }
   }
 

--- a/packages/agent-simulation/src/components/agent-simulation.scss
+++ b/packages/agent-simulation/src/components/agent-simulation.scss
@@ -138,7 +138,7 @@
       position: relative;
     }
 
-    .simContainer {
+    .simContainer, .snapshot {
       transform-origin: left top;
       transition: transform 0.2s ease-out;
     }
@@ -147,8 +147,6 @@
       position: absolute;
       top: 0;
       left: 0;
-      transform-origin: left top;
-      transition: transform 0.2s ease-out;
     }
   }
 

--- a/packages/agent-simulation/src/components/agent-simulation.tsx
+++ b/packages/agent-simulation/src/components/agent-simulation.tsx
@@ -674,7 +674,7 @@ export const AgentSimulationComponent = ({
               src={currentRecording.snapshot}
               alt="Simulation snapshot"
               className={css.snapshot}
-              style={{ transform: `scale(${zoomLevel})` }}
+              style={{ height: gridHeight, transform: `scale(${zoomLevel})`, width: gridWidth }}
             />
           )}
           <ZoomControls


### PR DESCRIPTION
[QI-137](https://concord-consortium.atlassian.net/browse/QI-137)

Fixes an issue where Agent Sim recording snapshot images could be displayed smaller than the actual simulation.

- Replaces hard-coded `height` and `width` set for the snapshot in the stylesheet with inline values that match the canvas dimensions (`gridHeight`, `gridWidth`).
- Also adds a `transform-origin` and `transition` for the snapshot that matches what is set for `.simContainer` so the canvas and snapshot zoom animation is the same.

[QI-137]: https://concord-consortium.atlassian.net/browse/QI-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ