### PR TITLE
feat: add accessible title to carousel child interactive iframes (QI-176)

### DIFF
--- a/packages/carousel/src/components/runtime.test.tsx
+++ b/packages/carousel/src/components/runtime.test.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { render, cleanup } from "@testing-library/react";
+
+import { Runtime } from "./runtime";
+import { IAuthoredState } from "./types";
+
+// Capture the props each child IframeRuntime is rendered with, so we can assert the title
+// the carousel derives for each slide.
+jest.mock("@concord-consortium/question-interactives-helpers/src/components/iframe-runtime", () => ({
+  IframeRuntime: (props: any) => <div data-testid="iframe-runtime" data-title={props.title} />,
+}));
+
+jest.mock("@concord-consortium/lara-interactive-api", () => ({
+  useAccessibility: jest.fn(() => ({})),
+  getClient: jest.fn(() => ({ post: jest.fn(), addListener: jest.fn() })),
+}));
+
+const authoredState: IAuthoredState = {
+  version: 2,
+  questionType: "iframe_interactive",
+  subinteractives: [
+    { id: "1", libraryInteractiveId: "open-response", authoredState: {} },
+    { id: "2", libraryInteractiveId: "image", authoredState: {} },
+  ],
+};
+
+afterEach(cleanup);
+
+describe("Carousel Runtime child iframe titles", () => {
+  const originalHref = window.location.href;
+
+  beforeEach(() => {
+    // The title's type name ("Open response", "Image") is resolved from the child's URL, which
+    // libraryInteractiveIdToUrl builds by swapping the trailing "carousel" segment of the current
+    // location for the child's id. The default jest testURL has no "carousel" segment, so without
+    // this the swap is a no-op, no type name resolves, and titles come out as just "Slide N".
+    window.history.replaceState(null, "", "/version/0.5.0/carousel");
+  });
+
+  afterEach(() => {
+    window.history.replaceState(null, "", originalHref);
+  });
+
+  it("gives each child iframe a 'Slide N: <interactive type>' title", () => {
+    const { getAllByTestId } = render(
+      <Runtime authoredState={authoredState} interactiveState={null} setInteractiveState={jest.fn()} />
+    );
+    const titles = getAllByTestId("iframe-runtime").map(el => el.getAttribute("data-title"));
+    expect(titles).toEqual(["Slide 1: Open response", "Slide 2: Image"]);
+  });
+
+  it("falls back to a generic type name when the interactive type can't be resolved", () => {
+    const unknownState: IAuthoredState = {
+      version: 2,
+      questionType: "iframe_interactive",
+      subinteractives: [
+        { id: "1", libraryInteractiveId: "not-a-real-interactive", authoredState: {} },
+      ],
+    };
+    const { getByTestId } = render(
+      <Runtime authoredState={unknownState} interactiveState={null} setInteractiveState={jest.fn()} />
+    );
+    expect(getByTestId("iframe-runtime")).toHaveAttribute("data-title", "Slide 1: Interactive content");
+  });
+});

--- a/packages/carousel/src/components/runtime.tsx
+++ b/packages/carousel/src/components/runtime.tsx
@@ -3,7 +3,7 @@ import { IframeRuntime } from "@concord-consortium/question-interactives-helpers
 import { IAuthoredState, IInteractiveState } from "./types";
 import { renderHTML } from "@concord-consortium/question-interactives-helpers/src/utilities/render-html";
 import { Carousel } from "react-responsive-carousel";
-import { libraryInteractiveIdToUrl } from "@concord-consortium/question-interactives-helpers/src/utilities/library-interactives";
+import { getLibraryInteractive, libraryInteractiveIdToUrl } from "@concord-consortium/question-interactives-helpers/src/utilities/library-interactives";
 import { cssUrlValue } from "@concord-consortium/question-interactives-helpers/src/utilities/css-url-value";
 import { DynamicText } from "@concord-consortium/dynamic-text";
 import { useAccessibility } from "@concord-consortium/lara-interactive-api";
@@ -106,6 +106,8 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
         {subinteractives.map(function(interactive, index) {
           const subState = subStates && subStates[interactive.id];
           const subinteractiveUrl = libraryInteractiveIdToUrl(interactive.libraryInteractiveId, "carousel");
+          const interactiveTypeName = getLibraryInteractive(subinteractiveUrl)?.name || "Interactive content";
+          const iframeTitle = `Slide ${index + 1}: ${interactiveTypeName}`;
           const logRequestData: Record<string, unknown> = { subinteractive_url: subinteractiveUrl,
                                                             subinteractive_type: interactive.authoredState.questionType,
                                                             subinteractive_sub_type: interactive.authoredState.questionSubType,
@@ -127,6 +129,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
                   scrolling="no"
                   accessibility={accessibility}
                   readOnly={readOnly}
+                  title={iframeTitle}
                 />
             </div>
           );

--- a/packages/helpers/src/components/iframe-runtime.test.tsx
+++ b/packages/helpers/src/components/iframe-runtime.test.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { render, cleanup } from "@testing-library/react";
+
+import { IframeRuntime } from "./iframe-runtime";
+
+// iframe-phone tries to talk to a real iframe; stub it so the component mounts cleanly.
+jest.mock("iframe-phone", () => ({
+  __esModule: true,
+  default: {
+    ParentEndpoint: jest.fn().mockImplementation(() => ({
+      post: jest.fn(),
+      addListener: jest.fn(),
+      disconnect: jest.fn(),
+    })),
+  },
+}));
+
+jest.mock("@concord-consortium/lara-interactive-api", () => ({
+  closeModal: jest.fn(),
+  flushStateUpdates: jest.fn(),
+  getClient: jest.fn(() => ({ post: jest.fn(), addListener: jest.fn() })),
+  log: jest.fn(),
+  setOnUnload: jest.fn(),
+  showModal: jest.fn(),
+}));
+
+const baseProps = {
+  interactiveState: null,
+  setInteractiveState: jest.fn(),
+  accessibility: {} as any,
+};
+
+afterEach(cleanup);
+
+describe("IframeRuntime iframe title", () => {
+  it("uses the title prop when provided", () => {
+    const { container } = render(
+      <IframeRuntime {...baseProps} url="https://example.com/image" title="Slide 2: Image" />
+    );
+    const iframe = container.querySelector("iframe");
+    expect(iframe).toHaveAttribute("title", "Slide 2: Image");
+  });
+
+  it("falls back to the library interactive name when no title prop is given", () => {
+    const { container } = render(
+      <IframeRuntime {...baseProps} url="https://example.com/image" />
+    );
+    const iframe = container.querySelector("iframe");
+    expect(iframe).toHaveAttribute("title", "Image");
+  });
+
+  it("falls back to a generic title when the url matches no known interactive", () => {
+    const { container } = render(
+      <IframeRuntime {...baseProps} url="https://example.com/unknown-thing" />
+    );
+    const iframe = container.querySelector("iframe");
+    expect(iframe).toHaveAttribute("title", "Interactive content");
+  });
+});

--- a/packages/helpers/src/components/iframe-runtime.tsx
+++ b/packages/helpers/src/components/iframe-runtime.tsx
@@ -34,12 +34,13 @@ interface IProps {
   flushOnSave?: boolean;
   accessibility: IAccessibilitySettings;
   onPhoneReady?: (phone: any) => (() => void) | void;
+  title?: string;
 }
 
 export const IframeRuntime: React.FC<IProps> =
   ({ authoredState, id, iframeStyling, interactiveState, logRequestData, report,
       url, setHint, setInteractiveState, addLocalLinkedDataListener, initMessage,
-      scale, onUnloadCallback, scrolling, flushOnSave, accessibility, readOnly, onPhoneReady }) => {
+      scale, onUnloadCallback, scrolling, flushOnSave, accessibility, readOnly, onPhoneReady, title }) => {
     const [ iframeHeight, setIframeHeight ] = useState(300);
     const [ internalHint, setInternalHint ] = useState("");
     const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -246,6 +247,9 @@ export const IframeRuntime: React.FC<IProps> =
     iframeStyle.pointerEvents = "none";
   }
 
+  // Always give the iframe a title for accessibility.
+  const iframeTitle = title || getLibraryInteractive(url)?.name || "Interactive content";
+
   return (
     <>
       <iframe
@@ -255,6 +259,7 @@ export const IframeRuntime: React.FC<IProps> =
         scrolling={scrolling}
         tabIndex={readOnly ? -1 : undefined}
         allow="geolocation; microphone; camera; bluetooth; clipboard-read; clipboard-write"
+        title={iframeTitle}
       />
       { internalHint &&
         <div className={css.hint}><DynamicText>{renderHTML(internalHint)}</DynamicText></div> }


### PR DESCRIPTION
Child interactive iframes inside a Carousel question interactive were rendered without a `title` attribute, which is an accessibility gap (screen reader users rely on iframe titles to identify embedded content).

Unlike top-level interactives — which LARA / Activity Player give a `title` from the authored **Name** field — a Carousel's child interactives are rendered *inside* the Carousel itself and have no Name field in authoring. The hosts have no knowledge of these children, so the title has to be supplied by the Carousel.

## Changes

- **`IframeRuntime` (helpers) now always renders a `title`.** Added an optional `title` prop; when omitted it falls back to the embedded interactive's type name (`getLibraryInteractive(url)?.name`) and finally to `"Interactive content"`. Because this is the shared component used by all nested-interactive hosts, **side-by-side and scaffolded-question child iframes also gain a sensible title for free.**
- **Carousel supplies a position-aware title per slide** of the form `Slide N: <interactive type>` (e.g. `Slide 1: Open response`, `Slide 2: Image`), falling back to `Slide N: Interactive content` if the type can't be resolved.

No changes were needed in LARA or Activity Player — both only ever set the title on the top-level Carousel iframe and have no knowledge of its children.

## Why this approach

- Derived at render time from data already present in authored state → **works on all existing Carousels with no migration and no authoring changes.**
- Centralizing the fallback in `IframeRuntime` means every child iframe it renders gets a title, not just the Carousel's.

## Known limitation

Slides of the same type produce titles distinguished only by position (`Slide 1: Image`, `Slide 4: Image`). This is inherent to "type + position." If richer titles are wanted later, the per-slide derivation is the only place that would need to change (e.g. pulling the child's prompt text).
