### PR TITLE
fix: carousel nav button color contrast (QI-147)

### DIFF
--- a/packages/carousel/src/components/runtime.scss
+++ b/packages/carousel/src/components/runtime.scss
@@ -6,7 +6,7 @@
   // shared palette — (1) assess which existing --cc-* values in helpers.scss should be
   // updated for sufficient contrast, and (2) decide if any of these local tokens should be
   // promoted into helpers.scss so other interactives can reuse them.
-  --cc-carousel-nav: #0093b0;          // active/highlight nav buttons & arrows — brand PMS 3145 C, ≥3:1 on white (WCAG 1.4.11)
+  --cc-carousel-nav: #0093b0;          // default (resting) color for nav dots & prev/next arrows — brand PMS 3145 C, ≥3:1 on white (WCAG 1.4.11)
   --cc-carousel-nav-hover: #007c8b;    // nav button hover — unchanged; already ~4.93:1 on white (WCAG 1.4.11)
   --cc-carousel-nav-disabled: #767676; // disabled prev/next arrows — ≥3:1 on white (WCAG 1.4.11)
 }

--- a/packages/carousel/src/components/runtime.scss
+++ b/packages/carousel/src/components/runtime.scss
@@ -1,5 +1,16 @@
 @import "@concord-consortium/question-interactives-helpers/src/styles/helpers";
 
+:root {
+  // Local color tokens unique to this interactive (no equivalent in helpers.scss yet).
+  // TODO [a11y]: As part of the ongoing accessibility work, reconcile these with the
+  // shared palette — (1) assess which existing --cc-* values in helpers.scss should be
+  // updated for sufficient contrast, and (2) decide if any of these local tokens should be
+  // promoted into helpers.scss so other interactives can reuse them.
+  --cc-carousel-nav: #0093b0;          // active/highlight nav buttons & arrows — brand PMS 3145 C, ≥3:1 on white (WCAG 1.4.11)
+  --cc-carousel-nav-hover: #007c8b;    // nav button hover — unchanged; already ~4.93:1 on white (WCAG 1.4.11)
+  --cc-carousel-nav-disabled: #767676; // disabled prev/next arrows — ≥3:1 on white (WCAG 1.4.11)
+}
+
 .runtime {
   button {
     @include ap-button;
@@ -42,7 +53,7 @@ nav {
   width: 100%;
 
   button {
-    background: #6fc6da;
+    background: var(--cc-carousel-nav);
     border: none;
     border-radius: 50%;
     cursor: pointer;
@@ -55,10 +66,10 @@ nav {
     width: 20px;
 
     &:hover {
-      background: #007c8b;
+      background: var(--cc-carousel-nav-hover);
     }
     &.activeButton {
-      background: #ea6d2f;
+      background: var(--cc-orange-dark-1);
     }
     &.prevButton, &.nextButton {
       background: transparent;
@@ -69,17 +80,23 @@ nav {
       width: 0;
     }
     &.prevButton {
-      border-right: solid 20px #6fc6da;
+      border-right: solid 20px var(--cc-carousel-nav);
 
+      &:hover:not(.disabled) {
+        border-right-color: var(--cc-carousel-nav-hover);
+      }
       &.disabled {
-        border-right-color: #aaa;
+        border-right-color: var(--cc-carousel-nav-disabled);
       }
     }
     &.nextButton {
-      border-left: solid 20px #6fc6da;
+      border-left: solid 20px var(--cc-carousel-nav);
 
+      &:hover:not(.disabled) {
+        border-left-color: var(--cc-carousel-nav-hover);
+      }
       &.disabled {
-        border-left-color: #aaa;
+        border-left-color: var(--cc-carousel-nav-disabled);
       }
     }
     &.disabled {
@@ -101,7 +118,7 @@ nav {
 
       &:hover, &.activeButton {
         background-color: transparent;
-        border: solid 2px #ea6d2f;
+        border: solid 2px var(--cc-orange-dark-1);
         transform: scale(1.1);
       }
     }
@@ -113,7 +130,7 @@ nav {
 }
 
 :global .slider .slide {
-  background: #fff;
+  background: var(--white);
 }
 
 :global .slider .slide iframe {


### PR DESCRIPTION
[QI-147](https://concord-consortium.atlassian.net/browse/QI-147)

Updates the Carousel Interactive's navigation control colors to meet **WCAG 2.1 AA — 1.4.11 Non-text Contrast** (≥3:1 against the white background), and refactors the stylesheet's colors onto CSS variables while we're here. Previously, the inactive arrow and active/highlight controls did not contrast sufficiently with `#FFFFFF`.

Also adds hover styles for the previous and next buttons so they match the behavior of the other buttons.

### Contrast changes
All ratios measured against `#FFFFFF`:

| Element | Before | Ratio | After | Ratio |
|---|---|---|---|---|
| Active/highlight nav buttons & arrows | `#6fc6da` | 1.95:1 ❌ | `#0093b0` (brand PMS 3145 C) | 3.62:1 ✅ |
| Disabled prev/next arrows | `#aaa` | 2.32:1 ❌ | `#767676` | 4.54:1 ✅ |

Both new colors stay within their original hue families, so the navigation's visual design remains coherent. The hover color (`#007c8b`, ~4.93:1) was already compliant and left unchanged.

> Note: the audit reported the original values as `#BBBBBB` / `#6FC6DB`; the actual code used `#aaa` / `#6fc6da` (each off by a hex digit, likely from sampling rendered pixels). The fix targets are unaffected.

### Refactor (same change set)
Since the file used hardcoded hex throughout, this also DRYs up the carousel's colors:
- Existing palette colors now reference shared tokens from `helpers.scss` (`--cc-orange-dark-1`, `--white`).
- Colors that are at least for now unique to this interactive (`#0093b0`, `#007c8b`, `#767676`) are defined once as local `--cc-carousel-*` custom properties.
- Added a `TODO [a11y]` flagging these local tokens for later reconciliation with the shared palette as the accessibility work continues.

### Files changed
- `packages/carousel/src/components/runtime.scss`


[QI-147]: https://concord-consortium.atlassian.net/browse/QI-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ