### PR TITLE
feat: bust cache on codap.concord.org iframe URLs [QI-171]

### DIFF
--- a/packages/full-screen/src/authoring-configs/codap-url-utils.test.ts
+++ b/packages/full-screen/src/authoring-configs/codap-url-utils.test.ts
@@ -604,7 +604,7 @@ describe("addCacheBustParam", () => {
     expect(addCacheBustParam("not a url")).toBe("not a url");
   });
 
-  it("returns empty/undefined input unchanged", () => {
+  it("returns an empty string input unchanged", () => {
     expect(addCacheBustParam("")).toBe("");
   });
 });

--- a/packages/full-screen/src/authoring-configs/codap-url-utils.test.ts
+++ b/packages/full-screen/src/authoring-configs/codap-url-utils.test.ts
@@ -7,7 +7,8 @@ import {
   getFilteredPassthroughParams,
   formatPassthroughParamsDisplay,
   buildCodapUrl,
-  parseCodapUrlToFormData
+  parseCodapUrlToFormData,
+  addCacheBustParam
 } from "./codap-url-utils";
 import { codapInitialData } from "./codap-schema";
 
@@ -557,6 +558,54 @@ describe("parseCodapUrlToFormData", () => {
     const result = parseCodapUrlToFormData(url);
     // Should still extract params from the inner URL
     expect(result.codapSourceDocumentUrl).toBe(url);
+  });
+});
+
+// ============================================================================
+// addCacheBustParam
+// ============================================================================
+
+describe("addCacheBustParam", () => {
+  it("appends _bustCache=true to a codap.concord.org URL", () => {
+    const url = "https://codap.concord.org/app/static/dg/en/cert/index.html?interactiveApi";
+    const result = addCacheBustParam(url);
+    const parsed = new URL(result);
+    expect(parsed.searchParams.get("_bustCache")).toBe("true");
+    // Existing params are preserved.
+    expect(parsed.searchParams.has("interactiveApi")).toBe(true);
+  });
+
+  it("preserves the hash fragment on shared-hash URLs", () => {
+    const url = "https://codap.concord.org/app/static/dg/en/cert/index.html#shared=https%3A%2F%2Fcfm-shared.concord.org%2Fdoc123";
+    const result = addCacheBustParam(url);
+    const parsed = new URL(result);
+    expect(parsed.searchParams.get("_bustCache")).toBe("true");
+    expect(parsed.hash).toBe("#shared=https%3A%2F%2Fcfm-shared.concord.org%2Fdoc123");
+  });
+
+  it("does not modify non-CODAP URLs", () => {
+    const url = "https://example.com/app?foo=bar";
+    expect(addCacheBustParam(url)).toBe(url);
+  });
+
+  it("does not modify URLs for other concord.org subdomains", () => {
+    const url = "https://models-resources.concord.org/app?foo=bar";
+    expect(addCacheBustParam(url)).toBe(url);
+  });
+
+  it("overwrites an existing _bustCache value rather than duplicating it", () => {
+    const url = "https://codap.concord.org/app?_bustCache=false";
+    const result = addCacheBustParam(url);
+    const parsed = new URL(result);
+    expect(parsed.searchParams.getAll("_bustCache")).toEqual(["true"]);
+  });
+
+  it("returns invalid URL strings unchanged", () => {
+    expect(addCacheBustParam("not a url")).toBe("not a url");
+  });
+
+  it("returns empty/undefined input unchanged", () => {
+    expect(addCacheBustParam("")).toBe("");
   });
 });
 /* eslint-enable @typescript-eslint/no-non-null-assertion */

--- a/packages/full-screen/src/authoring-configs/codap-url-utils.ts
+++ b/packages/full-screen/src/authoring-configs/codap-url-utils.ts
@@ -142,6 +142,34 @@ export const parseCodapUrl = (inputUrl: string): IParsedCodapUrl => {
   }
 };
 
+// Host whose URLs should receive the cache-busting parameter.
+const CODAP_HOST = "codap.concord.org";
+// Cache-busting query parameter appended to CODAP URLs loaded in the iframe.
+const BUST_CACHE_PARAM = "_bustCache";
+
+/**
+ * Appends a `_bustCache=true` cache-busting query parameter to codap.concord.org
+ * URLs so the browser/CDN does not serve a stale copy of CODAP. URLs for any other
+ * host (or strings that aren't valid URLs) are returned unchanged. Existing query
+ * params and the hash/fragment are preserved.
+ */
+export const addCacheBustParam = (inputUrl: string): string => {
+  if (!inputUrl) {
+    return inputUrl;
+  }
+  try {
+    const url = new URL(inputUrl);
+    if (url.hostname !== CODAP_HOST) {
+      return inputUrl;
+    }
+    url.searchParams.set(BUST_CACHE_PARAM, "true");
+    return url.toString();
+  } catch (e) {
+    // Not a parseable URL - leave it untouched.
+    return inputUrl;
+  }
+};
+
 /**
  * Parses custom params string into URLSearchParams.
  */

--- a/packages/full-screen/src/components/runtime.test.tsx
+++ b/packages/full-screen/src/components/runtime.test.tsx
@@ -234,6 +234,33 @@ describe("Runtime", () => {
     expect(lastIframeRuntimeProps.url).toBe("https://fallback.example.com/app");
   });
 
+  it("appends the cache-busting param to a codap.concord.org query param URL", () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const queryString = require("query-string");
+    (queryString.parse as jest.Mock).mockReturnValueOnce({
+      wrappedInteractive: "https://codap.concord.org/app?interactiveApi&documentId=doc456"
+    });
+
+    const authoredState: IAuthoredState = {
+      version: 1,
+      questionType: "iframe_interactive"
+      // no wrappedInteractiveUrl - falls back to the query param URL
+    };
+    mount(
+      <Runtime
+        authoredState={authoredState}
+        interactiveState={defaultInteractiveState}
+        setInteractiveState={jest.fn()}
+      />
+    );
+    expect(lastIframeRuntimeProps).not.toBeNull();
+    // The query-param fallback path also gets the cache-busting param for codap URLs.
+    const parsed = new URL(lastIframeRuntimeProps.url);
+    expect(parsed.hostname).toBe("codap.concord.org");
+    expect(parsed.searchParams.get("documentId")).toBe("doc456");
+    expect(parsed.searchParams.get("_bustCache")).toBe("true");
+  });
+
   it("prefers authoredState URL over query param URL", () => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const queryString = require("query-string");

--- a/packages/full-screen/src/components/runtime.test.tsx
+++ b/packages/full-screen/src/components/runtime.test.tsx
@@ -75,7 +75,11 @@ describe("Runtime", () => {
       />
     );
     expect(lastIframeRuntimeProps).not.toBeNull();
-    expect(lastIframeRuntimeProps.url).toBe(defaultAuthoredState.wrappedInteractiveUrl);
+    // The codap.concord.org URL is loaded with a cache-busting param appended.
+    const parsed = new URL(lastIframeRuntimeProps.url);
+    expect(parsed.origin + parsed.pathname).toBe("https://codap.concord.org/app");
+    expect(parsed.searchParams.get("documentId")).toBe("doc123");
+    expect(parsed.searchParams.get("_bustCache")).toBe("true");
   });
 
   it("shows message when no URL is configured", () => {
@@ -244,6 +248,10 @@ describe("Runtime", () => {
         setInteractiveState={jest.fn()}
       />
     );
-    expect(lastIframeRuntimeProps.url).toBe(defaultAuthoredState.wrappedInteractiveUrl);
+    // authoredState's codap URL is used (with cache-busting param), not the query param URL.
+    const parsed = new URL(lastIframeRuntimeProps.url);
+    expect(parsed.hostname).toBe("codap.concord.org");
+    expect(parsed.searchParams.get("documentId")).toBe("doc123");
+    expect(parsed.searchParams.get("_bustCache")).toBe("true");
   });
 });

--- a/packages/full-screen/src/components/runtime.tsx
+++ b/packages/full-screen/src/components/runtime.tsx
@@ -12,6 +12,7 @@ import {
   useInitMessage
 } from "@concord-consortium/lara-interactive-api";
 import { IAuthoredState, IInteractiveState } from "./types";
+import { addCacheBustParam } from "../authoring-configs/codap-url-utils";
 
 const screenfull = _screenfull.isEnabled ? _screenfull : undefined;
 
@@ -147,12 +148,16 @@ export const Runtime: React.FC<IRuntimeQuestionComponentProps<IAuthoredState, II
     return <div>Wrapped interactive is not configured.</div>;
   }
 
+  // Append a cache-busting param so CODAP is always loaded fresh from codap.concord.org.
+  // Non-CODAP URLs are returned unchanged.
+  const iframeUrl = addCacheBustParam(url);
+
   // Use setNotScaling() when fullscreen is disabled, otherwise use setScaling()
   const iframeStyle = fullscreenDisabled ? setNotScaling() : setScaling();
 
   return (
     <>
-      <IframeRuntime url={url}
+      <IframeRuntime url={iframeUrl}
                      iframeStyling={iframeStyle}
                      interactiveState={interactiveState}
                      setInteractiveState={setInteractiveState || (() => null)}


### PR DESCRIPTION
Append a `_bustCache=true` query param to codap.concord.org URLs loaded in the wrapped (full-screen) interactive iframe so a fresh copy of CODAP is requested instead of a stale cached one.

- add addCacheBustParam() helper that only touches codap.concord.org URLs and preserves existing query params and the hash fragment
- apply it at runtime to both the authored URL and the query-param fallback, so existing authored content is covered too

---

This was needed after the v2 to v3 flip as Activity Player was loading the v2 urls from disk cache as there was no `Cache-Control` header being returned from the v2 index.html url, only an `E-Tag` header.  This new `_bustCache` param should cause AP to load the url from CloudFront which will then cause the v2 -> v3 url rewrite to run.