### PR TITLE
QI-181: Upgrade Blockly to v13.1.1 for built-in keyboard accessibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@adobe/css-tools": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.2.0.tgz",
@@ -46,23 +53,80 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
-      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@csstools/css-calc": "^2.1.3",
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "lru-cache": "^10.4.3"
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
       }
     },
     "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0",
+      "peer": true
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
@@ -3115,9 +3179,9 @@
       }
     },
     "node_modules/@csstools/color-helpers": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
-      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
       "funding": [
         {
           "type": "github",
@@ -3129,14 +3193,15 @@
         }
       ],
       "license": "MIT-0",
+      "peer": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
       "funding": [
         {
           "type": "github",
@@ -3148,18 +3213,19 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
-      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
       "funding": [
         {
           "type": "github",
@@ -3171,22 +3237,23 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@csstools/color-helpers": "^5.1.0",
-        "@csstools/css-calc": "^2.1.4"
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
       "funding": [
         {
           "type": "github",
@@ -3198,17 +3265,18 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
       "funding": [
         {
           "type": "github",
@@ -3220,8 +3288,9 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@cypress/request": {
@@ -3584,6 +3653,24 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@firebase/analytics": {
@@ -10635,6 +10722,16 @@
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "dev": true
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -12723,17 +12820,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -14532,17 +14618,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect": {
       "version": "29.6.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.6.0.tgz",
@@ -15815,14 +15890,6 @@
       "dependencies": {
         "ini": "^1.3.2"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/glob": {
       "version": "10.3.1",
@@ -21988,14 +22055,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/mkdirp-infer-owner": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mkdirp-infer-owner/-/mkdirp-infer-owner-2.0.0.tgz",
@@ -22203,14 +22262,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -22280,20 +22331,6 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/node-abi": {
-      "version": "3.77.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.77.0.tgz",
-      "integrity": "sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/node-addon-api": {
@@ -23037,6 +23074,7 @@
       "version": "2.2.22",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
       "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/nx": {
@@ -24668,92 +24706,6 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -25172,23 +25124,6 @@
       "integrity": "sha512-sf7oGoLuaYAScB4VGr0tzetsYlS8EJH6qnTCfQ/WVEa89hALQ4RQfCKt5xCyPQKPDUbVUAIP1QsxAwfAjlDp7Q==",
       "dev": true
     },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
     "node_modules/rc-slider": {
       "version": "11.1.9",
       "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-11.1.9.tgz",
@@ -25217,17 +25152,6 @@
       "peerDependencies": {
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/react": {
@@ -26415,12 +26339,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/rrweb-cssom": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
-      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-      "license": "MIT"
-    },
     "node_modules/rst-selector-parser": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
@@ -26552,7 +26470,8 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "devOptional": true
     },
     "node_modules/sane": {
       "version": "4.1.0",
@@ -27892,10 +27811,10 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true,
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -28775,28 +28694,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-fs/node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -29161,22 +29058,24 @@
       "integrity": "sha512-r0SSA5Y5IWERF9Xh++tFPx0jITBgGggOsRLDWWew6YRw/C2dr4uNO1fw1vanrBmHsICmPyMLNBZboTlxUmUuaA=="
     },
     "node_modules/tldts": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
-      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.8.tgz",
+      "integrity": "sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "tldts-core": "^6.1.86"
+        "tldts-core": "^7.4.8"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
-      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
-      "license": "MIT"
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.8.tgz",
+      "integrity": "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tmp": {
       "version": "0.2.1",
@@ -31327,12 +31226,12 @@
       "version": "1.27.0",
       "license": "MIT",
       "dependencies": {
-        "@blockly/field-slider": "8.0.2",
+        "@blockly/field-slider": "13.1.0",
         "@concord-consortium/dynamic-text": "^1.0.6",
         "@concord-consortium/lara-interactive-api": "1.14.0",
         "@concord-consortium/question-interactives-helpers": "^1.27.0",
         "@rjsf/utils": "^5.0.1",
-        "blockly": "12.3.0",
+        "blockly": "13.1.1",
         "chart.js": "^3.9.1",
         "classnames": "^2.3.1",
         "react": "^17.0.2",
@@ -31390,15 +31289,37 @@
       }
     },
     "packages/blockly/node_modules/@blockly/field-slider": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@blockly/field-slider/-/field-slider-8.0.2.tgz",
-      "integrity": "sha512-7CZsayIUcgFSAYnYWn6itkjo7WNIt+XOkp9bwzZA6Jhr9WfeJEZsUcXN/9tjKwJYD5rSUiFe2cARnuMlKCr15g==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@blockly/field-slider/-/field-slider-13.1.0.tgz",
+      "integrity": "sha512-ZCGYiuZqRjz3vw2FsVvM5mev30mLRFc86UvJ2zH5CPMLvIXDNdRozBvZTZq+mWsvC33TiaU2Bk88cIdyxZlNPQ==",
       "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      },
       "peerDependencies": {
-        "blockly": "^12.0.0"
+        "blockly": "^13.1.0"
+      }
+    },
+    "packages/blockly/node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peer": true,
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
       }
     },
     "packages/blockly/node_modules/agent-base": {
@@ -31406,86 +31327,101 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
     },
     "packages/blockly/node_modules/blockly": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.3.0.tgz",
-      "integrity": "sha512-dtxM6Dk8cm0QW4vMJTXmn7xi7a4GnQdXu28Esuuofx7DsYfq73456O5tm3ShUMDcXaFg8w3GVfgoH8I9v6gSVA==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-13.1.1.tgz",
+      "integrity": "sha512-0h3YDzlGclLKaZi9VHxyPjRJ9OFV6vw2+TMcolLZO1ZlgfY1Q79qDlGpH2nUYnTNiEVuJu9K6u6NHxqiPeRYOA==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "jsdom": "26.1.0"
-      },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "jsdom": "^27.4.0"
       }
     },
-    "packages/blockly/node_modules/canvas": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.0.tgz",
-      "integrity": "sha512-jk0GxrLtUEmW/TmFsk2WghvgHe8B0pxGilqCL21y8lHkPUGa6FTsnCNtHPOzT8O3y+N+m3espawV80bbBlgfTA==",
-      "hasInstallScript": true,
+    "packages/blockly/node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "license": "MIT",
-      "optional": true,
       "peer": true,
       "dependencies": {
-        "node-addon-api": "^7.0.0",
-        "prebuild-install": "^7.1.3"
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
-        "node": "^18.12.0 || >= 20.9.0"
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "packages/blockly/node_modules/cssstyle": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
-      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@asamuzakjp/css-color": "^3.2.0",
-        "rrweb-cssom": "^0.8.0"
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/blockly/node_modules/data-urls": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0"
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      }
+    },
+    "packages/blockly/node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
       }
     },
     "packages/blockly/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
-        "node": ">=0.12"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "packages/blockly/node_modules/html-encoding-sniffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "whatwg-encoding": "^3.1.1"
+        "@exodus/bytes": "^1.6.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "packages/blockly/node_modules/http-proxy-agent": {
@@ -31493,6 +31429,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -31506,6 +31443,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -31514,47 +31452,36 @@
         "node": ">= 14"
       }
     },
-    "packages/blockly/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "packages/blockly/node_modules/jsdom": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
-      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "cssstyle": "^4.2.1",
-        "data-urls": "^5.0.0",
-        "decimal.js": "^10.5.0",
-        "html-encoding-sniffer": "^4.0.0",
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.16",
-        "parse5": "^7.2.1",
-        "rrweb-cssom": "^0.8.0",
+        "parse5": "^8.0.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^5.1.1",
+        "tough-cookie": "^6.0.0",
         "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^3.1.1",
+        "webidl-conversions": "^8.0.0",
         "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.1.1",
-        "ws": "^8.18.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
         "canvas": "^3.0.0"
@@ -31565,21 +31492,31 @@
         }
       }
     },
-    "packages/blockly/node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT",
-      "optional": true,
+    "packages/blockly/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/blockly/node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0",
       "peer": true
     },
     "packages/blockly/node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "entities": "^6.0.0"
+        "entities": "^8.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -31590,6 +31527,7 @@
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
@@ -31598,27 +31536,29 @@
       }
     },
     "packages/blockly/node_modules/tough-cookie": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
-        "tldts": "^6.1.32"
+        "tldts": "^7.0.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "packages/blockly/node_modules/tr46": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/blockly/node_modules/w3c-xmlserializer": {
@@ -31626,6 +31566,7 @@
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "xml-name-validator": "^5.0.0"
       },
@@ -31634,24 +31575,13 @@
       }
     },
     "packages/blockly/node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "packages/blockly/node_modules/whatwg-encoding": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/blockly/node_modules/whatwg-mimetype": {
@@ -31659,28 +31589,31 @@
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "packages/blockly/node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/blockly/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -31702,6 +31635,7 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -33028,6 +32962,12 @@
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "dev": true
     },
+    "@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "peer": true
+    },
     "@adobe/css-tools": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.2.0.tgz",
@@ -33044,23 +32984,68 @@
       }
     },
     "@asamuzakjp/css-color": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
-      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "peer": true,
       "requires": {
-        "@csstools/css-calc": "^2.1.3",
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "lru-cache": "^10.4.3"
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
       },
       "dependencies": {
         "lru-cache": {
-          "version": "10.4.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+          "version": "11.5.2",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+          "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+          "peer": true
         }
       }
+    },
+    "@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "peer": true,
+      "requires": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      },
+      "dependencies": {
+        "css-tree": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+          "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+          "peer": true,
+          "requires": {
+            "mdn-data": "2.27.1",
+            "source-map-js": "^1.2.1"
+          }
+        },
+        "lru-cache": {
+          "version": "11.5.2",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+          "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+          "peer": true
+        },
+        "mdn-data": {
+          "version": "2.27.1",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+          "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+          "peer": true
+        }
+      }
+    },
+    "@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "peer": true
     },
     "@aws-crypto/crc32": {
       "version": "5.2.0",
@@ -35332,35 +35317,40 @@
       }
     },
     "@csstools/color-helpers": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
-      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "peer": true
     },
     "@csstools/css-calc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "peer": true,
       "requires": {}
     },
     "@csstools/css-color-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
-      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "peer": true,
       "requires": {
-        "@csstools/color-helpers": "^5.1.0",
-        "@csstools/css-calc": "^2.1.4"
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
       }
     },
     "@csstools/css-parser-algorithms": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "peer": true,
       "requires": {}
     },
     "@csstools/css-tokenizer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "peer": true
     },
     "@cypress/request": {
       "version": "3.0.1",
@@ -35654,6 +35644,13 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.44.0.tgz",
       "integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==",
       "dev": true
+    },
+    "@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "peer": true,
+      "requires": {}
     },
     "@firebase/analytics": {
       "version": "0.10.0",
@@ -41197,6 +41194,15 @@
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "dev": true
     },
+    "bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "peer": true,
+      "requires": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -41271,7 +41277,7 @@
     "blockly": {
       "version": "file:packages/blockly",
       "requires": {
-        "@blockly/field-slider": "8.0.2",
+        "@blockly/field-slider": "13.1.0",
         "@concord-consortium/dynamic-text": "^1.0.6",
         "@concord-consortium/lara-interactive-api": "1.14.0",
         "@concord-consortium/question-interactives-helpers": "^1.27.0",
@@ -41294,7 +41300,7 @@
         "@typescript-eslint/parser": "^5.46.1",
         "@wojtekmaj/enzyme-adapter-react-17": "^0.8.0",
         "autoprefixer": "^9.8.8",
-        "blockly": "12.3.0",
+        "blockly": "13.1.1",
         "chart.js": "^3.9.1",
         "classnames": "^2.3.1",
         "css-loader": "^4.3.0",
@@ -41332,70 +41338,90 @@
       },
       "dependencies": {
         "@blockly/field-slider": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/@blockly/field-slider/-/field-slider-8.0.2.tgz",
-          "integrity": "sha512-7CZsayIUcgFSAYnYWn6itkjo7WNIt+XOkp9bwzZA6Jhr9WfeJEZsUcXN/9tjKwJYD5rSUiFe2cARnuMlKCr15g==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@blockly/field-slider/-/field-slider-13.1.0.tgz",
+          "integrity": "sha512-ZCGYiuZqRjz3vw2FsVvM5mev30mLRFc86UvJ2zH5CPMLvIXDNdRozBvZTZq+mWsvC33TiaU2Bk88cIdyxZlNPQ==",
+          "requires": {}
+        },
+        "@csstools/css-syntax-patches-for-csstree": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+          "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+          "peer": true,
           "requires": {}
         },
         "agent-base": {
           "version": "7.1.4",
           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-          "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
+          "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+          "peer": true
         },
         "blockly": {
-          "version": "12.3.0",
-          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.3.0.tgz",
-          "integrity": "sha512-dtxM6Dk8cm0QW4vMJTXmn7xi7a4GnQdXu28Esuuofx7DsYfq73456O5tm3ShUMDcXaFg8w3GVfgoH8I9v6gSVA==",
-          "requires": {
-            "jsdom": "26.1.0"
-          }
+          "version": "13.1.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-13.1.1.tgz",
+          "integrity": "sha512-0h3YDzlGclLKaZi9VHxyPjRJ9OFV6vw2+TMcolLZO1ZlgfY1Q79qDlGpH2nUYnTNiEVuJu9K6u6NHxqiPeRYOA==",
+          "requires": {}
         },
-        "canvas": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.0.tgz",
-          "integrity": "sha512-jk0GxrLtUEmW/TmFsk2WghvgHe8B0pxGilqCL21y8lHkPUGa6FTsnCNtHPOzT8O3y+N+m3espawV80bbBlgfTA==",
-          "optional": true,
+        "css-tree": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+          "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
           "peer": true,
           "requires": {
-            "node-addon-api": "^7.0.0",
-            "prebuild-install": "^7.1.3"
+            "mdn-data": "2.27.1",
+            "source-map-js": "^1.2.1"
           }
         },
         "cssstyle": {
-          "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
-          "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+          "version": "5.3.7",
+          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+          "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+          "peer": true,
           "requires": {
-            "@asamuzakjp/css-color": "^3.2.0",
-            "rrweb-cssom": "^0.8.0"
+            "@asamuzakjp/css-color": "^4.1.1",
+            "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+            "css-tree": "^3.1.0",
+            "lru-cache": "^11.2.4"
           }
         },
         "data-urls": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-          "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+          "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+          "peer": true,
           "requires": {
-            "whatwg-mimetype": "^4.0.0",
-            "whatwg-url": "^14.0.0"
+            "whatwg-mimetype": "^5.0.0",
+            "whatwg-url": "^15.1.0"
+          },
+          "dependencies": {
+            "whatwg-mimetype": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+              "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+              "peer": true
+            }
           }
         },
         "entities": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-          "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+          "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+          "peer": true
         },
         "html-encoding-sniffer": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-          "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+          "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+          "peer": true,
           "requires": {
-            "whatwg-encoding": "^3.1.1"
+            "@exodus/bytes": "^1.6.0"
           }
         },
         "http-proxy-agent": {
           "version": "7.0.2",
           "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
           "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+          "peer": true,
           "requires": {
             "agent-base": "^7.1.0",
             "debug": "^4.3.4"
@@ -41405,81 +41431,84 @@
           "version": "7.0.6",
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
           "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+          "peer": true,
           "requires": {
             "agent-base": "^7.1.2",
             "debug": "4"
           }
         },
-        "iconv-lite": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        },
         "jsdom": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
-          "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+          "version": "27.4.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+          "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+          "peer": true,
           "requires": {
-            "cssstyle": "^4.2.1",
-            "data-urls": "^5.0.0",
-            "decimal.js": "^10.5.0",
-            "html-encoding-sniffer": "^4.0.0",
+            "@acemir/cssom": "^0.9.28",
+            "@asamuzakjp/dom-selector": "^6.7.6",
+            "@exodus/bytes": "^1.6.0",
+            "cssstyle": "^5.3.4",
+            "data-urls": "^6.0.0",
+            "decimal.js": "^10.6.0",
+            "html-encoding-sniffer": "^6.0.0",
             "http-proxy-agent": "^7.0.2",
             "https-proxy-agent": "^7.0.6",
             "is-potential-custom-element-name": "^1.0.1",
-            "nwsapi": "^2.2.16",
-            "parse5": "^7.2.1",
-            "rrweb-cssom": "^0.8.0",
+            "parse5": "^8.0.0",
             "saxes": "^6.0.0",
             "symbol-tree": "^3.2.4",
-            "tough-cookie": "^5.1.1",
+            "tough-cookie": "^6.0.0",
             "w3c-xmlserializer": "^5.0.0",
-            "webidl-conversions": "^7.0.0",
-            "whatwg-encoding": "^3.1.1",
+            "webidl-conversions": "^8.0.0",
             "whatwg-mimetype": "^4.0.0",
-            "whatwg-url": "^14.1.1",
-            "ws": "^8.18.0",
+            "whatwg-url": "^15.1.0",
+            "ws": "^8.18.3",
             "xml-name-validator": "^5.0.0"
           }
         },
-        "node-addon-api": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-          "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-          "optional": true,
+        "lru-cache": {
+          "version": "11.5.2",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+          "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+          "peer": true
+        },
+        "mdn-data": {
+          "version": "2.27.1",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+          "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
           "peer": true
         },
         "parse5": {
-          "version": "7.3.0",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-          "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+          "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+          "peer": true,
           "requires": {
-            "entities": "^6.0.0"
+            "entities": "^8.0.0"
           }
         },
         "saxes": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
           "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+          "peer": true,
           "requires": {
             "xmlchars": "^2.2.0"
           }
         },
         "tough-cookie": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-          "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+          "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+          "peer": true,
           "requires": {
-            "tldts": "^6.1.32"
+            "tldts": "^7.0.5"
           }
         },
         "tr46": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-          "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+          "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+          "peer": true,
           "requires": {
             "punycode": "^2.3.1"
           }
@@ -41488,47 +41517,45 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
           "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+          "peer": true,
           "requires": {
             "xml-name-validator": "^5.0.0"
           }
         },
         "webidl-conversions": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
-        },
-        "whatwg-encoding": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-          "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-          "requires": {
-            "iconv-lite": "0.6.3"
-          }
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+          "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+          "peer": true
         },
         "whatwg-mimetype": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-          "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="
+          "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+          "peer": true
         },
         "whatwg-url": {
-          "version": "14.2.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-          "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+          "version": "15.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+          "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+          "peer": true,
           "requires": {
-            "tr46": "^5.1.0",
-            "webidl-conversions": "^7.0.0"
+            "tr46": "^6.0.0",
+            "webidl-conversions": "^8.0.0"
           }
         },
         "ws": {
-          "version": "8.18.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-          "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+          "version": "8.21.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+          "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+          "peer": true,
           "requires": {}
         },
         "xml-name-validator": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
-          "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="
+          "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+          "peer": true
         }
       }
     },
@@ -43172,13 +43199,6 @@
         }
       }
     },
-    "deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "optional": true,
-      "peer": true
-    },
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -44677,13 +44697,6 @@
         }
       }
     },
-    "expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "optional": true,
-      "peer": true
-    },
     "expect": {
       "version": "29.6.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.6.0.tgz",
@@ -45769,13 +45782,6 @@
       "requires": {
         "ini": "^1.3.2"
       }
-    },
-    "github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "optional": true,
-      "peer": true
     },
     "glob": {
       "version": "10.3.1",
@@ -50883,13 +50889,6 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "devOptional": true
     },
-    "mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "optional": true,
-      "peer": true
-    },
     "mkdirp-infer-owner": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mkdirp-infer-owner/-/mkdirp-infer-owner-2.0.0.tgz",
@@ -51140,13 +51139,6 @@
         "to-regex": "^3.0.1"
       }
     },
-    "napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "optional": true,
-      "peer": true
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -51205,16 +51197,6 @@
       "requires": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
-      }
-    },
-    "node-abi": {
-      "version": "3.77.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.77.0.tgz",
-      "integrity": "sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "semver": "^7.3.5"
       }
     },
     "node-addon-api": {
@@ -51790,7 +51772,8 @@
     "nwsapi": {
       "version": "2.2.22",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
-      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ=="
+      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+      "devOptional": true
     },
     "nx": {
       "version": "15.9.4",
@@ -53083,58 +53066,6 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
-    "prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "dependencies": {
-        "decompress-response": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-          "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "mimic-response": "^3.1.0"
-          }
-        },
-        "mimic-response": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-          "optional": true,
-          "peer": true
-        },
-        "simple-get": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-          "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "decompress-response": "^6.0.0",
-            "once": "^1.3.1",
-            "simple-concat": "^1.0.0"
-          }
-        }
-      }
-    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -53459,28 +53390,6 @@
       "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
       "integrity": "sha512-sf7oGoLuaYAScB4VGr0tzetsYlS8EJH6qnTCfQ/WVEa89hALQ4RQfCKt5xCyPQKPDUbVUAIP1QsxAwfAjlDp7Q==",
       "dev": true
-    },
-    "rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "dependencies": {
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-          "optional": true,
-          "peer": true
-        }
-      }
     },
     "rc-slider": {
       "version": "11.1.9",
@@ -54417,11 +54326,6 @@
         }
       }
     },
-    "rrweb-cssom": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
-      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="
-    },
     "rst-selector-parser": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
@@ -54526,7 +54430,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "devOptional": true
     },
     "sane": {
       "version": "4.1.0",
@@ -55754,10 +55659,9 @@
       "devOptional": true
     },
     "source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -56496,28 +56400,6 @@
         }
       }
     },
-    "tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      },
-      "dependencies": {
-        "chownr": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-          "optional": true,
-          "peer": true
-        }
-      }
-    },
     "tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -56774,17 +56656,19 @@
       "integrity": "sha512-r0SSA5Y5IWERF9Xh++tFPx0jITBgGggOsRLDWWew6YRw/C2dr4uNO1fw1vanrBmHsICmPyMLNBZboTlxUmUuaA=="
     },
     "tldts": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
-      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.8.tgz",
+      "integrity": "sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==",
+      "peer": true,
       "requires": {
-        "tldts-core": "^6.1.86"
+        "tldts-core": "^7.4.8"
       }
     },
     "tldts-core": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
-      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.8.tgz",
+      "integrity": "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==",
+      "peer": true
     },
     "tmp": {
       "version": "0.2.1",

--- a/packages/blockly/package.json
+++ b/packages/blockly/package.json
@@ -111,12 +111,12 @@
     "webpack-dev-server": "^4.7.4"
   },
   "dependencies": {
-    "@blockly/field-slider": "8.0.2",
+    "@blockly/field-slider": "13.1.0",
     "@concord-consortium/dynamic-text": "^1.0.6",
     "@concord-consortium/lara-interactive-api": "1.14.0",
     "@concord-consortium/question-interactives-helpers": "^1.27.0",
     "@rjsf/utils": "^5.0.1",
-    "blockly": "12.3.0",
+    "blockly": "13.1.1",
     "chart.js": "^3.9.1",
     "classnames": "^2.3.1",
     "react": "^17.0.2",

--- a/packages/blockly/src/components/blockly.tsx
+++ b/packages/blockly/src/components/blockly.tsx
@@ -9,6 +9,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { registerCustomBlocks } from "../blocks/block-factory";
 import "../blocks/block-registration";
 import { saveEvents } from "../utils/block-utils";
+import { BLOCKLY_RENDERER } from "../utils/blockly-options";
 import { hasAuthoredStarterContent, parseStarterProgram } from "../utils/starter-utils";
 import { injectCustomBlocksIntoToolbox } from "../utils/toolbox-utils";
 import { IAuthoredState, IInteractiveState, INITIAL_SEED_BLOCKS, SEED_BLOCK_TYPES } from "./types";
@@ -70,7 +71,8 @@ export const BlocklyComponent: React.FC<IProps> = ({ authoredState, interactiveS
         // Inject custom blocks into toolbox based on their assigned categories
         const enhancedToolbox = injectCustomBlocksIntoToolbox(toolbox, safeCustomBlocks);
         const newWorkspace = inject(blocklyDivRef.current, {
-          readOnly: report, toolbox: JSON.parse(enhancedToolbox), trashcan: true
+          readOnly: report, toolbox: JSON.parse(enhancedToolbox), trashcan: true,
+          renderer: BLOCKLY_RENDERER
         });
         workspaceRef.current = newWorkspace;
         setError(null);

--- a/packages/blockly/src/components/custom-block-form-child-blocks.tsx
+++ b/packages/blockly/src/components/custom-block-form-child-blocks.tsx
@@ -3,6 +3,7 @@ import React, { MutableRefObject, useEffect, useRef } from "react";
 
 import { registerCustomBlocks } from "../blocks/block-factory";
 import { saveEvents, stateContainsType } from "../utils/block-utils";
+import { BLOCKLY_RENDERER } from "../utils/blockly-options";
 import { injectCustomBlocksIntoToolbox } from "../utils/toolbox-utils";
 import { ICustomBlock } from "./types";
 
@@ -56,7 +57,8 @@ export const CustomBlockFormChildBlocks = ({
     // Inject custom blocks into toolbox based on their assigned categories
     const enhancedToolbox = injectCustomBlocksIntoToolbox(toolbox, safeBlocks);
     const newWorkspace = inject(childBlocksContainerRef.current, {
-      readOnly: false, toolbox: JSON.parse(enhancedToolbox), trashcan: true
+      readOnly: false, toolbox: JSON.parse(enhancedToolbox), trashcan: true,
+      renderer: BLOCKLY_RENDERER
     });
 
     // Add the current template to the workspace and render it

--- a/packages/blockly/src/components/custom-block-form-child-blocks.tsx
+++ b/packages/blockly/src/components/custom-block-form-child-blocks.tsx
@@ -91,6 +91,10 @@ export const CustomBlockFormChildBlocks = ({
     const childBlocksContainer = childBlocksContainerRef.current;
     return () => {
       newWorkspace.removeChangeListener(saveState);
+      // Clearing innerHTML drops the DOM but leaves the workspace registered with Blockly's
+      // global focus manager and shortcut registry, so an undisposed workspace can still
+      // react to keystrokes. This effect re-runs often as the authoring form re-renders.
+      newWorkspace.dispose();
       if (childBlocksContainer) childBlocksContainer.innerHTML = "";
     };
   }, [childBlocks, childBlocksRef, currentOption, editingBlock, existingBlocks, optionChildBlocksRef, setHasChange, toolbox]);

--- a/packages/blockly/src/components/report-item/get-report-item-html.tsx
+++ b/packages/blockly/src/components/report-item/get-report-item-html.tsx
@@ -1,6 +1,7 @@
 import { IAuthoredState, IInteractiveState } from "../types";
-import { inject, serialization } from "blockly";
+import { inject, serialization, VERSION } from "blockly";
 import { registerCustomBlocks } from "../../blocks/block-factory";
+import { BLOCKLY_RENDERER } from "../../utils/blockly-options";
 import { injectCustomBlocksIntoToolbox } from "../../utils/toolbox-utils";
 
 import "../../blocks/block-registration";
@@ -49,7 +50,10 @@ export const getReportItemHtml = ({ interactiveState, authoredState }: IProps) =
       trashcan: false,
       scrollbars: false,
       zoom: { controls: false, wheel: false, startScale: 0.4, minScale: 0.4, maxScale: 0.4, scaleSpeed: 1 },
-      media: "https://unpkg.com/blockly/media/",
+      renderer: BLOCKLY_RENDERER,
+      // Pinned to the Blockly we actually bundle. An unversioned unpkg URL serves whatever
+      // is latest, which can drift out from under this build; VERSION tracks package.json.
+      media: `https://unpkg.com/blockly@${VERSION}/media/`,
     });
 
     serialization.workspaces.load(blocklyStateJson, workspace);

--- a/packages/blockly/src/components/starter-program-editor.tsx
+++ b/packages/blockly/src/components/starter-program-editor.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useMemo, useRef } from "react";
 import "../blocks/block-registration";
 import { registerCustomBlocks } from "../blocks/block-factory";
 import { saveEvents } from "../utils/block-utils";
+import { BLOCKLY_RENDERER } from "../utils/blockly-options";
 import { buildValidTypeSet, pruneStarterState } from "../utils/starter-utils";
 import { injectCustomBlocksIntoToolbox } from "../utils/toolbox-utils";
 import { ICustomBlock, INITIAL_SEED_BLOCKS, SEED_BLOCK_TYPES } from "./types";
@@ -55,7 +56,8 @@ export const StarterProgramEditor: React.FC<IProps> = ({ customBlocks, starterBl
     try {
       const parsedToolbox = JSON.parse(enhancedToolbox);
       workspace = inject(container, {
-        readOnly: false, toolbox: parsedToolbox, trashcan: true
+        readOnly: false, toolbox: parsedToolbox, trashcan: true,
+        renderer: BLOCKLY_RENDERER
       });
 
       if (effectiveStarter) {

--- a/packages/blockly/src/setupTests.ts
+++ b/packages/blockly/src/setupTests.ts
@@ -21,6 +21,89 @@ if (typeof globalThis.crypto === "undefined") {
 // Mock window.alert
 global.alert = jest.fn();
 
+// Blockly 13 fetches its workspace sounds during inject(). jsdom provides no global
+// fetch, and the resulting unhandled rejection kills the Jest worker rather than
+// failing a test, so every suite that injects a workspace must have one available.
+// jsdom has no AudioContext either, so Blockly skips decoding whatever this returns.
+if (typeof globalThis.fetch === "undefined") {
+  (globalThis as any).fetch = jest.fn(() =>
+    Promise.resolve({ arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)) })
+  );
+}
+
+// Blockly 13's stylesheet uses `:has()` nested inside `:not()` for its keyboard-focus
+// rules. jsdom's selector engine (nwsapi) cannot parse that and throws "is not a valid
+// selector" out of inject(), so no workspace renders under test. jsdom only fixed this
+// in v27 by replacing nwsapi, and no jest-environment-jsdom runs a jsdom that new.
+// Dropping the offending rules keeps the rest of the stylesheet intact; they only drive
+// focus-ring styling, which jsdom does not render and no test asserts on.
+//
+// This is a workaround for a jsdom limitation, not a Blockly one, so it is gated on the
+// limitation itself rather than on a version number: the day jsdom can parse the selector,
+// the check below fails and tells us to delete all of this.
+const BLOCKLY_FOCUS_SELECTOR =
+  ".blocklyKeyboardNavigation:not(:has(.blocklyDropDownDiv:focus-within, .blocklyWidgetDiv:focus-within)) " +
+  ".blocklyPassiveFocus:is(.blocklyPath, .blocklyHighlightedConnectionPath)";
+
+const selectorEngineRejectsHas = (() => {
+  try {
+    document.createElement("div").matches(BLOCKLY_FOCUS_SELECTOR);
+    return false;
+  } catch {
+    return true;
+  }
+})();
+
+if (!selectorEngineRejectsHas) {
+  throw new Error(
+    "jsdom can now parse Blockly's `:has()` focus selectors, so the stylesheet workaround " +
+    "in setupTests.ts is obsolete. Delete removeHasRules and the HTMLStyleElement " +
+    "textContent patch below (and this check), then re-run the tests."
+  );
+}
+
+const removeHasRules = (css: string): string => {
+  let out = "";
+  let i = 0;
+  while (i < css.length) {
+    const open = css.indexOf("{", i);
+    if (open === -1) {
+      out += css.slice(i);
+      break;
+    }
+    const prelude = css.slice(i, open);
+    let depth = 1;
+    let j = open + 1;
+    while (j < css.length && depth > 0) {
+      if (css[j] === "{") depth++;
+      else if (css[j] === "}") depth--;
+      j++;
+    }
+    const body = css.slice(open + 1, j - 1);
+    if (prelude.trimStart().startsWith("@")) {
+      // At-rules (@media, @supports) nest further rules, so recurse into the block.
+      out += `${prelude}{${removeHasRules(body)}}`;
+    } else if (!prelude.includes(":has(")) {
+      out += css.slice(i, j);
+    }
+    i = j;
+  }
+  return out;
+};
+
+const textContent = Object.getOwnPropertyDescriptor(Node.prototype, "textContent");
+if (textContent?.get && textContent?.set) {
+  Object.defineProperty(HTMLStyleElement.prototype, "textContent", {
+    configurable: true,
+    get(this: HTMLStyleElement) {
+      return textContent.get?.call(this);
+    },
+    set(this: HTMLStyleElement, value: string) {
+      textContent.set?.call(this, removeHasRules(String(value ?? "")));
+    },
+  });
+}
+
 // https://www.benmvp.com/blog/quick-trick-jest-asynchronous-tests/
 beforeEach(() => {
   // ensure there's at least one assertion run for every test case

--- a/packages/blockly/src/setupTests.ts
+++ b/packages/blockly/src/setupTests.ts
@@ -25,11 +25,15 @@ global.alert = jest.fn();
 // fetch, and the resulting unhandled rejection kills the Jest worker rather than
 // failing a test, so every suite that injects a workspace must have one available.
 // jsdom has no AudioContext either, so Blockly skips decoding whatever this returns.
-if (typeof globalThis.fetch === "undefined") {
-  (globalThis as any).fetch = jest.fn(() =>
-    Promise.resolve({ arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)) })
-  );
-}
+// Stub unconditionally: were the environment ever to supply a real fetch, tests would
+// silently start requesting the sound files over the network.
+(globalThis as any).fetch = jest.fn(() =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+  })
+);
 
 // Blockly 13's stylesheet uses `:has()` nested inside `:not()` for its keyboard-focus
 // rules. jsdom's selector engine (nwsapi) cannot parse that and throws "is not a valid
@@ -99,7 +103,11 @@ if (textContent?.get && textContent?.set) {
       return textContent.get?.call(this);
     },
     set(this: HTMLStyleElement, value: string) {
-      textContent.set?.call(this, removeHasRules(String(value ?? "")));
+      const css = String(value ?? "");
+      // Only touch Blockly's own stylesheet. Rewriting every <style> in the suite could
+      // strip `:has()` from unrelated code and hide a genuine selector problem there.
+      const isBlocklyStylesheet = this.id === "blockly-common-style" || css.includes(".blockly");
+      textContent.set?.call(this, isBlocklyStylesheet ? removeHasRules(css) : css);
     },
   });
 }

--- a/packages/blockly/src/setupTests.ts
+++ b/packages/blockly/src/setupTests.ts
@@ -96,21 +96,29 @@ const removeHasRules = (css: string): string => {
 };
 
 const textContent = Object.getOwnPropertyDescriptor(Node.prototype, "textContent");
-if (textContent?.get && textContent?.set) {
-  Object.defineProperty(HTMLStyleElement.prototype, "textContent", {
-    configurable: true,
-    get(this: HTMLStyleElement) {
-      return textContent.get?.call(this);
-    },
-    set(this: HTMLStyleElement, value: string) {
-      const css = String(value ?? "");
-      // Only touch Blockly's own stylesheet. Rewriting every <style> in the suite could
-      // strip `:has()` from unrelated code and hide a genuine selector problem there.
-      const isBlocklyStylesheet = this.id === "blockly-common-style" || css.includes(".blockly");
-      textContent.set?.call(this, isBlocklyStylesheet ? removeHasRules(css) : css);
-    },
-  });
+if (!textContent?.get || !textContent?.set) {
+  // We know from the probe above that the workaround is still needed. Skipping it silently
+  // would surface later as an opaque selector-parse failure out of inject(), so say so here.
+  throw new Error(
+    "Cannot patch HTMLStyleElement.textContent: Node.prototype.textContent is not an " +
+    "accessor in this environment, so Blockly's `:has()` rules cannot be stripped. " +
+    "The suite will fail on selector parsing until this shim is reworked."
+  );
 }
+
+Object.defineProperty(HTMLStyleElement.prototype, "textContent", {
+  configurable: true,
+  get(this: HTMLStyleElement) {
+    return textContent.get?.call(this);
+  },
+  set(this: HTMLStyleElement, value: string) {
+    const css = String(value ?? "");
+    // Only touch Blockly's own stylesheet. Rewriting every <style> in the suite could
+    // strip `:has()` from unrelated code and hide a genuine selector problem there.
+    const isBlocklyStylesheet = this.id === "blockly-common-style" || css.includes(".blockly");
+    textContent.set?.call(this, isBlocklyStylesheet ? removeHasRules(css) : css);
+  },
+});
 
 // https://www.benmvp.com/blog/quick-trick-jest-asynchronous-tests/
 beforeEach(() => {

--- a/packages/blockly/src/utils/blockly-options.ts
+++ b/packages/blockly/src/utils/blockly-options.ts
@@ -4,6 +4,8 @@
  * so leaving the default in place would restyle every student's blocks as a side effect
  * of an accessibility upgrade. We pin geras to keep the appearance unchanged.
  *
- * This is shared by all four `inject()` sites so they cannot drift apart.
+ * Shared by every `inject()` site that renders for a user — the runtime, both authoring
+ * workspaces, and the report item — so they cannot drift apart. (A test injects a bare
+ * workspace directly; the renderer does not matter there.)
  */
 export const BLOCKLY_RENDERER = "geras";

--- a/packages/blockly/src/utils/blockly-options.ts
+++ b/packages/blockly/src/utils/blockly-options.ts
@@ -1,0 +1,9 @@
+/**
+ * Blockly 13 changed the default renderer from `geras` to `thrasos`. Thrasos drops the
+ * bevel that geras draws on each block (the `blocklyPathLight`/`blocklyPathDark` paths),
+ * so leaving the default in place would restyle every student's blocks as a side effect
+ * of an accessibility upgrade. We pin geras to keep the appearance unchanged.
+ *
+ * This is shared by all four `inject()` sites so they cannot drift apart.
+ */
+export const BLOCKLY_RENDERER = "geras";

--- a/packages/tests-e2e/e2e/blockly.test.js
+++ b/packages/tests-e2e/e2e/blockly.test.js
@@ -1,0 +1,78 @@
+import { phonePost } from "../support/e2e";
+
+// The runtime seeds an empty workspace with these three blocks, none of which may be deleted.
+const SEED_BLOCKS = [
+  { type: "setup", label: "setup" },
+  { type: "go", label: "go" },
+  { type: "onclick", label: "on mouse click" }
+];
+
+const authoredState = {
+  version: 1,
+  questionType: "iframe_interactive",
+  simulationCode: "",
+  customBlocks: [],
+  toolbox: JSON.stringify({
+    kind: "flyoutToolbox",
+    contents: [
+      { kind: "block", type: "controls_if" }
+    ]
+  })
+};
+
+context("Test blockly interactive", () => {
+  beforeEach(() => {
+    cy.visit("/wrapper.html?iframe=/blockly");
+    phonePost("initInteractive", { mode: "runtime", authoredState });
+  });
+
+  context("Runtime view", () => {
+    it("renders the workspace with the seed blocks", () => {
+      cy.getIframeBody().find(".injectionDiv").should("exist");
+      SEED_BLOCKS.forEach(({ type }) => {
+        cy.getIframeBody().find(`g.${type}.blocklyNotDeletable`).should("exist");
+      });
+    });
+
+    // Blockly announces through a single live region created during inject(), and names each
+    // block on the path that renders it. Screen reader users have neither without these.
+    it("exposes the workspace and blocks to screen readers", () => {
+      cy.getIframeBody().find("#blocklyAriaAnnounce")
+        .should("have.attr", "role", "status")
+        .and("have.attr", "aria-live", "polite");
+
+      SEED_BLOCKS.forEach(({ type, label }) => {
+        cy.getIframeBody().find(`g.${type} > path.blocklyPath`)
+          .should("have.attr", "role", "figure")
+          .and("have.attr", "aria-label")
+          .and("contain", label);
+      });
+    });
+
+    // Blockly deliberately keeps blocks out of the tab order — block code cannot be usefully
+    // linearized — so the workspace is the tab stop and arrow keys move a cursor into it.
+    it("lets a keyboard user reach a block", () => {
+      cy.getIframeBody().find("g.blocklyWorkspace").should("have.attr", "tabindex", "0");
+
+      cy.getIframeBody().find(".blocklyMainBackground").click({ force: true });
+      cy.getIframeBody().find("g.blocklyWorkspace.blocklyActiveFocus").should("exist");
+
+      // Blockly reads KeyboardEvent fields, so a plain Event (Cypress's default) is ignored.
+      cy.getIframeBody().find("g.blocklyWorkspace.blocklyActiveFocus")
+        .trigger("keydown", {
+          eventConstructor: "KeyboardEvent",
+          key: "ArrowDown",
+          code: "ArrowDown",
+          keyCode: 40,
+          which: 40,
+          bubbles: true,
+          cancelable: true
+        });
+
+      // Focus lands on a block, and it carries the name a screen reader would read out.
+      cy.getIframeBody().find("path.blocklyPath.blocklyActiveFocus")
+        .should("exist")
+        .and("have.attr", "aria-label");
+    });
+  });
+});


### PR DESCRIPTION
Upgrades Blockly to v13.1.1, which moves keyboard navigation and screen-reader support into core. This is the enabling dependency for QI-160 (Blockly Interactive: Make fully keyboard accessible).

This supersedes the QI-175 spike, which recommended staying on Blockly 12 and adding `@blockly/keyboard-navigation`. Blockly 13 shipped a week before that spike was written; the plugin has no v13-compatible release and upstream directs integrators to drop it. We never installed it, so there was nothing to remove.

## Changes

- `blockly` 12.3.0 → 13.1.1
- `@blockly/field-slider` 8.0.2 → 13.1.0 (peers on `blockly ^13.1.0`, so 13.0.x would not satisfy it)
- **Renderer pinned to `geras`.** Blockly 13 changed the default to `thrasos`, which omits the bevel `geras` draws on each block. Accepting the default would have restyled every student's blocks as a side effect of an accessibility upgrade. Shared via one `BLOCKLY_RENDERER` constant so the user-facing `inject()` sites cannot drift apart.
- **Report-item media URL now derives from Blockly's `VERSION` export.** It was an unversioned `unpkg.com/blockly/media/` path serving whatever is latest, which could drift out from under the build.
- **New Cypress spec for the blockly interactive** (see below).

## The interesting part: Blockly 13 cannot run under Jest's jsdom

This was scoped as a mechanical bump. It wasn't — nearly all the work was the test environment.

Blockly 13's stylesheet uses `:has()` nested inside `:not()` for its keyboard-focus rules. jsdom's selector engine (nwsapi) cannot parse that and throws "is not a valid selector" out of `inject()`, so no workspace renders under test. Six suites / 17 tests failed.

Every option is blocked:

- jsdom 16, 20, 22, 26 all use nwsapi and all throw (verified each).
- jsdom 29 fixed it by replacing nwsapi with `@asamuzakjp/dom-selector` (verified working).
- But jsdom 27+ is incompatible with `jest-environment-jsdom` — any version, including Jest 29's and Jest 30's. It dies with `ReferenceError: global is not defined`.
- And Jest 29 in this one workspace triggers `ERESOLVE` against the 23 other packages peer-pinned to Jest 26.

So no Jest + jsdom combination available today can run Blockly 13's real `inject()`. This is a gap between two upstream projects, not a misconfiguration.

**Workaround:** strip Blockly's `:has()` rules from its stylesheet inside the test environment, scoped to Blockly's own `<style>` element. Those rules only drive focus-ring styling, which jsdom does not render and no test asserts on. It is gated on a **feature probe rather than a version number**, so the day jsdom can parse the selector the test run fails loudly and tells us to delete it.

Separately, Blockly 13 fetches its workspace sounds during `inject()`. jsdom has no global `fetch`, and the unhandled rejection killed the Jest worker outright rather than failing a test — the source of the opaque "Call retries were exceeded" errors.

## New: e2e coverage for the blockly interactive

The blockly interactive had **no Cypress coverage at all**, which meant CI exercised this upgrade only through jsdom — the one environment that cannot render Blockly's focus system or process its keyboard shortcuts. `packages/tests-e2e/e2e/blockly.test.js` closes that gap with three tests, run in real Chrome:

1. **Renders the workspace with the seed blocks** — `.injectionDiv` injects; `setup`, `go`, and `onclick` all render as `.blocklyNotDeletable`.
2. **Exposes the workspace and blocks to screen readers** — the `role="status"` / `aria-live="polite"` live region exists, and each block is named on its `path.blocklyPath` via `role="figure"` and an `aria-label` (e.g. `"Begin stack, setup, empty"`). **Neither existed on Blockly 12**, so this is the assertion that fails if the upgrade is reverted.
3. **Lets a keyboard user reach a block** — the workspace is the tab stop, and an arrow key moves focus onto a named block.

Blockly deliberately keeps blocks out of the tab order (block code cannot be usefully linearized), so the workspace is a single tab stop and arrow keys move a cursor within it. The spec asserts that real design rather than an assumed one.

Keyboard drag-and-drop is deliberately **out of scope here** — it belongs to QI-160.

## Breaking changes that did not affect us

Nullable connection types (zero TS errors in `src/`), events dropping XML (we never read `BlockCreate.xml` / `BlockDelete.oldXml`), `engines: node >= 22` (CI already on 22), and the injection-div DOM reorder / `box-sizing` change.

## Verification

287 Jest tests pass across 23 suites, plus the 3 new Cypress tests. Lint clean. Production build succeeds.

Driven in a real browser (Playwright during development, Cypress in CI):

- All four workspaces render, and the blocks are pixel-identical to v12 under the pinned `geras` renderer.
- `div#blocklyAriaAnnounce` with `role="status"` / `aria-live="polite"` now exists. This is **AC #5 of QI-160**, which the QI-175 spike judged upstream-blocked and recommended deferring — it ships in core.
- Blocks are now named for screen readers (`role="figure"` + `aria-label`); on v12 they carried **no ARIA at all**.
- Focusing the workspace and pressing an arrow key moves focus onto a block, and Blockly announces through the live region.
- Seed blocks (`setup`, `go`, `on mouse click`) remain non-deletable.

To be precise about what has **not** been demonstrated: a full keyboard drag (pick up with `M`, move, drop with `Enter`) has not been exercised end to end. That is QI-160's job, not this PR's.

## Not verified — please don't assume these are done

1. **Single-key shortcut collisions in authoring.** Blockly 13 registers `M`/`T`/`C`/`I`/`D` globally, and two of our four workspaces are embedded in the RJSF authoring form beside text inputs. The demo harness renders its authoring iframe empty, so I could not exercise this. Needs a manual check in real LARA authoring: type letters into an authoring field and confirm blocks do not move.
2. **Existing saved student work.** Tests use fixtures. Blockly 13 did not change the serialization format and the legacy XML mutator in `block-factory.ts` survives the suite, but that is not the same as loading a real student's program.
3. **Safari 15.4 floor.** Blockly 13 relies on the CSS `:has()` selector. Needs a product decision, or a polyfill.

These three are called out on QI-181 for project team review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
