### PR TITLE
fix: trap keyboard focus in confirm-mode modals [QI-158]

### DIFF
--- a/packages/blockly/src/components/header.test.tsx
+++ b/packages/blockly/src/components/header.test.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+
+import { Header } from "./header";
+
+afterEach(cleanup);
+
+const defaultProps = {
+  name: "Model 1",
+  savedStates: [],
+};
+
+// The File menu button toggles the menu on mousedown (see header.tsx).
+const openMenu = () => fireEvent.mouseDown(screen.getByRole("button", { name: "File menu" }));
+
+describe("Header", () => {
+  it("returns focus to the File menu button when a menu item is activated", () => {
+    render(<Header {...defaultProps} onShowFileModal={jest.fn()} />);
+    const fileButton = screen.getByRole("button", { name: "File menu" });
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /New/ }));
+    // The activating menu item unmounts with the menu, so focus must be moved to
+    // the persistent File menu button. That lets the dialog the parent renders in
+    // response capture it and restore focus there when the dialog closes.
+    expect(document.activeElement).toBe(fileButton);
+  });
+
+  it("still notifies the parent to open the requested dialog", () => {
+    const onShowFileModal = jest.fn();
+    render(<Header {...defaultProps} onShowFileModal={onShowFileModal} />);
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /New/ }));
+    expect(onShowFileModal).toHaveBeenCalledWith("new");
+  });
+});

--- a/packages/blockly/src/components/header.tsx
+++ b/packages/blockly/src/components/header.tsx
@@ -26,6 +26,7 @@ export const Header: React.FC<IProps> = (props) => {
   const {savedStates, onShowFileModal} = props;
   const [showMenu, setShowMenu] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const fileMenuButtonRef = useRef<HTMLButtonElement>(null);
   const hasSavedStates = savedStates.length > 1;
 
   const handleMouseDown = (e: React.MouseEvent) => {
@@ -38,6 +39,11 @@ export const Header: React.FC<IProps> = (props) => {
   };
 
   const handleShowFileModal = (fileModal: FileModal) => () => {
+    // Return focus to the persistent File menu button before the menu (and the
+    // activating menu item) unmount. The dialog the parent renders in response
+    // captures this element as the previously focused one and restores focus to
+    // it on close; without this, focus would fall to <body> when the item unmounts.
+    fileMenuButtonRef.current?.focus();
     setShowMenu(false);
     onShowFileModal(fileModal);
   };
@@ -71,6 +77,7 @@ export const Header: React.FC<IProps> = (props) => {
       {showMenu && <div className={css.backdrop} onMouseDown={handleCloseMenu} />}
       <div className={css.fileMenuWrapper} ref={menuRef}>
         <button
+          ref={fileMenuButtonRef}
           className={classNames(css.fileMenuButton, {[css.active]: showMenu})}
           onMouseDown={handleMouseDown}
           aria-expanded={showMenu}

--- a/packages/helpers/src/components/modal.test.tsx
+++ b/packages/helpers/src/components/modal.test.tsx
@@ -333,6 +333,28 @@ describe("Modal", () => {
     it.each([
       ["confirm", "confirm" as const],
       ["alert", "alert" as const],
+    ])("stops Escape from propagating to ancestors (%s mode)", (_label, mode) => {
+      const ancestorKeyDown = jest.fn();
+      render(
+        <div onKeyDown={ancestorKeyDown}>
+          <Modal
+            {...defaultProps}
+            mode={mode}
+            onConfirm={jest.fn()}
+            onCancel={jest.fn()}
+          />
+        </div>
+      );
+      const dialog = screen.getByRole("dialog");
+      fireEvent.keyDown(dialog, { key: "Escape" });
+      // Dismissal must be self-contained: an ancestor (e.g. the Blockly workspace,
+      // which also listens for Escape) must not receive the same keypress.
+      expect(ancestorKeyDown).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ["confirm", "confirm" as const],
+      ["alert", "alert" as const],
     ])("renders dialog role with aria-modal, aria-labelledby pointing at title, aria-describedby pointing at message (%s mode)", (_label, mode) => {
       render(
         <Modal

--- a/packages/helpers/src/components/modal.test.tsx
+++ b/packages/helpers/src/components/modal.test.tsx
@@ -71,7 +71,7 @@ describe("Modal", () => {
       expect(onCancel).toHaveBeenCalled();
     });
 
-    it("does not move initial focus to the OK button", () => {
+    it("moves initial focus to the first focusable in the body (Cancel when the message has none), not the X close button", () => {
       render(
         <Modal
           {...defaultProps}
@@ -79,8 +79,112 @@ describe("Modal", () => {
           onCancel={jest.fn()}
         />
       );
-      // In confirm mode there is no initial focus management.
-      expect(document.activeElement).not.toBe(screen.getByRole("button", { name: "OK" }));
+      // Initial focus skips the title-bar X and lands on the first focusable
+      // inside the modal body. With a plain-text message that is the Cancel
+      // button (the safe default for a confirm dialog).
+      expect(document.activeElement).toBe(screen.getByRole("button", { name: "Cancel" }));
+      expect(document.activeElement).not.toBe(screen.getByRole("button", { name: "Close" }));
+    });
+
+    it("moves initial focus to a form field inside the message when present", () => {
+      render(
+        <Modal
+          {...defaultProps}
+          message={<div><input data-testid="name-input" type="text" /></div>}
+          onConfirm={jest.fn()}
+          onCancel={jest.fn()}
+        />
+      );
+      expect(document.activeElement).toBe(screen.getByTestId("name-input"));
+    });
+
+    it("calls onCancel when Escape is pressed (and not onConfirm)", () => {
+      const onConfirm = jest.fn();
+      const onCancel = jest.fn();
+      render(
+        <Modal
+          {...defaultProps}
+          onConfirm={onConfirm}
+          onCancel={onCancel}
+        />
+      );
+      const dialog = screen.getByRole("dialog");
+      fireEvent.keyDown(dialog, { key: "Escape" });
+      expect(onCancel).toHaveBeenCalled();
+      expect(onConfirm).not.toHaveBeenCalled();
+    });
+
+    it("traps focus, wrapping Tab from the last focusable back to the first", async () => {
+      const user = userEvent.setup();
+      render(
+        <Modal
+          {...defaultProps}
+          onConfirm={jest.fn()}
+          onCancel={jest.fn()}
+        />
+      );
+      const close = screen.getByRole("button", { name: "Close" });
+      const ok = screen.getByRole("button", { name: "OK" });
+      // Tabbing forward off the last focusable (OK) wraps to the first (X close).
+      ok.focus();
+      await user.tab();
+      expect(document.activeElement).toBe(close);
+      // Shift+Tab off the first focusable (X close) wraps to the last (OK).
+      close.focus();
+      await user.tab({ shift: true });
+      expect(document.activeElement).toBe(ok);
+    });
+
+    it("restores focus to the previously focused element on cancel", () => {
+      const Wrapper = () => {
+        const [open, setOpen] = React.useState(false);
+        return (
+          <div>
+            <button onClick={() => setOpen(true)} data-testid="opener">open</button>
+            {open && (
+              <Modal
+                {...defaultProps}
+                onConfirm={() => setOpen(false)}
+                onCancel={() => setOpen(false)}
+              />
+            )}
+          </div>
+        );
+      };
+      render(<Wrapper />);
+      const opener = screen.getByTestId("opener");
+      opener.focus();
+      fireEvent.click(opener);
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(document.activeElement).toBe(opener);
+    });
+
+    it("restores focus to the previously focused element on dismiss via Escape", () => {
+      const Wrapper = () => {
+        const [open, setOpen] = React.useState(false);
+        return (
+          <div>
+            <button onClick={() => setOpen(true)} data-testid="opener">open</button>
+            {open && (
+              <Modal
+                {...defaultProps}
+                onConfirm={() => setOpen(false)}
+                onCancel={() => setOpen(false)}
+              />
+            )}
+          </div>
+        );
+      };
+      render(<Wrapper />);
+      const opener = screen.getByTestId("opener");
+      opener.focus();
+      fireEvent.click(opener);
+      const dialog = screen.getByRole("dialog");
+      fireEvent.keyDown(dialog, { key: "Escape" });
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(document.activeElement).toBe(opener);
     });
   });
 

--- a/packages/helpers/src/components/modal.tsx
+++ b/packages/helpers/src/components/modal.tsx
@@ -131,13 +131,13 @@ export const Modal = ({
           )}
         </div>
         <div ref={bodyRef} className={css.modalBody}>
-          {/* OK button is intentionally rendered outside <form> so pressing Enter
+          {/* The confirm button is rendered outside <form> so pressing Enter
               on it doesn't double-fire onConfirm (button click + form submit).
-              Keep it outside if you ever refactor this layout. The <form> wrapper
-              has no submittable content today (just a message div), so it cannot
-              fire onSubmit on its own. If you ever add an <input>/<textarea> inside
-              this body, be aware that Enter inside that field would route to
-              onConfirm — switch to a regular <div> or route submit explicitly. */}
+              The <form> wraps `message`, which may contain an <input>/<textarea>
+              (e.g. a rename dialog) — pressing Enter in such a field submits the
+              form and calls onConfirm, which is intentional. Keep the confirm
+              button outside the form when refactoring; if a future dialog needs
+              Enter to do something other than confirm, handle onSubmit explicitly. */}
           <form onSubmit={onConfirm}>
             <div id={messageId} className={css.modalMessage}>{message}</div>
           </form>

--- a/packages/helpers/src/components/modal.tsx
+++ b/packages/helpers/src/components/modal.tsx
@@ -71,6 +71,10 @@ export const Modal = ({
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === "Escape") {
       e.preventDefault();
+      // Keep dismissal self-contained: don't let Escape bubble to an ancestor
+      // (e.g. the Blockly workspace, which also listens for Escape) and trigger
+      // a second, unrelated action from the same keypress.
+      e.stopPropagation();
       // Route Escape per mode so it mirrors the modal's own dismiss affordance:
       // in alert mode to onConfirm (dismiss == the single OK button), in confirm
       // mode to onCancel (dismiss without acting == Cancel/X). The onConfirm prop

--- a/packages/helpers/src/components/modal.tsx
+++ b/packages/helpers/src/components/modal.tsx
@@ -6,6 +6,11 @@ import CloseIcon from "../assets/close-icon.svg";
 
 import css from "./modal.scss";
 
+// Elements considered focusable for initial focus and the focus trap.
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), ' +
+  'textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
 interface Props {
   variant: "teal" | "orange";
   title: string;
@@ -18,9 +23,11 @@ interface Props {
        | React.KeyboardEvent<HTMLDivElement>
   ) => void;
   onCancel: () => void;
-  // Optional mode. Defaults to "confirm" (existing behavior). In "alert" mode the Cancel
-  // button and X close button are hidden, and full focus management is applied: initial
-  // focus on the confirm button, focus trap, Escape dismisses, focus is restored on close.
+  // Optional mode. Defaults to "confirm". Both modes apply full focus management:
+  // initial focus is moved into the dialog, Tab is trapped within it, Escape dismisses,
+  // and focus is restored to the previously focused element on close. In "alert" mode the
+  // Cancel and X close buttons are hidden and Escape routes to onConfirm (dismiss == OK);
+  // in "confirm" mode Escape routes to onCancel (dismiss without acting).
   mode?: "confirm" | "alert";
 }
 
@@ -34,15 +41,19 @@ export const Modal = ({
   // React 17 lacks useId; useMemo with a uuid achieves the same per-instance uniqueness.
   const titleId = useMemo(() => `modal-title-${uuid()}`, []);
   const messageId = useMemo(() => `modal-message-${uuid()}`, []);
-  const confirmButtonRef = useRef<HTMLButtonElement>(null);
+  const bodyRef = useRef<HTMLDivElement>(null);
   const overlayRef = useRef<HTMLDivElement>(null);
   const previouslyFocusedRef = useRef<Element | null>(null);
 
-  // Initial focus + focus restore (alert mode only).
+  // Initial focus + focus restore (both modes). Mode never changes for a given
+  // mounted modal, so this runs once on open and cleans up on close.
   useEffect(() => {
-    if (!isAlert) return;
     previouslyFocusedRef.current = document.activeElement;
-    confirmButtonRef.current?.focus();
+    // Move initial focus to the first focusable inside the modal body, which
+    // deliberately skips the title-bar Close (X). In alert mode that is the OK
+    // button; in confirm mode it is the first form field, or the Cancel button
+    // when the body has no field (the safe default for a destructive confirm).
+    bodyRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)?.focus();
     return () => {
       const prev = previouslyFocusedRef.current as HTMLElement | null;
       if (prev && document.contains(prev) && typeof prev.focus === "function") {
@@ -54,27 +65,26 @@ export const Modal = ({
         (document.activeElement as HTMLElement | null)?.blur?.();
       }
     };
-  }, [isAlert]);
+  }, []);
 
-  // Escape dismisses + focus trap (alert mode only).
+  // Escape dismisses + focus trap (both modes).
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (!isAlert) return;
     if (e.key === "Escape") {
       e.preventDefault();
-      // Route Escape to onConfirm (not onCancel) in alert mode so it dismisses
-      // identically to clicking OK by construction. Otherwise a caller passing
-      // different handlers for onConfirm vs onCancel could silently violate the
-      // requirement that Escape and OK behave identically. The onConfirm prop
+      // Route Escape per mode so it mirrors the modal's own dismiss affordance:
+      // in alert mode to onConfirm (dismiss == the single OK button), in confirm
+      // mode to onCancel (dismiss without acting == Cancel/X). The onConfirm prop
       // signature includes React.KeyboardEvent<HTMLDivElement> in its union to
-      // accept this path without a cast.
-      onConfirm(e);
+      // accept the alert path without a cast.
+      if (isAlert) {
+        onConfirm(e);
+      } else {
+        onCancel();
+      }
       return;
     }
     if (e.key === "Tab" && overlayRef.current) {
-      const focusables = overlayRef.current.querySelectorAll<HTMLElement>(
-        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), ' +
-        'textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
-      );
+      const focusables = overlayRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
       if (focusables.length === 0) return;
       if (focusables.length === 1) {
         // Single focusable (alert mode's OK button): prevent Tab from moving
@@ -94,7 +104,7 @@ export const Modal = ({
         first.focus();
       }
     }
-  }, [isAlert, onConfirm]);
+  }, [isAlert, onConfirm, onCancel]);
 
   return (
     <div
@@ -116,7 +126,7 @@ export const Modal = ({
             </button>
           )}
         </div>
-        <div className={css.modalBody}>
+        <div ref={bodyRef} className={css.modalBody}>
           {/* OK button is intentionally rendered outside <form> so pressing Enter
               on it doesn't double-fire onConfirm (button click + form submit).
               Keep it outside if you ever refactor this layout. The <form> wrapper
@@ -134,7 +144,6 @@ export const Modal = ({
               </button>
             )}
             <button
-              ref={confirmButtonRef}
               onClick={onConfirm}
               className={classnames(css.modalConfirmButton, css[variant])}
             >


### PR DESCRIPTION
## What & why

[QI-158](https://concord-consortium.atlassian.net/browse/QI-158) — trap keyboard focus in the Blockly file dialogs (Questions `#14` & `#15`). Audit issue `#95`, WCAG **2.4.3** (Level A, High).

Root cause was not in Blockly: the shared `Modal` (`packages/helpers`) gated **all** focus management behind alert mode, so confirm-mode dialogs got `role="dialog"`/`aria-modal` but no initial focus, focus trap, Escape handling, or focus restore. Fixing it in one place repairs every confirm-mode modal — the **five Blockly file dialogs** (New/Open/Copy/Rename/Delete) and agent-simulation's **Delete Recording**.

## Changes

**1. Shared `Modal` — extend focus management to confirm mode** (`modal.tsx`)
- Initial focus moves to the first focusable in the modal body (the text field, or **Cancel** when there's none — the safe default for a destructive confirm), skipping the title-bar Close (X). Alert mode still lands on OK.
- Escape routes to `onCancel` in confirm mode (dismiss without acting); alert mode keeps Escape → `onConfirm`.
- Tab trap and focus restore are now shared across both modes; the focusable selector is one constant.

**2. Blockly header — restore focus to the File menu button** (`header.tsx`)
- The file dialogs open from a menu item that unmounts when the menu closes, so the modal would capture a gone element and drop focus to `<body>` on close. Move focus to the persistent **File** button when a menu item is activated, so the dialog restores focus there on close (satisfies "focus returns to the trigger").

## Testing

- **Unit (TDD, RED→GREEN):** 5 new confirm-mode focus tests in `modal.test.tsx` (alert mode unchanged); new `header.test.tsx` for the focus-return. helpers 120/120, `maybe-file-modal` 46/46, agent-simulation 212/212, lint clean.
- **Real browser (Playwright/Chromium):** drove the New and Delete dialogs in the live interactive — initial focus correct, focus trapped across 12 Tab/Shift-Tab presses (never reaches the Blockly canvas), Escape dismisses, and focus restored to the File menu button. 10/10 checks.

Pre-existing Blockly `fetch is not defined` jsdom suite failures are unrelated (confirmed on `master`) and untouched by this PR.

## Out of scope

The broader File-menu keyboard operability — opening the menu via keyboard (it toggles on mouse-down only) and Enter/Space activation of items (WCAG 2.1.1) — is tracked in **QI-157**. The focus-return added here is a natural subset that ticket will build on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[QI-158]: https://concord-consortium.atlassian.net/browse/QI-158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ