### PR TITLE
ci: cap Nx build parallelism to 3 to reduce runner shutdown flakes [QI-179]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,10 @@ jobs:
       - name: Install Dependencies
         run: npm ci
       - name: Build
-        run: npm run build
+        # Cap Nx build parallelism (default is os.cpus().length = 4 on the runner).
+        # Running 4 production webpack builds at once caused runner "shutdown signal"
+        # flakes under memory pressure; limit to 3 concurrent builds.
+        run: npm run build -- --concurrency 3
       - name: Run Tests
         run: npm run test
   cypress:
@@ -37,7 +40,9 @@ jobs:
       - name: Install Dependencies
         run: npm ci
       - name: Build
-        run: npm run build
+        # See build_test note: cap Nx build parallelism to avoid runner
+        # "shutdown signal" flakes from concurrent webpack builds.
+        run: npm run build -- --concurrency 3
       - name: Start server in the background
         run: npm start &
       - uses: cypress-io/github-action@v4


### PR DESCRIPTION
## Problem

CI intermittently fails on the **Build** step with `The runner has received a shutdown signal` — a runner reclaim consistent with resource/memory pressure. Most recently seen on the master merge run [28589549023](https://github.com/concord-consortium/question-interactives/actions/runs/28589549023) (`cypress (2)` job).

## Root cause

There is no `nx.json`, so Nx build parallelism falls to Lerna 6's default, which is `os.cpus().length` (not Nx's usual default of 3). On GitHub `ubuntu-latest` runners (4 vCPUs) this runs **4 full production webpack builds concurrently**, creating a peak-memory spike. The failing log shows 4 builds (`drawing-tool-interactive`, `agent-simulation`, `bar-graph`, `blockly`) starting just before the runner was reclaimed.

## Change

Cap Nx build concurrency to **3 in CI only**, by passing `--concurrency 3` to `lerna run build` in the two `npm run build` steps in `.github/workflows/ci.yml` (`build_test` + `cypress`). Local dev builds are unaffected.

## Notes

- Stopgap complementary to the planned Nx per-package build caching work, which addresses the same pressure from the other side.
- If concurrency 3 still flakes, drop to 2 (or 1) as a one-line follow-up.
- `s3-deploy` is untouched (it builds via the s3-deploy-action, not `npm run build`, and is not the flake source).

Jira: [QI-179](https://concord-consortium.atlassian.net/browse/QI-179)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[QI-179]: https://concord-consortium.atlassian.net/browse/QI-179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ