### PR TITLE
chore: update drawing-tool for toolbar accessibility [QI-155]

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "question-interactives",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "question-interactives",
-      "version": "1.26.0",
+      "version": "1.27.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -2880,6 +2880,50 @@
       "license": "MIT",
       "dependencies": {
         "pixi.js": "^6.3.0"
+      }
+    },
+    "node_modules/@concord-consortium/drawing-tool": {
+      "version": "2.4.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/drawing-tool/-/drawing-tool-2.4.0-pre.0.tgz",
+      "integrity": "sha512-bHyAAydF/lldbhvuJtVgReXxIry1xO9gXcm82rcFmMHZMUf1Pk39X4/ZQZOnkYy7/JC5Wgs0afk/WDRNvtjbFw==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter2": "~0.4.14",
+        "fabric": "3.6.3",
+        "hammerjs": "~2.0.4",
+        "query-string": "^4.3.2",
+        "uuid": "^8.3.2"
+      },
+      "peerDependencies": {
+        "jquery": ">= 2.1.3"
+      }
+    },
+    "node_modules/@concord-consortium/drawing-tool/node_modules/eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha512-K7J4xq5xAD5jHsGM5ReWXRTFa3JRGofHiMcVgQ8PRwgWxzjHpMWCIzsmyf60+mh8KLsqYPcjUMa0AC4hd6lPyQ==",
+      "license": "MIT"
+    },
+    "node_modules/@concord-consortium/drawing-tool/node_modules/query-string": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+      "integrity": "sha512-O2XLNDBIg1DnTOa+2XrIwSiXEV8h2KImXUnjhhn2+UsvZ+Es2uyd5CCRTNQlDGbzUQOW3aYCBx9rVA6dzsiY7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@concord-consortium/drawing-tool/node_modules/strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@concord-consortium/dynamic-text": {
@@ -13142,49 +13186,9 @@
       "resolved": "packages/drag-and-drop",
       "link": true
     },
-    "node_modules/drawing-tool": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/drawing-tool/-/drawing-tool-2.3.2.tgz",
-      "integrity": "sha512-SElU+v8iE8Vxph8gcZIXPYBNpgCAF9BdTpKsAkswooeoyK5OLkACVrfaD7EPZTqlu2qcmWc9X10YstDfskqitA==",
-      "dependencies": {
-        "eventemitter2": "~0.4.14",
-        "fabric": "3.6.3",
-        "hammerjs": "~2.0.4",
-        "query-string": "^4.3.2",
-        "uuid": "^8.3.2"
-      },
-      "peerDependencies": {
-        "jquery": ">= 2.1.3"
-      }
-    },
     "node_modules/drawing-tool-interactive": {
       "resolved": "packages/drawing-tool",
       "link": true
-    },
-    "node_modules/drawing-tool/node_modules/eventemitter2": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
-      "integrity": "sha512-K7J4xq5xAD5jHsGM5ReWXRTFa3JRGofHiMcVgQ8PRwgWxzjHpMWCIzsmyf60+mh8KLsqYPcjUMa0AC4hd6lPyQ=="
-    },
-    "node_modules/drawing-tool/node_modules/query-string": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-      "integrity": "sha512-O2XLNDBIg1DnTOa+2XrIwSiXEV8h2KImXUnjhhn2+UsvZ+Es2uyd5CCRTNQlDGbzUQOW3aYCBx9rVA6dzsiY7Q==",
-      "dependencies": {
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/drawing-tool/node_modules/strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -31897,13 +31901,13 @@
       "version": "1.27.0",
       "license": "MIT",
       "dependencies": {
+        "@concord-consortium/drawing-tool": "2.4.0-pre.0",
         "@concord-consortium/dynamic-text": "^1.0.6",
         "@concord-consortium/lara-interactive-api": "1.13.0",
         "@concord-consortium/question-interactives-helpers": "^1.27.0",
         "@concord-consortium/text-decorator": "^1.0.2",
         "@rjsf/utils": "^5.0.1",
         "classnames": "^2.3.1",
-        "drawing-tool": "^2.3.2",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "uuid": "^8.3.0"
@@ -35091,6 +35095,39 @@
       "integrity": "sha512-uDrwxfYBIhNL9t+78UaBYQXHSflj1kaGcdrTMjP7AEO8No/npTLll/yW8es7o2uh+9EdwRJk7t9QGzRtChUnFA==",
       "requires": {
         "pixi.js": "^6.3.0"
+      }
+    },
+    "@concord-consortium/drawing-tool": {
+      "version": "2.4.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/drawing-tool/-/drawing-tool-2.4.0-pre.0.tgz",
+      "integrity": "sha512-bHyAAydF/lldbhvuJtVgReXxIry1xO9gXcm82rcFmMHZMUf1Pk39X4/ZQZOnkYy7/JC5Wgs0afk/WDRNvtjbFw==",
+      "requires": {
+        "eventemitter2": "~0.4.14",
+        "fabric": "3.6.3",
+        "hammerjs": "~2.0.4",
+        "query-string": "^4.3.2",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "eventemitter2": {
+          "version": "0.4.14",
+          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+          "integrity": "sha512-K7J4xq5xAD5jHsGM5ReWXRTFa3JRGofHiMcVgQ8PRwgWxzjHpMWCIzsmyf60+mh8KLsqYPcjUMa0AC4hd6lPyQ=="
+        },
+        "query-string": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+          "integrity": "sha512-O2XLNDBIg1DnTOa+2XrIwSiXEV8h2KImXUnjhhn2+UsvZ+Es2uyd5CCRTNQlDGbzUQOW3aYCBx9rVA6dzsiY7Q==",
+          "requires": {
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+          "integrity": "sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ=="
+        }
       }
     },
     "@concord-consortium/dynamic-text": {
@@ -43547,42 +43584,10 @@
         "webpack-dev-server": "^4.7.4"
       }
     },
-    "drawing-tool": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/drawing-tool/-/drawing-tool-2.3.2.tgz",
-      "integrity": "sha512-SElU+v8iE8Vxph8gcZIXPYBNpgCAF9BdTpKsAkswooeoyK5OLkACVrfaD7EPZTqlu2qcmWc9X10YstDfskqitA==",
-      "requires": {
-        "eventemitter2": "~0.4.14",
-        "fabric": "3.6.3",
-        "hammerjs": "~2.0.4",
-        "query-string": "^4.3.2",
-        "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "eventemitter2": {
-          "version": "0.4.14",
-          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
-          "integrity": "sha512-K7J4xq5xAD5jHsGM5ReWXRTFa3JRGofHiMcVgQ8PRwgWxzjHpMWCIzsmyf60+mh8KLsqYPcjUMa0AC4hd6lPyQ=="
-        },
-        "query-string": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-          "integrity": "sha512-O2XLNDBIg1DnTOa+2XrIwSiXEV8h2KImXUnjhhn2+UsvZ+Es2uyd5CCRTNQlDGbzUQOW3aYCBx9rVA6dzsiY7Q==",
-          "requires": {
-            "object-assign": "^4.1.0",
-            "strict-uri-encode": "^1.0.0"
-          }
-        },
-        "strict-uri-encode": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-          "integrity": "sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ=="
-        }
-      }
-    },
     "drawing-tool-interactive": {
       "version": "file:packages/drawing-tool",
       "requires": {
+        "@concord-consortium/drawing-tool": "2.4.0-pre.0",
         "@concord-consortium/dynamic-text": "^1.0.6",
         "@concord-consortium/lara-interactive-api": "1.13.0",
         "@concord-consortium/question-interactives-helpers": "^1.27.0",
@@ -43607,7 +43612,6 @@
         "autoprefixer": "^9.8.8",
         "classnames": "^2.3.1",
         "css-loader": "^4.3.0",
-        "drawing-tool": "^2.3.2",
         "enzyme": "^3.11.0",
         "eslint": "^8.29.0",
         "eslint-plugin-eslint-comments": "^3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2883,9 +2883,9 @@
       }
     },
     "node_modules/@concord-consortium/drawing-tool": {
-      "version": "2.4.0-pre.0",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/drawing-tool/-/drawing-tool-2.4.0-pre.0.tgz",
-      "integrity": "sha512-bHyAAydF/lldbhvuJtVgReXxIry1xO9gXcm82rcFmMHZMUf1Pk39X4/ZQZOnkYy7/JC5Wgs0afk/WDRNvtjbFw==",
+      "version": "2.4.0-pre.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/drawing-tool/-/drawing-tool-2.4.0-pre.1.tgz",
+      "integrity": "sha512-ct4Hw2ArFw/t5YzxAGHl7+TKnp0QqXlMOzioSeBEEF3FFi1LX3gSl+eeMhh+DiyZIfoM8qDF3gtqg/1xCWQWwQ==",
       "license": "MIT",
       "dependencies": {
         "eventemitter2": "~0.4.14",
@@ -31901,7 +31901,7 @@
       "version": "1.27.0",
       "license": "MIT",
       "dependencies": {
-        "@concord-consortium/drawing-tool": "2.4.0-pre.0",
+        "@concord-consortium/drawing-tool": "2.4.0-pre.1",
         "@concord-consortium/dynamic-text": "^1.0.6",
         "@concord-consortium/lara-interactive-api": "1.13.0",
         "@concord-consortium/question-interactives-helpers": "^1.27.0",
@@ -35098,9 +35098,9 @@
       }
     },
     "@concord-consortium/drawing-tool": {
-      "version": "2.4.0-pre.0",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/drawing-tool/-/drawing-tool-2.4.0-pre.0.tgz",
-      "integrity": "sha512-bHyAAydF/lldbhvuJtVgReXxIry1xO9gXcm82rcFmMHZMUf1Pk39X4/ZQZOnkYy7/JC5Wgs0afk/WDRNvtjbFw==",
+      "version": "2.4.0-pre.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/drawing-tool/-/drawing-tool-2.4.0-pre.1.tgz",
+      "integrity": "sha512-ct4Hw2ArFw/t5YzxAGHl7+TKnp0QqXlMOzioSeBEEF3FFi1LX3gSl+eeMhh+DiyZIfoM8qDF3gtqg/1xCWQWwQ==",
       "requires": {
         "eventemitter2": "~0.4.14",
         "fabric": "3.6.3",
@@ -43587,7 +43587,7 @@
     "drawing-tool-interactive": {
       "version": "file:packages/drawing-tool",
       "requires": {
-        "@concord-consortium/drawing-tool": "2.4.0-pre.0",
+        "@concord-consortium/drawing-tool": "2.4.0-pre.1",
         "@concord-consortium/dynamic-text": "^1.0.6",
         "@concord-consortium/lara-interactive-api": "1.13.0",
         "@concord-consortium/question-interactives-helpers": "^1.27.0",

--- a/packages/drawing-tool/package.json
+++ b/packages/drawing-tool/package.json
@@ -111,7 +111,7 @@
     "webpack-dev-server": "^4.7.4"
   },
   "dependencies": {
-    "@concord-consortium/drawing-tool": "2.4.0-pre.0",
+    "@concord-consortium/drawing-tool": "2.4.0-pre.1",
     "@concord-consortium/dynamic-text": "^1.0.6",
     "@concord-consortium/lara-interactive-api": "1.13.0",
     "@concord-consortium/question-interactives-helpers": "^1.27.0",

--- a/packages/drawing-tool/package.json
+++ b/packages/drawing-tool/package.json
@@ -111,13 +111,13 @@
     "webpack-dev-server": "^4.7.4"
   },
   "dependencies": {
+    "@concord-consortium/drawing-tool": "2.4.0-pre.0",
     "@concord-consortium/dynamic-text": "^1.0.6",
     "@concord-consortium/lara-interactive-api": "1.13.0",
     "@concord-consortium/question-interactives-helpers": "^1.27.0",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@rjsf/utils": "^5.0.1",
     "classnames": "^2.3.1",
-    "drawing-tool": "^2.3.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "uuid": "^8.3.0"

--- a/packages/drawing-tool/src/components/drawing-tool.test.tsx
+++ b/packages/drawing-tool/src/components/drawing-tool.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { mount } from "enzyme";
 import { DrawingTool, LARA_IMAGE_PROXY } from "./drawing-tool";
 
-jest.mock("drawing-tool", () => class DrawingToolLib {
+jest.mock("@concord-consortium/drawing-tool", () => class DrawingToolLib {
   on = jest.fn();
   resetHistory = jest.fn();
   save = jest.fn();

--- a/packages/drawing-tool/src/components/drawing-tool.tsx
+++ b/packages/drawing-tool/src/components/drawing-tool.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 import classNames from "classnames";
-import DrawingToolLib from "drawing-tool";
+import DrawingToolLib from "@concord-consortium/drawing-tool";
 import { getAnswerType, IGenericAuthoredState, IGenericInteractiveState, StampCollection } from "./types";
 import predefinedStampCollections from "./stamp-collections";
-import 'drawing-tool/dist/drawing-tool.css';
+import "@concord-consortium/drawing-tool/dist/drawing-tool.css";
 import { shouldUseLARAImgProxy } from "@concord-consortium/question-interactives-helpers/src/hooks/use-cors-image-error-check";
 import css from "./runtime.scss";
 

--- a/packages/drawing-tool/src/components/runtime.tsx
+++ b/packages/drawing-tool/src/components/runtime.tsx
@@ -13,7 +13,7 @@ import { UploadBackground } from "./upload-background";
 import { TakeSnapshot } from "./take-snapshot";
 import { DrawingTool } from "./drawing-tool";
 
-import 'drawing-tool/dist/drawing-tool.css';
+import '@concord-consortium/drawing-tool/dist/drawing-tool.css';
 import css from "./runtime.scss";
 
 export interface IProps {

--- a/packages/drawing-tool/src/components/take-snapshot.tsx
+++ b/packages/drawing-tool/src/components/take-snapshot.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import 'drawing-tool/dist/drawing-tool.css';
+import '@concord-consortium/drawing-tool/dist/drawing-tool.css';
 import css from "./runtime.scss";
 import cssHelpers from "@concord-consortium/question-interactives-helpers/src/styles/helpers.scss";
 import SnapshotIcon from "@concord-consortium/question-interactives-helpers/src/icons/snapshot-icon.svg";

--- a/packages/drawing-tool/src/components/upload-background.tsx
+++ b/packages/drawing-tool/src/components/upload-background.tsx
@@ -4,7 +4,7 @@ import { copyImageToS3, copyLocalImageToS3 } from "@concord-consortium/question-
 import { getAnswerType, IGenericAuthoredState, IGenericInteractiveState } from "./types";
 import classnames from "classnames";
 
-import 'drawing-tool/dist/drawing-tool.css';
+import '@concord-consortium/drawing-tool/dist/drawing-tool.css';
 import css from "./runtime.scss";
 import cssHelpers from "@concord-consortium/question-interactives-helpers/src/styles/helpers.scss";
 

--- a/packages/drawing-tool/src/global.d.ts
+++ b/packages/drawing-tool/src/global.d.ts
@@ -1,5 +1,5 @@
 declare module "*.scss";
 declare module "*.svg";
 declare module "shutterbug";
-declare module "drawing-tool";
+declare module "@concord-consortium/drawing-tool";
 declare module "iframe-phone";

--- a/packages/fill-in-the-blank/src/global.d.ts
+++ b/packages/fill-in-the-blank/src/global.d.ts
@@ -1,4 +1,3 @@
 declare module "*.scss";
 declare module "*.svg";
 declare module "shutterbug";
-declare module "drawing-tool";

--- a/packages/full-screen/src/global.d.ts
+++ b/packages/full-screen/src/global.d.ts
@@ -1,5 +1,4 @@
 declare module "*.scss";
 declare module "*.svg";
 declare module "shutterbug";
-declare module "drawing-tool";
 declare module "iframe-phone";

--- a/packages/graph/src/global.d.ts
+++ b/packages/graph/src/global.d.ts
@@ -1,4 +1,3 @@
 declare module "*.scss";
 declare module "*.svg";
 declare module "shutterbug";
-declare module "drawing-tool";

--- a/packages/helpers/src/global.d.ts
+++ b/packages/helpers/src/global.d.ts
@@ -2,5 +2,4 @@ declare module "*.scss";
 declare module "*.svg";
 declare module "shutterbug";
 declare module "iframe-phone";
-declare module "drawing-tool";
 declare module "react-dnd-preview";

--- a/packages/image-question/src/global.d.ts
+++ b/packages/image-question/src/global.d.ts
@@ -1,4 +1,4 @@
 declare module "*.scss";
 declare module "*.svg";
 declare module "shutterbug";
-declare module "drawing-tool";
+declare module "@concord-consortium/drawing-tool";

--- a/packages/image/src/global.d.ts
+++ b/packages/image/src/global.d.ts
@@ -1,4 +1,3 @@
 declare module "*.scss";
 declare module "*.svg";
 declare module "shutterbug";
-declare module "drawing-tool";

--- a/packages/labbook/src/global.d.ts
+++ b/packages/labbook/src/global.d.ts
@@ -2,5 +2,5 @@ declare module "*.png";
 declare module "*.svg";
 declare module "*.scss";
 declare module "shutterbug";
-declare module "drawing-tool";
+declare module "@concord-consortium/drawing-tool";
 declare module "iframe-phone";

--- a/packages/multiple-choice-alerts/src/global.d.ts
+++ b/packages/multiple-choice-alerts/src/global.d.ts
@@ -1,4 +1,3 @@
 declare module "*.scss";
 declare module "*.svg";
 declare module "shutterbug";
-declare module "drawing-tool";

--- a/packages/multiple-choice/src/global.d.ts
+++ b/packages/multiple-choice/src/global.d.ts
@@ -1,4 +1,3 @@
 declare module "*.scss";
 declare module "*.svg";
 declare module "shutterbug";
-declare module "drawing-tool";

--- a/packages/score-bot/src/global.d.ts
+++ b/packages/score-bot/src/global.d.ts
@@ -1,4 +1,3 @@
 declare module "*.scss";
 declare module "*.svg";
 declare module "shutterbug";
-declare module "drawing-tool";

--- a/packages/tests-e2e/e2e/drawing-tool.test.js
+++ b/packages/tests-e2e/e2e/drawing-tool.test.js
@@ -36,7 +36,7 @@ context("Test Image interactive", () => {
       });
 
       cy.getIframeBody().find(".dt-container").should('exist');
-      cy.getIframeBody().find('[title="Stamp tool (click and hold to show available categories)"]').should('not.exist');
+      cy.getIframeBody().find('[aria-label="Stamp tool"]').should('not.exist');
     });
 
     it("renders drawing tool with stamps", () => {
@@ -45,7 +45,7 @@ context("Test Image interactive", () => {
         authoredState: authoredStateWithStamps
       });
 
-      cy.getIframeBody().find('[title="Stamp tool (click and hold to show available categories)"]').should('exist');
+      cy.getIframeBody().find('[aria-label="Stamp tool"]').should('exist');
     });
   });
 });

--- a/packages/video-player/src/global.d.ts
+++ b/packages/video-player/src/global.d.ts
@@ -1,4 +1,3 @@
 declare module "*.scss";
 declare module "*.svg";
 declare module "shutterbug";
-declare module "drawing-tool";


### PR DESCRIPTION
## Summary
- Switches the `drawing-tool-interactive` package from the unscoped `drawing-tool@^2.3.2` to the scoped `@concord-consortium/drawing-tool@2.4.0-pre.0`, which is the prerelease carrying the toolbar accessibility work from [QI-155](https://concord-consortium.atlassian.net/browse/QI-155) ("Drawing Tool: Make toolbar navigation keyboard accessible").
- Updates the JS, CSS, jest mock, and `global.d.ts` references in `drawing-tool`, `image-question`, and `labbook` to the new package name.
- Removes dead ``declare module \"drawing-tool\"`` lines from nine packages that never imported the library.

## Links
- https://activity-player.concord.org/branch/master/index.html?activity=sample-activity-all-question-interactives&override.qi=toolbar-accessibility  you can test this branch in the activity player. The activity has examples of all of the interactives that are updated. Note that this is the master branch of the activity player so it doesn't have any focus trap support in the dialog that comes up for the image question.

## Test plan
- [x] `npx jest` passes in `packages/drawing-tool` (38/38), `packages/image-question` (13/13), and `packages/labbook` (18/18)
- [x] `npm run build` succeeds in `packages/drawing-tool`, `packages/image-question`, and `packages/labbook`
- [x] Smoke-test the drawing tool, image-question, and labbook interactives in a browser and confirm the new toolbar accessibility behavior (Tab in/out, ↑/↓ between buttons, Enter/Space to activate, palette navigation, Esc to close)
- [x] Verify QI-155 acceptance criteria against the running interactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[QI-155]: https://concord-consortium.atlassian.net/browse/QI-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ