### PR TITLE
fix: blockly fields lose focus after each keystroke (QI-141)

### DIFF
--- a/packages/blockly/src/components/custom-block-form-parameters.tsx
+++ b/packages/blockly/src/components/custom-block-form-parameters.tsx
@@ -68,7 +68,7 @@ export const CustomBlockFormParameters: React.FC<IProps> = ({ parameters, onPara
       </div>
       <div>
         {parameters.map((p, i) => (
-          <div key={`${p.kind}-${p.name || ''}-${i}`} className={css.paramRow} data-testid={`param-row-${i}`}>
+          <div key={i} className={css.paramRow} data-testid={`param-row-${i}`}>
             <div className={css.paramHeader}>
               <span
                 className={css.paramType}


### PR DESCRIPTION
[QI-141](https://concord-consortium.atlassian.net/browse/QI-141)

In the Blockly authoring form's "Parameters" section for Action blocks, "Name" fields lose focus after each keystroke. This is because the parameter's name value (`p.name`) is part of the parameter row element's `key` value: ``key={`${p.kind}-${p.name || ''}-${i}`}``. So when the name changes, the row is re-rendered and focus is lost.

This fix sets the `key` value to simply the index (`i`). That provides the required uniqueness within the group, and is sufficient since there's no re-ordering of parameters allowed.

The buggy value-as-part-of-the-key pattern does not exist anywhere else in the Blockly code.

[QI-141]: https://concord-consortium.atlassian.net/browse/QI-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ