### PR TITLE
feat: add sample interval and max samples to agent sim [QI-165]

### DIFF
--- a/packages/agent-simulation/src/components/agent-simulation.test.tsx
+++ b/packages/agent-simulation/src/components/agent-simulation.test.tsx
@@ -1580,4 +1580,235 @@ describe("AgentSimulationComponent", () => {
       expect(playBtn).not.toBeDisabled();
     });
   });
+
+  describe("sample interval and max samples", () => {
+    let mockAdd: jest.Mock;
+    let mockPublish: jest.Mock;
+    let dateNowSpy: jest.SpyInstance | undefined;
+
+    // Returns the most-recently-registered afterTick — the visualization is recreated
+    // whenever the sim is reset (reset, new recording, code update), so we always want
+    // the latest call.
+    const getLatestAfterTick = (): (() => void) => {
+      const lastCall = mockVis.mock.calls[mockVis.mock.calls.length - 1];
+      return lastCall[1].afterTick as () => void;
+    };
+
+    const tickPublishes = () =>
+      mockPublish.mock.calls.filter(
+        ([msg]) =>
+          msg?.topic === "recording-tick" || msg?.topic === "simulation-tick"
+      );
+
+    beforeEach(() => {
+      mockAgentSimulation.widgets = [];
+      mockGlobals.values.mockReturnValue({ count: 5 });
+
+      mockAdd = jest.fn().mockResolvedValue(undefined);
+      mockPublish = jest.fn();
+      mockCreatePubSubChannel.mockReturnValue({
+        publish: mockPublish,
+        subscribe: jest.fn(),
+        unsubscribe: jest.fn(),
+      });
+      mockUseObjectStorage.mockReturnValue({
+        add: mockAdd,
+        list: jest.fn(),
+        monitor: jest.fn(),
+        read: jest.fn(),
+        readMetadata: jest.fn(() => Promise.resolve({})),
+        readData: jest.fn(),
+        readDataItem: jest.fn(),
+      });
+    });
+
+    afterEach(() => {
+      if (dateNowSpy) {
+        dateNowSpy.mockRestore();
+        dateNowSpy = undefined;
+      }
+    });
+
+    it("samples every tick when sampleIntervalMs and maxSamples are unset (default behavior)", async () => {
+      render(
+        <ObjectStorageProvider config={objectStorageConfig}>
+          <AgentSimulationComponent
+            authoredState={defaultAuthoredState}
+            interactiveState={defaultInteractiveState}
+            setInteractiveState={mockSetInteractiveState}
+          />
+        </ObjectStorageProvider>
+      );
+      await act(async () => { await new Promise(resolve => setTimeout(resolve, 10)); });
+
+      const afterTick = getLatestAfterTick();
+      act(() => { afterTick(); afterTick(); afterTick(); });
+
+      const ticks = tickPublishes();
+      expect(ticks).toHaveLength(3);
+      // Sequential simulation tick values, all simulation-tick (no current recording).
+      expect(ticks.map(c => c[0].values.tick)).toEqual([0, 1, 2]);
+      expect(ticks.every(c => c[0].topic === "simulation-tick")).toBe(true);
+    });
+
+    it("throttles samples per sampleIntervalMs and stamps each sample with its sim-tick number", async () => {
+      let now = 1_000_000;
+      dateNowSpy = jest.spyOn(Date, "now").mockImplementation(() => now);
+
+      const authored: IAuthoredState = { ...defaultAuthoredState, sampleIntervalMs: 500 };
+
+      render(
+        <ObjectStorageProvider config={objectStorageConfig}>
+          <AgentSimulationComponent
+            authoredState={authored}
+            interactiveState={defaultInteractiveState}
+            setInteractiveState={mockSetInteractiveState}
+          />
+        </ObjectStorageProvider>
+      );
+      await act(async () => { await new Promise(resolve => setTimeout(resolve, 10)); });
+
+      const afterTick = getLatestAfterTick();
+      // Sim ticks 0..5 at the wall-clock times below. Only ticks whose elapsed-since-last-sample
+      // is >= 500ms produce a published sample, but `tick` keeps counting on every call.
+      const schedule = [
+        { advanceMs: 0,   expectSample: true,  expectedTick: 0 }, // first tick — always sampled
+        { advanceMs: 200, expectSample: false                  }, // 200ms < 500ms → skip
+        { advanceMs: 299, expectSample: false                  }, // 499ms total < 500ms → skip
+        { advanceMs: 1,   expectSample: true,  expectedTick: 3 }, // exactly 500ms → sample
+        { advanceMs: 200, expectSample: false                  }, // 200ms since last → skip
+        { advanceMs: 301, expectSample: true,  expectedTick: 5 }, // 501ms since last → sample
+      ];
+      for (const step of schedule) {
+        now += step.advanceMs;
+        act(() => { afterTick(); });
+      }
+
+      const ticks = tickPublishes();
+      const expectedSamples = schedule.filter(s => s.expectSample);
+      expect(ticks).toHaveLength(expectedSamples.length);
+      expect(ticks.map(c => c[0].values.tick)).toEqual(expectedSamples.map(s => s.expectedTick));
+    });
+
+    it("auto-stops the recording when maxSamples is reached and saves exactly that many rows", async () => {
+      const authored: IAuthoredState = { ...defaultAuthoredState, maxSamples: 3 };
+
+      render(
+        <ObjectStorageProvider config={objectStorageConfig}>
+          <AgentSimulationComponent
+            authoredState={authored}
+            interactiveState={defaultInteractiveState}
+            setInteractiveState={mockSetInteractiveState}
+          />
+        </ObjectStorageProvider>
+      );
+      await act(async () => { await new Promise(resolve => setTimeout(resolve, 10)); });
+
+      // Enter recording mode + press play. The play handler resets the sim because the
+      // recording has no startedAt yet, so afterTick is re-registered against the new vis.
+      fireEvent.click(screen.getByText("New"));
+      await act(async () => { await new Promise(resolve => setTimeout(resolve, 10)); });
+      fireEvent.click(screen.getByTestId("play-pause-button"));
+      await act(async () => { await new Promise(resolve => setTimeout(resolve, 10)); });
+
+      mockSimulation.pause.mockClear();
+
+      // Fire the cap-many ticks → 3rd tick triggers auto-stop via setTimeout(0).
+      const afterTick = getLatestAfterTick();
+      act(() => { afterTick(); afterTick(); afterTick(); });
+
+      // Flush the setTimeout(0) + the async save() chain (getThumbnail + add()).
+      await act(async () => { await new Promise(resolve => setTimeout(resolve, 30)); });
+
+      // Any further ticks (from the sim before pause() fully takes effect) must NOT add
+      // another sample — the cap must be exact.
+      act(() => { afterTick(); afterTick(); });
+
+      // Sim got paused.
+      expect(mockSimulation.pause).toHaveBeenCalledWith(true);
+
+      // recording-stopped PubSub fired (reuses existing topic — no new event).
+      const stopped = mockPublish.mock.calls.find(([m]) => m?.topic === "recording-stopped");
+      expect(stopped).toBeDefined();
+
+      // Exactly 3 recording-tick events were published (no over-shoot).
+      const recordingTicks = mockPublish.mock.calls.filter(
+        ([m]) => m?.topic === "recording-tick"
+      );
+      expect(recordingTicks).toHaveLength(3);
+
+      // Save was called and the data table holds exactly 3 rows.
+      expect(mockAdd).toHaveBeenCalledTimes(1);
+      const storedObject = mockAdd.mock.calls[0][0];
+      const dataTableEntry = Object.entries(storedObject.metadata.items).find(
+        ([, item]: [string, any]) => item.subType === "simulation-tick-data"
+      );
+      expect(dataTableEntry).toBeDefined();
+      const [dataTableId] = dataTableEntry as [string, any];
+      expect(storedObject.data[dataTableId].rows).toHaveLength(3);
+    });
+
+    it("does not auto-stop in free-play (non-recording) mode even when sample count exceeds maxSamples", async () => {
+      const authored: IAuthoredState = { ...defaultAuthoredState, maxSamples: 2 };
+
+      render(
+        <ObjectStorageProvider config={objectStorageConfig}>
+          <AgentSimulationComponent
+            authoredState={authored}
+            interactiveState={defaultInteractiveState}
+            setInteractiveState={mockSetInteractiveState}
+          />
+        </ObjectStorageProvider>
+      );
+      await act(async () => { await new Promise(resolve => setTimeout(resolve, 10)); });
+
+      // Play, but don't enter a recording.
+      fireEvent.click(screen.getByTestId("play-pause-button"));
+      await act(async () => { await new Promise(resolve => setTimeout(resolve, 10)); });
+
+      mockSimulation.pause.mockClear();
+      mockAdd.mockClear();
+
+      const afterTick = getLatestAfterTick();
+      act(() => { afterTick(); afterTick(); afterTick(); afterTick(); });
+      await act(async () => { await new Promise(resolve => setTimeout(resolve, 10)); });
+
+      // No auto-stop: sim still running, save not called.
+      expect(mockSimulation.pause).not.toHaveBeenCalledWith(true);
+      expect(mockAdd).not.toHaveBeenCalled();
+
+      // All four samples emitted as simulation-tick (free-play topic).
+      const simTicks = mockPublish.mock.calls.filter(([m]) => m?.topic === "simulation-tick");
+      expect(simTicks).toHaveLength(4);
+    });
+
+    it("interval throttle applies in free-play mode (simulation-tick) too", async () => {
+      let now = 2_000_000;
+      dateNowSpy = jest.spyOn(Date, "now").mockImplementation(() => now);
+
+      const authored: IAuthoredState = { ...defaultAuthoredState, sampleIntervalMs: 250 };
+
+      render(
+        <ObjectStorageProvider config={objectStorageConfig}>
+          <AgentSimulationComponent
+            authoredState={authored}
+            interactiveState={defaultInteractiveState}
+            setInteractiveState={mockSetInteractiveState}
+          />
+        </ObjectStorageProvider>
+      );
+      await act(async () => { await new Promise(resolve => setTimeout(resolve, 10)); });
+
+      const afterTick = getLatestAfterTick();
+      // 4 ticks 100ms apart → only ticks at t=0 and t=300 (interval elapsed) sample.
+      act(() => { afterTick(); });          // sample (first)
+      now += 100; act(() => { afterTick(); }); // skip (100<250)
+      now += 100; act(() => { afterTick(); }); // skip (200<250)
+      now += 100; act(() => { afterTick(); }); // sample (300>=250)
+
+      const simTicks = mockPublish.mock.calls.filter(([m]) => m?.topic === "simulation-tick");
+      expect(simTicks).toHaveLength(2);
+      expect(simTicks.map(c => c[0].values.tick)).toEqual([0, 3]);
+    });
+  });
 });

--- a/packages/agent-simulation/src/components/agent-simulation.test.tsx
+++ b/packages/agent-simulation/src/components/agent-simulation.test.tsx
@@ -1717,12 +1717,13 @@ describe("AgentSimulationComponent", () => {
       const afterTick = getLatestAfterTick();
       act(() => { afterTick(); afterTick(); afterTick(); });
 
+      // Any further ticks that fire BEFORE the setTimeout(0) flushes (the "gap"
+      // between cap-hit and pause taking effect) must NOT add another sample —
+      // the cap must be exact. Synchronous act() calls run before pending timers.
+      act(() => { afterTick(); afterTick(); });
+
       // Flush the setTimeout(0) + the async save() chain (getThumbnail + add()).
       await act(async () => { await new Promise(resolve => setTimeout(resolve, 30)); });
-
-      // Any further ticks (from the sim before pause() fully takes effect) must NOT add
-      // another sample — the cap must be exact.
-      act(() => { afterTick(); afterTick(); });
 
       // Sim got paused.
       expect(mockSimulation.pause).toHaveBeenCalledWith(true);
@@ -1731,7 +1732,7 @@ describe("AgentSimulationComponent", () => {
       const stopped = mockPublish.mock.calls.find(([m]) => m?.topic === "recording-stopped");
       expect(stopped).toBeDefined();
 
-      // Exactly 3 recording-tick events were published (no over-shoot).
+      // Exactly 3 recording-tick events were published (no over-shoot from gap ticks).
       const recordingTicks = mockPublish.mock.calls.filter(
         ([m]) => m?.topic === "recording-tick"
       );
@@ -1746,6 +1747,46 @@ describe("AgentSimulationComponent", () => {
       expect(dataTableEntry).toBeDefined();
       const [dataTableId] = dataTableEntry as [string, any];
       expect(storedObject.data[dataTableId].rows).toHaveLength(3);
+    });
+
+    it("releases the max-samples guard after the deferred auto-stop runs, so later ticks can publish again", async () => {
+      // Regression for a save-failure path bug: maxSamplesAutoStoppedRef was only cleared
+      // when the sim was rebuilt, but save() rejection deselects the recording WITHOUT
+      // rebuilding the sim. A stale `true` guard would silently drop every subsequent
+      // tick in free-play. The guard must be released once handlePlayPause has paused
+      // the sim — at that point the gap it was protecting against has closed.
+      const authored: IAuthoredState = { ...defaultAuthoredState, maxSamples: 2 };
+
+      render(
+        <ObjectStorageProvider config={objectStorageConfig}>
+          <AgentSimulationComponent
+            authoredState={authored}
+            interactiveState={defaultInteractiveState}
+            setInteractiveState={mockSetInteractiveState}
+          />
+        </ObjectStorageProvider>
+      );
+      await act(async () => { await new Promise(resolve => setTimeout(resolve, 10)); });
+
+      fireEvent.click(screen.getByText("New"));
+      await act(async () => { await new Promise(resolve => setTimeout(resolve, 10)); });
+      fireEvent.click(screen.getByTestId("play-pause-button"));
+      await act(async () => { await new Promise(resolve => setTimeout(resolve, 10)); });
+
+      const afterTick = getLatestAfterTick();
+      // Hit the cap → auto-stop is queued.
+      act(() => { afterTick(); afterTick(); });
+      // Flush setTimeout(0) → handlePlayPause runs → guard released. Also lets
+      // save() complete and clear tickDataRef.
+      await act(async () => { await new Promise(resolve => setTimeout(resolve, 30)); });
+
+      mockPublish.mockClear();
+
+      // The next direct tick must publish. Before the guard was released after
+      // handlePlayPause, this would have been silently dropped by the early-return
+      // at the top of afterTick.
+      act(() => { afterTick(); });
+      expect(mockPublish.mock.calls.length).toBeGreaterThan(0);
     });
 
     it("does not auto-stop in free-play (non-recording) mode even when sample count exceeds maxSamples", async () => {

--- a/packages/agent-simulation/src/components/agent-simulation.tsx
+++ b/packages/agent-simulation/src/components/agent-simulation.tsx
@@ -68,7 +68,7 @@ const SAVE_TIMEOUT_MS = 30_000;
 export const AgentSimulationComponent = ({
   authoredState, interactiveState, setInteractiveState, report
 }: IProps) => {
-  const { code, gridHeight, gridStep, gridWidth, maxRecordingTime } = authoredState;
+  const { code, gridHeight, gridStep, gridWidth, maxRecordingTime, sampleIntervalMs, maxSamples } = authoredState;
   // The blockly code we're using, which doesn't get updated until the user accepts newer code
   const [blocklyCode, _setBlocklyCode] = useState<string>(interactiveState?.blocklyCode || "");
   const [recordings, _setRecordings] = useState<IRecordings>(interactiveState?.recordings || []);
@@ -134,6 +134,20 @@ export const AgentSimulationComponent = ({
   const tickDataRef = useRef<{ [key: string]: any }[]>([]);
   const handlePlayPauseRef: React.MutableRefObject<() => void> = useRef(() => undefined);
   const inRecordingModeRef = useRef(false);
+  // Wall-clock timestamp (Date.now) of the most recent sample taken in this run of the
+  // simulation. null = no sample yet, so the next tick is always sampled. Reset whenever
+  // the simulation is recreated (reset / new-recording / code update).
+  const lastSampleAtRef = useRef<number | null>(null);
+  // Set true once the max-samples cap has triggered an auto-stop, so we don't try to
+  // auto-stop a second time before handlePlayPause has had a chance to pause the sim.
+  const maxSamplesAutoStoppedRef = useRef(false);
+  // Mirrors authoredState.sampleIntervalMs / maxSamples for use inside afterTick (which
+  // closes over the values from the render that built the visualization). Updated on
+  // every render so authoring-time changes take effect on the next tick.
+  const sampleIntervalMsRef = useRef<number | undefined>(sampleIntervalMs);
+  sampleIntervalMsRef.current = sampleIntervalMs;
+  const maxSamplesRef = useRef<number | undefined>(maxSamples);
+  maxSamplesRef.current = maxSamples;
 
   const timeFormatter = useMemo(() => {
     return new Intl.DateTimeFormat(undefined, {
@@ -385,16 +399,58 @@ export const AgentSimulationComponent = ({
     // save the globals at each tick for recording
     let tick = 0;
     tickDataRef.current = [];
+    lastSampleAtRef.current = null;
+    maxSamplesAutoStoppedRef.current = false;
     const afterTick = () => {
-      if (simRef.current) {
-        const { globals } = simRef.current;
-        const values = { tick, ...globals.values() };
+      if (!simRef.current) {
+        return;
+      }
+      // Hard stop after maxSamples auto-stop is queued: any sim ticks that fire
+      // before the setTimeout(0) below has run handlePlayPause must not add to the
+      // recording, or the saved row count would exceed `maxSamples`. Reset in
+      // resetSimulationWithPreservedGlobals when the sim is rebuilt.
+      if (maxSamplesAutoStoppedRef.current) {
+        return;
+      }
+      const { globals } = simRef.current;
+      const currentTick = tick;
+      tick++;
 
-        tickDataRef.current.push(values);
-        tick++;
+      // Throttle samples by wall-clock interval when sampleIntervalMs is set.
+      // The first tick after a sim (re)create is always sampled because
+      // lastSampleAtRef starts null. `tick` keeps counting every simulation
+      // step so downstream consumers can read sim-time from the sample.
+      const intervalMs = sampleIntervalMsRef.current;
+      const now = Date.now();
+      if (
+        intervalMs !== undefined &&
+        lastSampleAtRef.current !== null &&
+        now - lastSampleAtRef.current < intervalMs
+      ) {
+        return;
+      }
+      lastSampleAtRef.current = now;
 
-        const topic = inRecordingModeRef.current ? "recording-tick" : "simulation-tick";
-        recordingChannelRef.current?.publish({topic, values});
+      const values = { tick: currentTick, ...globals.values() };
+      tickDataRef.current.push(values);
+
+      const topic = inRecordingModeRef.current ? "recording-tick" : "simulation-tick";
+      recordingChannelRef.current?.publish({topic, values});
+
+      // When maxSamples is set and we've just recorded the Nth sample of a recording,
+      // stop the recording via the same path as the maxRecordingTime cutoff. Defer to
+      // setTimeout(0) so handlePlayPause runs after this tick callback returns, matching
+      // the existing maxRecordingTime cutoff which is invoked from a setInterval — keeps
+      // the sim.pause + save() chain out of the afterTick stack.
+      const cap = maxSamplesRef.current;
+      if (
+        inRecordingModeRef.current &&
+        !maxSamplesAutoStoppedRef.current &&
+        cap !== undefined &&
+        tickDataRef.current.length >= cap
+      ) {
+        maxSamplesAutoStoppedRef.current = true;
+        setTimeout(() => handlePlayPauseRef.current(), 0);
       }
     };
 

--- a/packages/agent-simulation/src/components/agent-simulation.tsx
+++ b/packages/agent-simulation/src/components/agent-simulation.tsx
@@ -450,7 +450,15 @@ export const AgentSimulationComponent = ({
         tickDataRef.current.length >= cap
       ) {
         maxSamplesAutoStoppedRef.current = true;
-        setTimeout(() => handlePlayPauseRef.current(), 0);
+        setTimeout(() => {
+          handlePlayPauseRef.current();
+          // Release the guard once handlePlayPause has paused the sim. The guard
+          // only needs to cover the gap between cap-hit and the deferred pause;
+          // leaving it set across that boundary blocks future ticks on paths
+          // that don't rebuild the sim (e.g. save-failure deselects the
+          // recording without resetting, or the user re-enters free-play).
+          maxSamplesAutoStoppedRef.current = false;
+        }, 0);
       }
     };
 

--- a/packages/agent-simulation/src/components/app.tsx
+++ b/packages/agent-simulation/src/components/app.tsx
@@ -52,6 +52,16 @@ const baseAuthoringProps = {
         maximum: maxMaxRecordingTime,
         default: defaultMaxRecordingTime
       },
+      sampleIntervalMs: {
+        title: "Sample Interval (ms, optional)",
+        type: "number",
+        minimum: 1
+      },
+      maxSamples: {
+        title: "Maximum Samples per Recording (optional)",
+        type: "number",
+        minimum: 1
+      },
       code: {
         title: "Simulation Code",
         type: "string",
@@ -104,6 +114,12 @@ const baseAuthoringProps = {
       "ui:widget": "updown"
     },
     maxRecordingTime: {
+      "ui:widget": "updown"
+    },
+    sampleIntervalMs: {
+      "ui:widget": "updown"
+    },
+    maxSamples: {
       "ui:widget": "updown"
     },
     code: {

--- a/packages/agent-simulation/src/components/types.ts
+++ b/packages/agent-simulation/src/components/types.ts
@@ -17,6 +17,8 @@ export interface IAuthoredState extends IAuthoringInteractiveMetadata {
   hint?: string;
   version: number;
   maxRecordingTime: number;
+  sampleIntervalMs?: number;
+  maxSamples?: number;
 }
 
 export interface IInteractiveState extends IRuntimeInteractiveMetadata {
@@ -28,7 +30,7 @@ export interface IInteractiveState extends IRuntimeInteractiveMetadata {
   recordings: IRecordings;
 }
 
-export const DefaultAuthoredState: Omit<Required<IAuthoredState>, "questionSubType"|"required"|"prompt"> = {
+export const DefaultAuthoredState: Omit<Required<IAuthoredState>, "questionSubType"|"required"|"prompt"|"sampleIntervalMs"|"maxSamples"> = {
   code: "",
   dataSourceInteractive: "",
   gridHeight: 450,


### PR DESCRIPTION
Add two optional authoring options that throttle when samples are added to the recording's tick data and emitted as PubSub recording-tick / simulation-tick events:

- sampleIntervalMs: only sample once per N ms of wall-clock time
- maxSamples: auto-stop the recording after N samples are taken

Both default to today's behavior (sample every tick, capped only by maxRecordingTime). Together they let authors keep recordings under the Firestore 1MB per-document limit surfaced by QI-163.