### PR TITLE
fix: open response input border color (QI-162)

### DIFF
--- a/packages/helpers/src/components/base-app.scss
+++ b/packages/helpers/src/components/base-app.scss
@@ -8,7 +8,7 @@ html {
   @include ap-styles;
 
   textarea {
-    border: 1px solid #ccc;
+    border: 1px solid #949494;
     border-radius: 8px;
     width: 100%;
     padding: 16px;

--- a/packages/open-response/src/components/runtime.scss
+++ b/packages/open-response/src/components/runtime.scss
@@ -48,7 +48,7 @@
 
       .controls {
         align-items: center;
-        border: solid 1px #ccc;
+        border: solid 1px #949494;
         border-radius: 8px;
         display: flex;
         margin-left: 5px;


### PR DESCRIPTION
[QI-162](https://concord-consortium.atlassian.net/browse/QI-162)

Updates the Open Response input field border color from `#CCCCCC` to `#949494` to meet the WCAG 1.4.11 minimum 3:1 contrast requirement for UI components, so users with low vision or color-perception challenges can reliably locate form fields.

## Changes

- `base-app.scss` — Updated the shared `.runtime textarea` border to `#949494`. This is the rule that styles the Open Response input field (it has no border styling of its own).
- `open-response/runtime.scss` — Updated the audio/voice-typing controls border to `#949494` to match, keeping the input area visually consistent when audio/voice typing is enabled.

## Scope / impact

The `base-app.scss` rule is shared across all interactives that render a `<textarea>` inside the runtime/report wrapper. In practice this also darkens the Score Bot input border, which is a beneficial, intentional change aligned with the broader goal of improving accessibility across question interactives. Labbook (its textarea uses `border: none` with a separate wrapper border) and all authoring form textareas are unaffected.

[QI-162]: https://concord-consortium.atlassian.net/browse/QI-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ