### PR TITLE
feat: programmatic labels for fill-in-the-blank (QI-153)

### DIFF
--- a/packages/fill-in-the-blank/src/components/runtime.test.tsx
+++ b/packages/fill-in-the-blank/src/components/runtime.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { fireEvent, render } from "@testing-library/react";
-import { Runtime, replaceBlanksWithInputs, replaceBlanksWithValues } from "./runtime";
+import { Runtime, blankContextId, getBlankAriaLabel, getBlankLabelContext, getPromptContextDescription, replaceBlanksWithInputs, replaceBlanksWithValues } from "./runtime";
 import { IAuthoredState, IInteractiveState } from "./types";
 import { DynamicTextTester } from "@concord-consortium/question-interactives-helpers/src/utilities/dynamic-text-tester";
 
@@ -34,7 +34,7 @@ describe("Runtime", () => {
 
   it("renders prompt and inputs", () => {
     const { container, getByText } = render(<DynamicTextTester><Runtime authoredState={authoredState} /></DynamicTextTester>);
-    expect(getByText("Test prompt with", { exact: false })).toBeDefined();
+    expect(getByText("Test prompt with", { exact: false, selector: "p" })).toBeDefined();
     const inputs = container.querySelectorAll("input");
     expect(inputs.length).toBe(2);
     expect(inputs[0].id).toBe("[blank-1]");
@@ -85,10 +85,36 @@ describe("Runtime", () => {
     });
   });
 
+  it("gives each input a concise positional aria-label", () => {
+    const { container } = render(<DynamicTextTester><Runtime authoredState={authoredState} /></DynamicTextTester>);
+    const inputs = container.querySelectorAll("input");
+    expect(inputs[0].getAttribute("aria-label")).toBe("Blank 1 of 2");
+    expect(inputs[1].getAttribute("aria-label")).toBe("Blank 2 of 2");
+  });
+
+  it("describes each input with a hidden, shared full-prompt context element", () => {
+    const { container } = render(<DynamicTextTester><Runtime authoredState={authoredState} /></DynamicTextTester>);
+    const inputs = container.querySelectorAll("input");
+    // every input points at the same context element
+    expect(inputs[0].getAttribute("aria-describedby")).toBe(blankContextId);
+    expect(inputs[1].getAttribute("aria-describedby")).toBe(blankContextId);
+    // the referenced element exists, is hidden, and holds the full prompt text
+    const context = container.querySelector(`#${blankContextId}`) as HTMLElement;
+    expect(context).not.toBeNull();
+    expect(context.hidden).toBe(true);
+    expect(context.textContent).toBe("Full text: Test prompt with blank and blank.");
+  });
+
+  it("does not render the context element when the prompt has no blanks", () => {
+    const noBlanks: IAuthoredState = { version: 1, questionType: "iframe_interactive", prompt: "<p>No blanks here.</p>" };
+    const { container } = render(<DynamicTextTester><Runtime authoredState={noBlanks} /></DynamicTextTester>);
+    expect(container.querySelector(`#${blankContextId}`)).toBeNull();
+  });
+
   describe("report mode", () => {
     it("renders prompt and *disabled* inputs", () => {
       const { container, getByText } = render(<DynamicTextTester><Runtime authoredState={authoredState} report={true} /></DynamicTextTester>);
-      expect(getByText("Test prompt with", { exact: false })).toBeDefined();
+      expect(getByText("Test prompt with", { exact: false, selector: "p" })).toBeDefined();
       const inputs = container.querySelectorAll("input");
       expect(inputs.length).toEqual(2);
       expect(inputs[0].disabled).toEqual(true);
@@ -112,6 +138,47 @@ describe("replaceBlanksWithValues helper", () => {
                     responses: interactiveState.blanks
                   });
     expect(result).toEqual("<p>Test prompt with [ Test response ] and [  ].</p>");
+  });
+});
+
+describe("getBlankLabelContext helper", () => {
+  it("strips HTML and reads blank tokens as the word 'blank'", () => {
+    expect(getBlankLabelContext("<p>Test prompt with [blank-1] and [blank-2].</p>"))
+      .toBe("Test prompt with blank and blank.");
+  });
+
+  it("handles an empty prompt", () => {
+    expect(getBlankLabelContext("")).toBe("");
+  });
+});
+
+describe("getBlankAriaLabel helper", () => {
+  const prompt = "<p>Test prompt with [blank-1] and [blank-2].</p>";
+
+  it("returns the blank's position when there are multiple blanks", () => {
+    expect(getBlankAriaLabel(prompt, "[blank-1]")).toBe("Blank 1 of 2");
+    expect(getBlankAriaLabel(prompt, "[blank-2]")).toBe("Blank 2 of 2");
+  });
+
+  it("derives position from prompt order, not the id", () => {
+    const reordered = "<p>[blank-2] comes before [blank-1].</p>";
+    expect(getBlankAriaLabel(reordered, "[blank-2]")).toBe("Blank 1 of 2");
+    expect(getBlankAriaLabel(reordered, "[blank-1]")).toBe("Blank 2 of 2");
+  });
+
+  it("omits the count when there is only one blank", () => {
+    expect(getBlankAriaLabel("<p>There is one [blank-1].</p>", "[blank-1]")).toBe("Blank");
+  });
+
+  it("falls back to a generic label when the blankId is not in the prompt", () => {
+    expect(getBlankAriaLabel(prompt, "[blank-3]")).toBe("Blank");
+  });
+});
+
+describe("getPromptContextDescription helper", () => {
+  it("prefixes the plain-text prompt with a 'Full text:' label", () => {
+    expect(getPromptContextDescription("<p>Test prompt with [blank-1] and [blank-2].</p>"))
+      .toBe("Full text: Test prompt with blank and blank.");
   });
 });
 

--- a/packages/fill-in-the-blank/src/components/runtime.tsx
+++ b/packages/fill-in-the-blank/src/components/runtime.tsx
@@ -43,6 +43,38 @@ export const replaceBlanksWithInputs = (prompt: string) => {
   return prompt.replace(blankRegexp, blankId => `<input id="${blankId}"/>`);
 };
 
+const blankWord = "blank";
+
+// The id of the visually-hidden element that supplies the full prompt text as
+// an accessible description shared by every blank input (see getPromptContextDescription).
+export const blankContextId = "fill-in-the-blank-prompt-context";
+
+// Plain-text version of the prompt suitable for a screen reader: HTML removed
+// and each blank token read aloud as the word "blank".
+export const getBlankLabelContext = (prompt: string) =>
+  striptags(prompt)
+    .replace(blankRegexp, blankWord)
+    .replace(/\s+/g, " ")
+    .trim();
+
+// Concise accessible name for the input that fills `blankId`: just its position.
+// The surrounding prose supplies context when read linearly (browse mode), so
+// the name stays short to avoid duplicating that text on every field.
+export const getBlankAriaLabel = (prompt: string, blankId: string) => {
+  const orderedIds: string[] = prompt.match(blankRegexp) || [];
+  const total = orderedIds.length;
+  const position = orderedIds.indexOf(blankId) + 1;
+  // Inputs are generated from the prompt's own tokens, so position is always
+  // >= 1 in practice; fall back gracefully if a caller passes an unknown id.
+  if (position === 0) return "Blank";
+  return total > 1 ? `Blank ${position} of ${total}` : "Blank";
+};
+
+// Accessible description (announced on focus) giving the full prompt as context.
+// This is needed because focus mode skips the prose around an inline input.
+export const getPromptContextDescription = (prompt: string) =>
+  `Full text: ${getBlankLabelContext(prompt)}`;
+
 export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, report }) => {
   const decorateOptions = useGlossaryDecoration();
   const readOnly = !!(report || (authoredState.required && interactiveState?.submitted));
@@ -83,6 +115,8 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
         const _swallowClicks = (event: React.MouseEvent<HTMLInputElement>) => event.stopPropagation();
         return (
           <input id={blankId} type="text"
+            aria-label={getBlankAriaLabel(authoredState.prompt || "", blankId)}
+            aria-describedby={blankContextId}
             className={getInputClass(report, userInfo?.response, authorInfo?.matchTerm)}
             value={userInfo?.response || ""}
             size={authorInfo?.size || defaultBlankSize}
@@ -96,12 +130,18 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     }
   };
 
-  const htmlContents = replaceBlanksWithInputs(authoredState.prompt || "");
+  const promptText = authoredState.prompt || "";
+  const hasBlanks = (promptText.match(blankRegexp) || []).length > 0;
+  const htmlContents = replaceBlanksWithInputs(promptText);
   return (
     <div className="fill-in-the-blank">
       <DecorateChildren decorateOptions={decorateOptions}>
         <DynamicText>{renderHTML(htmlContents, replaceInputs)}</DynamicText>
       </DecorateChildren>
+      {/* Hidden context shared by all blanks via aria-describedby. Uses `hidden`
+          (not a visually-hidden class) so it is not re-read during linear/browse
+          reading, only resolved as each input's description on focus. */}
+      { hasBlanks && <span id={blankContextId} hidden>{getPromptContextDescription(promptText)}</span> }
     </div>
   );
 };


### PR DESCRIPTION
[QI-153](https://concord-consortium.atlassian.net/browse/QI-153)

Screen readers previously couldn't identify the input fields in the Fill In The Blank interactive — the inline <input> elements had no accessible name, so navigating to one announced only "edit text." This adds a programmatic label and on-focus context to every blank, satisfying the accessibility audit finding  and WCAG name/role/value expectations.

## Approach

Each blank gets two ARIA hooks:

- `aria-label` — a concise positional name: "Blank 1 of 2", "Blank 2 of 2", … (or just "Blank" when there's only one). The position is derived from the blank's order of appearance in the prompt, not its author-assigned ID, so [blank-fruit]/[blank-meat] still announce as "Blank 1 of 2" / "Blank 2 of 2."
- `aria-describedby` — points every input at a single shared, hidden element holding the full prompt text (HTML stripped, blank tokens read as the word "blank"), e.g. Full text: Every blank has a blank.

The context element uses the HTML hidden attribute (display:none) rather than a visually-hidden/sr-only class. This is deliberate: a visually-hidden element would be read inline during browse/say-all reading, duplicating the prompt on every field; a hidden element is not re-read during linear reading but is still resolved as each input's description on focus — exactly when the surrounding prose would otherwise be skipped.

How it reads:

- Browse / say-all: "Every — blank 1 of 2, edit — has a — blank 2 of 2, edit." (clean, no echo)
- Tab / focus: "Blank 1 of 2, edit, Full text: Every blank has a blank." (context on demand)

The correct answer (matchTerm) is never included in any label. No visible UI changes. No authoring changes (author-supplied labels were considered and deliberately left out of scope).

## Changes
- `packages/fill-in-the-blank/src/components/runtime.tsx` — new exported helpers `getBlankAriaLabel`, `getBlankLabelContext`, `getPromptContextDescription`, and `blankContextId`; `aria-label` and `aria-describedby` on the rendered input; the hidden context element (rendered only when the prompt contains blanks).
- `packages/fill-in-the-blank/src/components/runtime.test.tsx` — coverage for the positional label, order-not-ID positioning, the single-blank case, the `aria-describedby` wiring, and the hidden context element's content/hidden state.

[QI-153]: https://concord-consortium.atlassian.net/browse/QI-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ