### PR TITLE
QI-156: Lab Book keyboard-accessible toolbar & Take Snapshot button

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,10 @@ jobs:
       - name: Deploy files to Amazon S3
         uses: concord-consortium/s3-deploy-action@v1
         with:
+          # See build_test note: cap Nx build parallelism to avoid runner
+          # "shutdown signal" flakes from concurrent webpack builds. The action's
+          # default build is 'npm run build'; override it to add the concurrency cap.
+          build: npm run build -- --concurrency 3
           bucket: models-resources
           prefix: ${{ github.event.repository.name }} # 'question-interactives'
           awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/packages/drawing-tool/src/components/drawing-tool.test.tsx
+++ b/packages/drawing-tool/src/components/drawing-tool.test.tsx
@@ -7,6 +7,21 @@ jest.mock("@concord-consortium/drawing-tool", () => class DrawingToolLib {
   resetHistory = jest.fn();
   save = jest.fn();
   setBackgroundImage = setBackgroundImageMock;
+  // Mirror the real library: append a .dt-canvas-container with tabindex="0" to the
+  // element matched by the selector. Only works when the component is attached to the
+  // document (see the "read-only canvas" tests); the other tests mount detached, so this
+  // is a no-op for them.
+  constructor(selector: string) {
+    // The wrapper always passes "#<id>"; look the element up by id (querySelector would
+    // throw on uuid ids that start with a digit, matching how the real lib finds it).
+    const el = document.getElementById(selector.replace(/^#/, ""));
+    if (el) {
+      const canvasContainer = document.createElement("div");
+      canvasContainer.className = "dt-canvas-container";
+      canvasContainer.setAttribute("tabindex", "0");
+      el.appendChild(canvasContainer);
+    }
+  }
 });
 
 const setBackgroundImageMock = jest.fn();
@@ -42,6 +57,36 @@ describe("DrawingTool", () => {
       mount(<DrawingTool authoredState={authoredStateWithExternalBg} />);
       expect(setBackgroundImageMock).toHaveBeenCalled();
       expect(setBackgroundImageMock.mock.calls[0][0].src).toEqual(LARA_IMAGE_PROXY + "http://aws.example.com/image.png");
+    });
+  });
+
+  // The library always makes the canvas container a tab stop (tabindex="0"). A read-only
+  // Drawing Tool — e.g. a Labbook thumbnail preview — is not interactive, so it should not
+  // add an extra keyboard tab stop. See QI-156.
+  describe("read-only canvas keyboard focus", () => {
+    let container: HTMLDivElement;
+    beforeEach(() => {
+      container = document.createElement("div");
+      document.body.appendChild(container);
+    });
+    afterEach(() => {
+      document.body.removeChild(container);
+    });
+
+    it("removes the canvas container from the tab order when readOnly", () => {
+      const wrapper = mount(<DrawingTool authoredState={authoredState} readOnly={true} />, { attachTo: container });
+      const canvasContainer = container.querySelector(".dt-canvas-container");
+      expect(canvasContainer).not.toBeNull();
+      expect(canvasContainer?.getAttribute("tabindex")).toEqual("-1");
+      wrapper.unmount();
+    });
+
+    it("keeps the canvas container focusable when not readOnly", () => {
+      const wrapper = mount(<DrawingTool authoredState={authoredState} readOnly={false} />, { attachTo: container });
+      const canvasContainer = container.querySelector(".dt-canvas-container");
+      expect(canvasContainer).not.toBeNull();
+      expect(canvasContainer?.getAttribute("tabindex")).toEqual("0");
+      wrapper.unmount();
     });
   });
 });

--- a/packages/drawing-tool/src/components/drawing-tool.test.tsx
+++ b/packages/drawing-tool/src/components/drawing-tool.test.tsx
@@ -88,5 +88,15 @@ describe("DrawingTool", () => {
       expect(canvasContainer?.getAttribute("tabindex")).toEqual("0");
       wrapper.unmount();
     });
+
+    it("updates the tab order when readOnly flips on an already-mounted instance", () => {
+      // e.g. a required question is submitted: readOnly goes false -> true without remounting.
+      const wrapper = mount(<DrawingTool authoredState={authoredState} readOnly={false} />, { attachTo: container });
+      const canvasContainer = container.querySelector(".dt-canvas-container");
+      expect(canvasContainer?.getAttribute("tabindex")).toEqual("0");
+      wrapper.setProps({ readOnly: true });
+      expect(canvasContainer?.getAttribute("tabindex")).toEqual("-1");
+      wrapper.unmount();
+    });
   });
 });

--- a/packages/drawing-tool/src/components/drawing-tool.tsx
+++ b/packages/drawing-tool/src/components/drawing-tool.tsx
@@ -162,14 +162,6 @@ export const DrawingTool: React.FC<IProps> = ({ authoredState, interactiveState,
 
       drawingToolRef.current = new DrawingToolLib(`#${containerId}`, drawingToolOpts);
 
-      // A read-only Drawing Tool (e.g. Labbook thumbnail previews and report views) is not
-      // interactive, so its canvas container should not be a keyboard tab stop. The library
-      // always sets tabindex="0" on .dt-canvas-container; take read-only instances out of the
-      // tab order to avoid an extra tab stop per non-empty thumbnail. See QI-156.
-      if (readOnly) {
-        containerRef.current?.querySelector(".dt-canvas-container")?.setAttribute("tabindex", "-1");
-      }
-
       if (initialInteractiveStateRef.current) {
         drawingToolRef.current.load(initialInteractiveStateRef.current.drawingState, () => {
           // Load finished callback. Set manually background that is stored outside in the interactive or authored state.
@@ -183,6 +175,16 @@ export const DrawingTool: React.FC<IProps> = ({ authoredState, interactiveState,
       });
     }
   }, [authoredState, readOnly, setBackground, buttons, width, height, onDrawingChanged, containerId, canvasScale, wideLayout]);
+
+  // Keep a read-only Drawing Tool out of the keyboard tab order. The library always sets
+  // tabindex="0" on .dt-canvas-container, but a read-only canvas — Labbook thumbnail previews,
+  // report views, or a submitted "required" question — is not interactive and shouldn't be a
+  // tab stop. This runs on mount and whenever readOnly changes, so it also handles a required
+  // question being submitted on an already-mounted instance (readOnly flips false -> true
+  // without the component remounting). See QI-156.
+  useEffect(() => {
+    containerRef.current?.querySelector(".dt-canvas-container")?.setAttribute("tabindex", readOnly ? "-1" : "0");
+  }, [readOnly]);
 
   useEffect(() => {
     setBackground(interactiveState?.userBackgroundImageUrl);

--- a/packages/drawing-tool/src/components/drawing-tool.tsx
+++ b/packages/drawing-tool/src/components/drawing-tool.tsx
@@ -161,6 +161,15 @@ export const DrawingTool: React.FC<IProps> = ({ authoredState, interactiveState,
       }
 
       drawingToolRef.current = new DrawingToolLib(`#${containerId}`, drawingToolOpts);
+
+      // A read-only Drawing Tool (e.g. Labbook thumbnail previews and report views) is not
+      // interactive, so its canvas container should not be a keyboard tab stop. The library
+      // always sets tabindex="0" on .dt-canvas-container; take read-only instances out of the
+      // tab order to avoid an extra tab stop per non-empty thumbnail. See QI-156.
+      if (readOnly) {
+        containerRef.current?.querySelector(".dt-canvas-container")?.setAttribute("tabindex", "-1");
+      }
+
       if (initialInteractiveStateRef.current) {
         drawingToolRef.current.load(initialInteractiveStateRef.current.drawingState, () => {
           // Load finished callback. Set manually background that is stored outside in the interactive or authored state.

--- a/packages/helpers/src/components/media-library/drag-to-upload.tsx
+++ b/packages/helpers/src/components/media-library/drag-to-upload.tsx
@@ -36,7 +36,7 @@ export const DragToUpload: React.FC<IProps> = ({disabled, onUploadImage, onUploa
   };
 
   const handleFileUpload = (file: File|undefined) => {
-    if(!disabled) {
+    if(!disabled && !uploadInProgress) {
       if (file) {
         onUploadStart?.();
         uploadFile(file);
@@ -79,6 +79,7 @@ export const DragToUpload: React.FC<IProps> = ({disabled, onUploadImage, onUploa
         buttonClass={classes}
         onChange={handleFileUpload}
         id={"drop-file-upload"}
+        disabled={uploadInProgress || disabled}
       >
         <div className={css["button-text"]}>
           { uploadInProgress

--- a/packages/helpers/src/components/styled-file-input.scss
+++ b/packages/helpers/src/components/styled-file-input.scss
@@ -14,7 +14,11 @@ input[type="file"] {
 
 .fileInputLabel {
   &:focus-within {
-    outline: 2px solid var(--cc-charcoal);
+    // Match the browser's default focus ring color used by native controls such as the
+    // thumbnail delete button and the comment text area. The input is off-screen, so the
+    // visible ring is drawn on the label.
+    outline: 2px solid #005fcc; // fallback for non-WebKit/Blink
+    outline: 2px solid -webkit-focus-ring-color;
     outline-offset: 2px;
   }
 }

--- a/packages/helpers/src/components/styled-file-input.scss
+++ b/packages/helpers/src/components/styled-file-input.scss
@@ -11,3 +11,10 @@ input[type="file"] {
     // ⬆ Wont display on screen, but screen readers will read it.
   }
 }
+
+.fileInputLabel {
+  &:focus-within {
+    outline: 2px solid var(--cc-charcoal);
+    outline-offset: 2px;
+  }
+}

--- a/packages/helpers/src/components/styled-file-input.scss
+++ b/packages/helpers/src/components/styled-file-input.scss
@@ -12,13 +12,16 @@ input[type="file"] {
   }
 }
 
+@import "../styles/helpers.scss";
+
 .fileInputLabel {
+  // :focus-within (not :focus-visible) because the visible ring is drawn on the label while
+  // focus actually lands on the nested, off-screen <input>. This means a plain mouse click on
+  // the label also shows the ring. The precise fix, :has(:focus-visible), isn't usable: the
+  // repo has no browserslist config, so the default query includes Firefox ESR, which lacks
+  // :has() support, and autoprefixer can't polyfill a selector (the rule would be dropped and
+  // Firefox keyboard users would get no ring at all).
   &:focus-within {
-    // Match the browser's default focus ring color used by native controls such as the
-    // thumbnail delete button and the comment text area. The input is off-screen, so the
-    // visible ring is drawn on the label.
-    outline: 2px solid #005fcc; // fallback for non-WebKit/Blink
-    outline: 2px solid -webkit-focus-ring-color;
-    outline-offset: 2px;
+    @include native-focus-ring;
   }
 }

--- a/packages/helpers/src/components/styled-file-input.test.tsx
+++ b/packages/helpers/src/components/styled-file-input.test.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { StyledFileInput } from "./styled-file-input";
+
+describe("StyledFileInput", () => {
+  it("nests the file input inside the label so :focus-within shows focus on the label", () => {
+    render(
+      <StyledFileInput buttonClass="btn" onChange={jest.fn()} id="x">
+        Upload
+      </StyledFileInput>
+    );
+    const label = screen.getByTestId("upload-btn");
+    const input = screen.getByTestId("file-input");
+    expect(label.tagName).toBe("LABEL");
+    expect(label).toContainElement(input);
+  });
+});

--- a/packages/helpers/src/components/styled-file-input.test.tsx
+++ b/packages/helpers/src/components/styled-file-input.test.tsx
@@ -14,4 +14,22 @@ describe("StyledFileInput", () => {
     expect(label.tagName).toBe("LABEL");
     expect(label).toContainElement(input);
   });
+
+  it("disables the file input (removing it from the tab order) when disabled", () => {
+    render(
+      <StyledFileInput buttonClass="btn" onChange={jest.fn()} id="x" disabled={true}>
+        Upload
+      </StyledFileInput>
+    );
+    expect(screen.getByTestId("file-input")).toBeDisabled();
+  });
+
+  it("leaves the file input enabled when not disabled", () => {
+    render(
+      <StyledFileInput buttonClass="btn" onChange={jest.fn()} id="x">
+        Upload
+      </StyledFileInput>
+    );
+    expect(screen.getByTestId("file-input")).toBeEnabled();
+  });
 });

--- a/packages/helpers/src/components/styled-file-input.tsx
+++ b/packages/helpers/src/components/styled-file-input.tsx
@@ -6,6 +6,7 @@ export interface IStyledFileInputProps {
   onChange: (fileOrUrl: File | undefined) => void;
   buttonClass: string;
   id?: string;
+  disabled?: boolean;
 }
 
 /*
@@ -17,7 +18,7 @@ export interface IStyledFileInputProps {
  * - https://webaim.org/techniques/css/invisiblecontent/
  */
 export const StyledFileInput: React.FC<IStyledFileInputProps> = (props) => {
-  const {children, onChange, buttonClass, id} = props;
+  const {children, onChange, buttonClass, id, disabled} = props;
   const classes = classNames(buttonClass, css.fileInputLabel);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -46,6 +47,7 @@ export const StyledFileInput: React.FC<IStyledFileInputProps> = (props) => {
           className={css.hidden}
           id={`file-upload-${id}`}
           type="file"
+          disabled={disabled}
           onClick={handleClick}
           onChange={handleChange}
           data-testid="file-input"

--- a/packages/helpers/src/components/styled-file-input.tsx
+++ b/packages/helpers/src/components/styled-file-input.tsx
@@ -18,7 +18,7 @@ export interface IStyledFileInputProps {
  */
 export const StyledFileInput: React.FC<IStyledFileInputProps> = (props) => {
   const {children, onChange, buttonClass, id} = props;
-  const classes = classNames(buttonClass);
+  const classes = classNames(buttonClass, css.fileInputLabel);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleClick = (e: React.MouseEvent) => {
@@ -36,22 +36,20 @@ export const StyledFileInput: React.FC<IStyledFileInputProps> = (props) => {
   };
 
   return (
-    <>
-      <label
-        htmlFor={`file-upload-${id}`}
-        className={classes}
-        data-testid="upload-btn">
-          {children}
-      </label>
-      <input
-        ref={fileInputRef}
-        className={css.hidden}
-        id={`file-upload-${id}`}
-        type="file"
-        onClick={handleClick}
-        onChange={handleChange}
-        data-testid="file-input"
-      />
-    </>
+    <label
+      htmlFor={`file-upload-${id}`}
+      className={classes}
+      data-testid="upload-btn">
+        {children}
+        <input
+          ref={fileInputRef}
+          className={css.hidden}
+          id={`file-upload-${id}`}
+          type="file"
+          onClick={handleClick}
+          onChange={handleChange}
+          data-testid="file-input"
+        />
+    </label>
   );
 };

--- a/packages/helpers/src/styles/helpers.scss
+++ b/packages/helpers/src/styles/helpers.scss
@@ -36,6 +36,9 @@
   --cc-ap-button-click: #ff8113;
   --cc-ap-button-border: #949494;
   --cc-ap-button-focus-ring: #0957d0;
+  // The browser-native focus ring color (matches native controls like the comment textarea
+  // and the thumbnail delete button). See the native-focus-ring mixin below.
+  --cc-native-focus-ring: #005fcc;
 }
 
 
@@ -68,6 +71,17 @@ $themeColor2: #34a5be;
   input[type=checkbox], input[type=radio] {
     margin-right: 10px;
   }
+}
+
+// Browser-native keyboard focus ring, so custom-styled controls match native controls
+// (the comment textarea, the thumbnail delete button, etc.). Two outline declarations on
+// purpose: the token is the fallback for engines that don't support the -webkit- keyword
+// (Firefox keeps the first declaration and drops the second). Pass an offset to push the
+// ring outside a selection border, e.g. native-focus-ring(3px).
+@mixin native-focus-ring($offset: 2px) {
+  outline: 2px solid var(--cc-native-focus-ring);
+  outline: 2px solid -webkit-focus-ring-color;
+  outline-offset: $offset;
 }
 
 @mixin interactive-button {

--- a/packages/helpers/src/styles/helpers.scss
+++ b/packages/helpers/src/styles/helpers.scss
@@ -103,6 +103,11 @@ $themeColor2: #34a5be;
   &:hover {
     background-color: var(--cc-teal-light-4);
   }
+  &:focus-visible {
+    // Visible keyboard focus indicator (WCAG 2.4.7). Consumers that render this style on a
+    // <label>/wrapper (e.g. the styled file input) otherwise show no ring at all.
+    @include native-focus-ring;
+  }
   &:active {
     background-color: var(--cc-teal-light-3);
   }

--- a/packages/labbook/src/components/runtime.scss
+++ b/packages/labbook/src/components/runtime.scss
@@ -33,6 +33,7 @@
   --cc-ap-button-click: #ff8113;
   --cc-ap-button-border: #949494;
   --cc-ap-button-focus-ring: #0957d0;
+  --cc-native-focus-ring: #005fcc;
 }
 
 .app {

--- a/packages/labbook/src/components/thumbnail-chooser/thumbnail-wrapper.scss
+++ b/packages/labbook/src/components/thumbnail-chooser/thumbnail-wrapper.scss
@@ -1,5 +1,6 @@
 @import "../vars.scss";
 @import "../../../../helpers/src/styles/px-to-rem.scss";
+@import "../../../../helpers/src/styles/helpers.scss";
 
 :global(body.font-size-large) {
   .thumbnail-wrapper {
@@ -33,12 +34,9 @@
     transition: background-color .25s;
     overflow: hidden;
     &:focus-visible {
-      // Match the browser's default focus ring color (used by the delete button and the
-      // comment text area) and offset it outside the (up to 3px) teal selection border so
-      // it stays clearly visible when the thumbnail is selected.
-      outline: 2px solid #005fcc; // fallback for non-WebKit/Blink
-      outline: 2px solid -webkit-focus-ring-color;
-      outline-offset: 3px;
+      // Offset 3px so the ring sits outside the teal selection border when the thumbnail is
+      // selected, rather than blending into it.
+      @include native-focus-ring(3px);
     }
     &.wide {
       width: 105px;

--- a/packages/labbook/src/components/thumbnail-chooser/thumbnail-wrapper.scss
+++ b/packages/labbook/src/components/thumbnail-chooser/thumbnail-wrapper.scss
@@ -32,6 +32,14 @@
     position: relative;
     transition: background-color .25s;
     overflow: hidden;
+    &:focus-visible {
+      // Match the browser's default focus ring color (used by the delete button and the
+      // comment text area) and offset it outside the (up to 3px) teal selection border so
+      // it stays clearly visible when the thumbnail is selected.
+      outline: 2px solid #005fcc; // fallback for non-WebKit/Blink
+      outline: 2px solid -webkit-focus-ring-color;
+      outline-offset: 3px;
+    }
     &.wide {
       width: 105px;
       &.selected {

--- a/packages/labbook/src/components/thumbnail-chooser/thumbnail-wrapper.test.tsx
+++ b/packages/labbook/src/components/thumbnail-chooser/thumbnail-wrapper.test.tsx
@@ -71,6 +71,19 @@ describe("ThumbnailWrapper component", () => {
     expect(screen.queryAllByTestId("thumbnail-close-button")).toHaveLength(0);
   });
 
+  it("gives the delete button an accessible name", () => {
+    const thumbnailWrapperProps: IThumbnailWrapperProps = {
+      selected: true,
+      setSelectedContainerId: (id: string) => undefined,
+      clearContainer: (id: string) => undefined,
+      content: thumb,
+      readOnly: false
+    };
+
+    render(<ThumbnailWrapper {...thumbnailWrapperProps} />);
+    expect(screen.getByRole("button", { name: /delete model/i })).toBeInTheDocument();
+  });
+
   it("renders a readonly view", () => {
     const thumbnailWrapperProps: IThumbnailWrapperProps= {
       selected: true,

--- a/packages/labbook/src/components/thumbnail-chooser/thumbnail-wrapper.test.tsx
+++ b/packages/labbook/src/components/thumbnail-chooser/thumbnail-wrapper.test.tsx
@@ -81,7 +81,11 @@ describe("ThumbnailWrapper component", () => {
     };
 
     render(<ThumbnailWrapper {...thumbnailWrapperProps} />);
-    expect(screen.getByRole("button", { name: /delete model/i })).toBeInTheDocument();
+    const deleteButton = screen.getByTestId("thumbnail-close-button");
+    // Accessible name interpolates the label with no trailing whitespace, and the
+    // button is type="button" so it never acts as a form submit.
+    expect(deleteButton).toHaveAccessibleName("Delete model one");
+    expect(deleteButton).toHaveAttribute("type", "button");
   });
 
   it("renders a readonly view", () => {

--- a/packages/labbook/src/components/thumbnail-chooser/thumbnail-wrapper.tsx
+++ b/packages/labbook/src/components/thumbnail-chooser/thumbnail-wrapper.tsx
@@ -41,6 +41,7 @@ export const ThumbnailWrapper: React.FC<IThumbnailWrapperProps> = (props) => {
   return (
     <div className={css["thumbnail-wrapper"]} data-testid="thumbnail-wrapper">
       <button className={classes}
+              type="button"
               onClick={clickHandler}
               data-testid="thumbnail-button"
               disabled={uploadPreviewMode}
@@ -66,8 +67,8 @@ export const ThumbnailWrapper: React.FC<IThumbnailWrapperProps> = (props) => {
       </button>
         {
           selected && !empty && !readOnly &&
-          <button className={css["close"]} onClick={handleClose}
-                  aria-label={t("THUMBNAIL_CHOOSER.DELETE_MODEL", { vars: { label: label || "" } })}
+          <button className={css["close"]} type="button" onClick={handleClose}
+                  aria-label={t("THUMBNAIL_CHOOSER.DELETE_MODEL", { vars: { label: label || "" } }).trim()}
                   data-testid="thumbnail-close-button">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" width="12" height="12">
               <line x1="0" y1="0" x2="12" y2="12" strokeWidth="2.5"/>

--- a/packages/labbook/src/components/thumbnail-chooser/thumbnail-wrapper.tsx
+++ b/packages/labbook/src/components/thumbnail-chooser/thumbnail-wrapper.tsx
@@ -66,7 +66,9 @@ export const ThumbnailWrapper: React.FC<IThumbnailWrapperProps> = (props) => {
       </button>
         {
           selected && !empty && !readOnly &&
-          <button className={css["close"]} onClick={handleClose} data-testid="thumbnail-close-button">
+          <button className={css["close"]} onClick={handleClose}
+                  aria-label={t("THUMBNAIL_CHOOSER.DELETE_MODEL", { vars: { label: label || "" } })}
+                  data-testid="thumbnail-close-button">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" width="12" height="12">
               <line x1="0" y1="0" x2="12" y2="12" strokeWidth="2.5"/>
               <line x1="12" y1="0" x2="0" y2="12" strokeWidth="2.5"/>

--- a/packages/labbook/src/components/upload-button.scss
+++ b/packages/labbook/src/components/upload-button.scss
@@ -25,6 +25,12 @@
   background-color: var(--cc-teal-light-5);
   font-weight: normal;
   color: var(--cc-charcoal);
+  font-family: inherit;
+  cursor: pointer;
+  &:focus-visible {
+    outline: 2px solid var(--cc-charcoal);
+    outline-offset: 2px;
+  }
   &:hover {
     background-color: var(--cc-teal-light-4);
   }

--- a/packages/labbook/src/components/upload-button.scss
+++ b/packages/labbook/src/components/upload-button.scss
@@ -28,7 +28,10 @@
   font-family: inherit;
   cursor: pointer;
   &:focus-visible {
-    outline: 2px solid var(--cc-charcoal);
+    // Match the browser's default focus ring color used by native controls such as the
+    // thumbnail delete button and the comment text area.
+    outline: 2px solid #005fcc; // fallback for non-WebKit/Blink
+    outline: 2px solid -webkit-focus-ring-color;
     outline-offset: 2px;
   }
   &:hover {

--- a/packages/labbook/src/components/upload-button.scss
+++ b/packages/labbook/src/components/upload-button.scss
@@ -1,4 +1,5 @@
 @import "../../../helpers/src/styles/px-to-rem.scss";
+@import "../../../helpers/src/styles/helpers.scss";
 
 :global(body.font-size-large) {
   .upload-button {
@@ -28,11 +29,7 @@
   font-family: inherit;
   cursor: pointer;
   &:focus-visible {
-    // Match the browser's default focus ring color used by native controls such as the
-    // thumbnail delete button and the comment text area.
-    outline: 2px solid #005fcc; // fallback for non-WebKit/Blink
-    outline: 2px solid -webkit-focus-ring-color;
-    outline-offset: 2px;
+    @include native-focus-ring;
   }
   &:hover {
     background-color: var(--cc-teal-light-4);

--- a/packages/labbook/src/components/upload-button.test.tsx
+++ b/packages/labbook/src/components/upload-button.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { UploadButton } from "./upload-button";
+
+describe("UploadButton", () => {
+  it("renders a native button whose accessible name is its text", () => {
+    render(<UploadButton onClick={jest.fn()}>Take Snapshot</UploadButton>);
+    const btn = screen.getByRole("button", { name: "Take Snapshot" });
+    expect(btn.tagName).toBe("BUTTON");
+  });
+
+  it("calls onClick with 'upload' when activated", () => {
+    const onClick = jest.fn();
+    render(<UploadButton onClick={onClick}>Take Snapshot</UploadButton>);
+    fireEvent.click(screen.getByRole("button", { name: "Take Snapshot" }));
+    expect(onClick).toHaveBeenCalledWith("upload");
+  });
+
+  it("is disabled and does not fire onClick when disabled", () => {
+    const onClick = jest.fn();
+    render(<UploadButton onClick={onClick} disabled={true}>Take Snapshot</UploadButton>);
+    const btn = screen.getByRole("button", { name: "Take Snapshot" });
+    expect(btn).toBeDisabled();
+    fireEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("forwards data-testid to the button", () => {
+    render(<UploadButton onClick={jest.fn()} data-testid="snapshot-btn">Take Snapshot</UploadButton>);
+    expect(screen.getByTestId("snapshot-btn").tagName).toBe("BUTTON");
+  });
+});

--- a/packages/labbook/src/components/upload-button.tsx
+++ b/packages/labbook/src/components/upload-button.tsx
@@ -8,14 +8,21 @@ export interface IUploadButtonProps {
   disabled?: boolean;
   onClick?: (type: string) => void;
   inDialog?: boolean;
+  "data-testid"?: string;
 }
 
 export const UploadButton: React.FC<IUploadButtonProps> = (props) => {
   const {children, onClick, disabled, inDialog} = props;
   const classes = classNames(css["upload-button"], {[css.disabled]: disabled, [css.inDialog]: inDialog});
   return (
-    <div className={classes} onClick={()=>onClick && onClick("upload")}>
+    <button
+      type="button"
+      className={classes}
+      disabled={disabled}
+      onClick={() => onClick && onClick("upload")}
+      data-testid={props["data-testid"]}
+    >
       {children}
-    </div>
+    </button>
   );
 };

--- a/packages/labbook/src/components/upload-button.tsx
+++ b/packages/labbook/src/components/upload-button.tsx
@@ -4,7 +4,6 @@ import classNames from "classnames";
 import css from "./upload-button.scss";
 
 export interface IUploadButtonProps {
-  label?:string;
   disabled?: boolean;
   onClick?: (type: string) => void;
   inDialog?: boolean;

--- a/packages/labbook/src/components/upload-image.tsx
+++ b/packages/labbook/src/components/upload-image.tsx
@@ -53,7 +53,7 @@ export const UploadImage: React.FC<IProps> = ({ onUploadImage, uploadMode, onUpl
   };
 
   const handleFileUpload = (file: File|undefined) => {
-    if(!disabled) {
+    if(!disabled && !uploadInProgress) {
       if (file) {
         onUploadStart?.();
         uploadFile(file);
@@ -70,6 +70,7 @@ export const UploadImage: React.FC<IProps> = ({ onUploadImage, uploadMode, onUpl
         buttonClass={classes}
         onChange={handleFileUpload}
         id={text}
+        disabled={uploadInProgress || disabled}
       >
         {showUploadIcon && <UploadIcon/>}
         <div className={buttonTextClasses}>

--- a/packages/labbook/src/utils/translation/lang/en-us.json
+++ b/packages/labbook/src/utils/translation/lang/en-us.json
@@ -2,5 +2,6 @@
   "TEXT": "text",
   "INTRO.HELLO": "Hello World",
   "THUMBNAIL-CHOOSER.TITLE": "Thumbnail Chooser",
-  "THUMBNAIL_CHOOSER.NEW_MODEL": "New"
+  "THUMBNAIL_CHOOSER.NEW_MODEL": "New",
+  "THUMBNAIL_CHOOSER.DELETE_MODEL": "Delete model %{label}"
 }

--- a/specs/QI-156-labbook-keyboard-accessible-toolbar.md
+++ b/specs/QI-156-labbook-keyboard-accessible-toolbar.md
@@ -1,0 +1,115 @@
+# QI-156 — Lab Book: keyboard-accessible toolbar & Take Snapshot button
+
+**Date:** 2026-07-07
+**Jira:** [QI-156](https://concord-consortium.atlassian.net/browse/QI-156)
+**Branch:** `QI-156-labbook-keyboard-accessible-toolbar`
+**WCAG:** 2.1.1 Keyboard (Level A) — with a related 2.4.7 Focus Visible fix
+**Related stories:** QI-155 (drawing-tool interactive toolbar), QI-173 (drawing
+actions), QI-174 (navigating objects within the drawing area)
+
+## Background
+
+As a keyboard or assistive-technology user, I need the Lab Book controls to be
+fully operable without a mouse.
+
+The actual drawing toolbar (select, free, shapes, stamp, **annotation**, trash)
+is rendered by the shared `@concord-consortium/drawing-tool` library
+(v2.4.0-pre.1 is installed), which already has the accessibility work done —
+`<button>` elements with `aria-label`, `aria-pressed`, and `aria-expanded`. The
+`annotation` tool is just another registered tool in that library, so its button
+already gets the same accessible treatment. Most of the ticket's toolbar
+acceptance criteria are therefore satisfied by QI-155 / the shared library.
+
+This story covers the controls the **Lab Book itself adds** in its own React
+code, which are not keyboard operable today.
+
+## Scope
+
+### 1. `UploadButton`: `<div>` → native `<button>` (core fix)
+
+[packages/labbook/src/components/upload-button.tsx](../packages/labbook/src/components/upload-button.tsx)
+currently renders a `<div onClick>`, which cannot receive keyboard focus or be
+activated by Enter/Space. Convert it to a native `<button type="button">`. This
+single change makes all three consumers keyboard operable:
+
+- the **"Take Snapshot"** button
+  ([take-snapshot.tsx](../packages/labbook/src/components/take-snapshot.tsx)) —
+  the ticket's explicitly-called-out target (audit issue #93)
+- the **"Upload Image"** button, shown when the entry already has an image
+  ([runtime.tsx](../packages/labbook/src/components/runtime.tsx))
+- the **Replace / Create** buttons inside the upload modal
+  ([create-or-replace-image.tsx](../packages/labbook/src/components/create-or-replace-image.tsx))
+
+Additional requirements:
+
+- Drive the disabled state with the native `disabled` attribute. Today the
+  component only applies a `disabled` CSS class while `onClick` still fires;
+  the native attribute correctly blocks both mouse and keyboard activation and
+  removes the button from the tab order when disabled.
+- **Accessible name comes from the visible text children** (e.g. "Take
+  Snapshot", "Replace Current Image"). Do **not** add an `aria-label` that
+  differs from the visible text on these buttons — that would risk a WCAG 2.5.3
+  (Label in Name) failure. The ticket's `aria-label` criterion targets icon-only
+  toolbar buttons; these have visible text, so the visible text *is* the
+  accessible name.
+
+### 2. `upload-button.scss`: button reset + visible focus
+
+[upload-button.scss](../packages/labbook/src/components/upload-button.scss) —
+add `font-family: inherit;` and `cursor: pointer;` to neutralize default
+`<button>` styling, and a `:focus-visible` outline so keyboard focus is visible.
+The existing `.disabled` rule stays for the dimmed visual state, but disabling is
+now driven by the real attribute.
+
+### 3. Styled file input: visible focus (the "wrinkle")
+
+[styled-file-input.tsx](../packages/helpers/src/components/styled-file-input.tsx)
+already exposes a real `<input type="file">` positioned off-screen
+(`left: -10000px`, **not** `display:none`), so it stays in the tab order and
+Enter/Space already opens the OS file dialog — this satisfies 2.1.1. The gap is
+that the visible focus ring lands on the off-screen input rather than the visible
+`<label>`, so keyboard users can't *see* focus (2.4.7).
+
+Fix: nest the `<input>` inside the `<label>` and add a `:focus-within` outline in
+[styled-file-input.scss](../packages/helpers/src/components/styled-file-input.scss).
+This benefits both Lab Book's Upload Image control and the media-library
+drag-to-upload
+([drag-to-upload.tsx](../packages/helpers/src/components/media-library/drag-to-upload.tsx)),
+which is the other consumer of `StyledFileInput`.
+
+### 4. Thumbnail delete button: accessible name
+
+The delete/close button in
+[thumbnail-wrapper.tsx](../packages/labbook/src/components/thumbnail-chooser/thumbnail-wrapper.tsx)
+is already a native `<button>` but contains only an SVG, so screen readers
+announce no name. Add an `aria-label` using the existing `translate` util so it
+is announced (e.g. "Delete model").
+
+### 5. Verify (no code change expected)
+
+- **Annotation tool** button — rendered by the already-accessible shared
+  `@concord-consortium/drawing-tool` library; confirm it is Tab-reachable and
+  Enter/Space-activatable in the Lab Book context.
+- **File input** upload — confirm Enter/Space opens the OS file dialog.
+
+## Out of scope
+
+- `aria-pressed` — there are no toggle buttons among the Lab-Book-added controls.
+- `aria-expanded` / `aria-controls` — the Lab-Book-added buttons open a modal
+  dialog, not an inline expandable options container. The drawing-tool palette
+  buttons that need these are handled by the shared library / QI-155.
+- Drawing actions (QI-173) and navigating objects within the drawing area
+  (QI-174).
+
+## Testing
+
+TDD with the existing Jest + Testing-Library setup:
+
+- `UploadButton` renders a native `<button>`, exposes its text as the accessible
+  name, does not fire `onClick` when `disabled`, and activates via keyboard.
+- Take Snapshot invokes its handler when activated by keyboard.
+- The thumbnail delete button exposes an accessible name.
+
+Manual keyboard verification in the running app for the annotation tool button
+and the OS file dialog (items that are operable via native/shared-library
+behavior and not unit-testable here).

--- a/specs/QI-156-labbook-keyboard-accessible-toolbar.md
+++ b/specs/QI-156-labbook-keyboard-accessible-toolbar.md
@@ -92,6 +92,31 @@ is announced (e.g. "Delete model").
   Enter/Space-activatable in the Lab Book context.
 - **File input** upload — confirm Enter/Space opens the OS file dialog.
 
+## Focus ring color (design-system note)
+
+The focus rings this story adds — the Upload button, the styled file input, and
+the thumbnail — use the **browser's native focus ring color**
+(`-webkit-focus-ring-color`, `#005fcc`, with a hex fallback), matching the
+controls sitting right next to them: the thumbnail delete button and the comment
+text area, which are native elements and already render that ring.
+
+This is deliberately **not** the Concord design-system focus indicator. Our
+designer (Michael Tirenin) publishes specs in **Zeplin**, and the standard
+keyboard-focus style there is a double inset border — `2px #0957D0` inside
+`3px #FFFFFF` — captured in code as the `--cc-ap-button-focus-ring` token and the
+`@mixin ap-button` (added in QI-124, matching Activity Player AP-66). That style
+is currently applied only to the orange "AP" action buttons (the Submit/lock
+button `SubmitButton`, the Button interactive, carousel, scaffolded-question);
+its inner white ring exists specifically to keep the ring visible against the
+orange fill.
+
+The likely correct long-term direction is to restyle these Lab Book buttons as
+the standard orange AP buttons using that shared focus ring, for full
+design-system consistency. That is **deferred out of this story** to keep it
+scoped to keyboard operability (WCAG 2.1.1 / 2.4.7); here we only match the
+native controls already adjacent to them, and we intentionally do not touch the
+drawing-tool toolbar's own (teal `#016082`) ring.
+
 ## Out of scope
 
 - `aria-pressed` — there are no toggle buttons among the Lab-Book-added controls.


### PR DESCRIPTION
## Summary

Makes the Lab-Book-added controls keyboard operable and screen-reader labelled (WCAG 2.1.1 Keyboard, plus 2.4.7 Focus Visible). The drawing toolbar itself (select, free, shapes, stamp, **annotation**, trash) is rendered by the already-accessible shared `@concord-consortium/drawing-tool` library (QI-155) and is untouched here — this covers the controls the Lab Book adds in its own code.

Jira: [QI-156](https://concord-consortium.atlassian.net/browse/QI-156)

## Changes

- **`UploadButton` → native `<button>`** ([upload-button.tsx](packages/labbook/src/components/upload-button.tsx)): was a `<div onClick>` (not focusable). Converting it to a native `<button type="button">` fixes **Take Snapshot**, **Upload Image (replace)**, and the modal **Replace/Create** buttons in one change. Disabled state now uses the native `disabled` attribute; a `:focus-visible` outline was added.
- **Styled file input visible focus** ([styled-file-input.tsx](packages/helpers/src/components/styled-file-input.tsx)): the `<input type="file">` was already keyboard-operable (Enter/Space opens the OS dialog) but its focus ring landed on the off-screen input. Nesting the input inside its `<label>` + a `:focus-within` outline makes focus visible. Benefits the media-library drag-to-upload too.
- **Thumbnail delete accessible name** ([thumbnail-wrapper.tsx](packages/labbook/src/components/thumbnail-chooser/thumbnail-wrapper.tsx)): the icon-only delete button now has an `aria-label` via the translate util.

## Accessibility notes

- Text buttons derive their accessible name from **visible text** — no divergent `aria-label` (avoids WCAG 2.5.3 Label in Name). `aria-label` is used only on the icon-only thumbnail delete button.
- `aria-pressed` / `aria-expanded` were intentionally **not** added to Lab-Book-added controls: none are toggles, and the upload/snapshot buttons open a modal dialog rather than an inline expandable container. The palette buttons that need those live in the shared drawing-tool library (QI-155).

## Testing

- New/updated unit tests (TDD): `upload-button.test.tsx` (native button role/name, disabled behavior, testid forwarding), `styled-file-input.test.tsx` (input nested in label), `thumbnail-wrapper.test.tsx` (delete button accessible name).
- Full suites green: **labbook 23/23, helpers 113/113**. Lint clean for all changed files.
- **Manual keyboard verification** of the annotation tool button and the OS file dialog is a follow-up acceptance check (OS-level file dialog is not automatable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[QI-156]: https://concord-consortium.atlassian.net/browse/QI-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
---

## Design decision: focus ring color

The focus rings added here (Upload button, styled file input, selected thumbnail) use the **browser-native focus ring color** (`-webkit-focus-ring-color` / `#005fcc`), matching the adjacent native controls — the **thumbnail delete button** and the **comment text area**, which already render that ring. The selected-thumbnail ring also gets a `3px` `outline-offset` so it clears the teal selection border.

This is intentionally **not** the Concord design-system focus indicator. The design system's standard keyboard-focus style (per Michael's Zeplin specs) is a double inset border — `2px #0957D0` inside `3px #FFFFFF` — captured as the `--cc-ap-button-focus-ring` token / `@mixin ap-button` (QI-124, matching AP-66), and today it's applied only to the orange "AP" buttons (Submit/lock, Button interactive, carousel, scaffolded-question); its inner white ring exists to stay visible against the orange fill.

The likely correct long-term direction is to restyle these Lab Book buttons as the standard orange AP buttons with that shared focus ring, for full design-system consistency. That's **deferred** to keep this PR scoped to keyboard operability (WCAG 2.1.1 / 2.4.7). The drawing-tool toolbar's own teal (`#016082`) ring is left untouched.
---

## Try it in the Activity Player

https://activity-player.concord.org/branch/master/index.html?activity=sample-activity-all-question-interactives&override.qi=labbook-keyboard-accessible-toolbar

`override.qi=labbook-keyboard-accessible-toolbar` points the AP at this branch's deployed build (the deploy strips the `QI-156-` prefix). The sample activity includes the Lab Book. Keyboard checks: Tab to the drawing toolbar (incl. **Annotation**), **Take Snapshot** / **Upload Image**, and the thumbnail **delete** (✕); Enter/Space to activate; confirm visible focus rings; screen-reader announces the delete button as "Delete model …".