### PR TITLE
fix: programmatic label for agent-sim slider readout input [QI-161]

### DIFF
--- a/packages/agent-simulation/src/widgets/circular-slider-widget.test.tsx
+++ b/packages/agent-simulation/src/widgets/circular-slider-widget.test.tsx
@@ -92,6 +92,12 @@ describe("CircularSliderWidget", () => {
       renderWidget({ data: { ...defaultData, showReadout: undefined } });
       expect(screen.queryByTestId("slider-widget-input")).toBeNull();
     });
+
+    it("gives the readout input an accessible name matching the visible label", () => {
+      mockGlobals.set("foo", 42);
+      renderWidget({ data: { ...defaultData, showReadout: true } });
+      expect(screen.getByRole("spinbutton", { name: "Test Label Text" })).toBeInTheDocument();
+    });
   });
 
   describe("functionality", () => {

--- a/packages/agent-simulation/src/widgets/circular-slider-widget.tsx
+++ b/packages/agent-simulation/src/widgets/circular-slider-widget.tsx
@@ -264,11 +264,12 @@ export const CircularSliderWidget = observer(function CircularSliderWidget(props
         </div>
         {showReadout &&
           <div className={css.readoutContainer}>
-            <SliderReadout 
+            <SliderReadout
               formatType={formatType}
               isCompletedRecording={isCompletedRecording}
               inRecordingMode={inRecordingMode}
               isRecording={isRecording}
+              label={label}
               min={min}
               max={max}
               onChange={handleInputChange}

--- a/packages/agent-simulation/src/widgets/slider-readout.test.tsx
+++ b/packages/agent-simulation/src/widgets/slider-readout.test.tsx
@@ -105,4 +105,20 @@ describe("SliderReadout", () => {
     fireEvent.keyDown(input, { key: "Enter" });
     expect(document.activeElement).not.toBe(input);
   });
+
+  it("sets aria-label on the input when a label is provided", () => {
+    render(<SliderReadout {...baseProps} label="Sheep Energy from Grass" />);
+    expect(screen.getByTestId("slider-widget-input")).toHaveAttribute("aria-label", "Sheep Energy from Grass");
+  });
+
+  it("exposes the label as the input's accessible name", () => {
+    render(<SliderReadout {...baseProps} label="Sheep Energy from Grass" />);
+    // getByRole spinbutton resolves the accessible name; this is what a screen reader announces.
+    expect(screen.getByRole("spinbutton", { name: "Sheep Energy from Grass" })).toBeInTheDocument();
+  });
+
+  it("omits aria-label when no label is provided", () => {
+    render(<SliderReadout {...baseProps} />);
+    expect(screen.getByTestId("slider-widget-input")).not.toHaveAttribute("aria-label");
+  });
 });

--- a/packages/agent-simulation/src/widgets/slider-readout.test.tsx
+++ b/packages/agent-simulation/src/widgets/slider-readout.test.tsx
@@ -121,4 +121,14 @@ describe("SliderReadout", () => {
     render(<SliderReadout {...baseProps} />);
     expect(screen.getByTestId("slider-widget-input")).not.toHaveAttribute("aria-label");
   });
+
+  it("omits aria-label when the label is an empty string", () => {
+    render(<SliderReadout {...baseProps} label="" />);
+    expect(screen.getByTestId("slider-widget-input")).not.toHaveAttribute("aria-label");
+  });
+
+  it("omits aria-label when the label is whitespace only", () => {
+    render(<SliderReadout {...baseProps} label="   " />);
+    expect(screen.getByTestId("slider-widget-input")).not.toHaveAttribute("aria-label");
+  });
 });

--- a/packages/agent-simulation/src/widgets/slider-readout.tsx
+++ b/packages/agent-simulation/src/widgets/slider-readout.tsx
@@ -138,7 +138,7 @@ export const SliderReadout: React.FC<IProps> = (props) => {
       <input
         className={css.valueInput}
         data-testid="slider-widget-input"
-        aria-label={label || undefined}
+        aria-label={label?.trim() ? label : undefined}
         disabled={isRecording || isCompletedRecording}
         min={min}
         max={max}

--- a/packages/agent-simulation/src/widgets/slider-readout.tsx
+++ b/packages/agent-simulation/src/widgets/slider-readout.tsx
@@ -10,6 +10,7 @@ interface IProps {
   isCompletedRecording?: boolean;
   inRecordingMode?: boolean;
   isRecording?: boolean;
+  label?: string;
   max: number;
   min: number;
   precision?: number;
@@ -41,7 +42,7 @@ const calculateInputWidth = (min: number, max: number, currentValue: number, for
 };
 
 export const SliderReadout: React.FC<IProps> = (props) => {
-  const { formatType = "integer", isCompletedRecording, inRecordingMode, isRecording, min, max, onChange, precision, step, unit: _unit, value } = props;
+  const { formatType = "integer", isCompletedRecording, inRecordingMode, isRecording, label, min, max, onChange, precision, step, unit: _unit, value } = props;
   const unit = formatType === "percent" ? "%" : (_unit ?? "");
   
   const formattedValue = useMemo(() => {
@@ -137,6 +138,7 @@ export const SliderReadout: React.FC<IProps> = (props) => {
       <input
         className={css.valueInput}
         data-testid="slider-widget-input"
+        aria-label={label || undefined}
         disabled={isRecording || isCompletedRecording}
         min={min}
         max={max}

--- a/packages/agent-simulation/src/widgets/slider-widget.test.tsx
+++ b/packages/agent-simulation/src/widgets/slider-widget.test.tsx
@@ -101,6 +101,12 @@ describe("SliderWidget", () => {
       const sliderBody = screen.getByTestId("slider-widget-slider-body");
       expect(sliderBody.querySelector(".rcSlider")).toBeInTheDocument();
     });
+
+    it("gives the readout input an accessible name matching the visible label", () => {
+      mockGlobals.set("foo", 42);
+      renderWidget({ data: { ...defaultData, showReadout: true } });
+      expect(screen.getByRole("spinbutton", { name: "Primary Label Text" })).toBeInTheDocument();
+    });
   });
 
   describe("functionality", () => {

--- a/packages/agent-simulation/src/widgets/slider-widget.tsx
+++ b/packages/agent-simulation/src/widgets/slider-widget.tsx
@@ -67,11 +67,12 @@ export const SliderWidget = observer(function SliderWidget({ data, globalKey, si
           {label}
         </span>
         {showReadout &&
-          <SliderReadout 
+          <SliderReadout
             formatType={formatType}
             isCompletedRecording={isCompletedRecording}
             inRecordingMode={inRecordingMode}
             isRecording={isRecording}
+            label={label}
             min={min}
             max={max}
             onChange={handleInputChange}


### PR DESCRIPTION
## Summary

Gives the editable number `<input>` in the agent-simulation slider readout a programmatic accessible name, so screen readers announce the field's purpose (e.g. "Sheep Energy from Grass") on focus.

Fixes [QI-161](https://concord-consortium.atlassian.net/browse/QI-161) — audit Issue #98.

## Problem

The visible label (e.g. "Sheep Energy from Grass") is a plain `<span>` in `slider-widget.tsx` with no association to the input, and the `<input type="number">` in `slider-readout.tsx` had no `aria-label`, `aria-labelledby`, or wrapping `<label>`. A screen reader landing on it announced only *"edit, spin button, 7"* — no purpose.

**WCAG:** 1.3.1 Info & Relationships / 4.1.2 Name, Role, Value — Level A.

## Fix

- `SliderReadout` gains an optional `label?: string` prop, rendered as `aria-label={label?.trim() ? label : undefined}` on the input (guarded so an empty, absent, or whitespace-only label emits no attribute; a meaningful label is applied untrimmed so the accessible name matches the visible text exactly).
- `SliderWidget` and `CircularSliderWidget` — the two consumers of `SliderReadout` — pass their existing visible `label` down. One shared-component change covers both widget types.

`aria-label` was chosen over `aria-labelledby` because the same global can render as both a slider and a readout on one page, so a `globalKey`-derived label `id` would collide. `aria-label` sidesteps that while matching the visible text (so 2.5.3 Label in Name also holds).

## Testing

- New tests assert the resolved **accessible name** via `getByRole("spinbutton", { name: "..." })` — what a screen reader actually announces — plus the omitted-attribute cases for absent, empty, and whitespace-only labels.
- Targeted suites (`slider-readout`, `slider-widget`, `circular-slider-widget`): 51/51 pass.
- Full `agent-simulation` package suite: 217/217 pass; `npm run lint` clean.
- Verified the tests are non-vacuous: reverting `label={label}` makes the new integration tests fail.

## Manual verification (post-deploy)

The audit's repro is Activity Player activity **14205**, **page_163092** (the "Sheep Energy from Grass" slider). Once this branch deploys to a preview, inspect the `slider-widget-input` element and confirm the a11y pane reports the visible label as the computed **Name**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[QI-161]: https://concord-consortium.atlassian.net/browse/QI-161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ