### PR TITLE
feat: keyboard-operable Blockly File menu (ARIA menu button) [QI-157]

### DIFF
--- a/packages/blockly/src/components/header.scss
+++ b/packages/blockly/src/components/header.scss
@@ -91,13 +91,20 @@
 
       &.disabled {
         opacity: 0.35;
-        pointer-events: none;
+        // No pointer-events:none — the item must still receive roving focus.
+        // Activation is blocked by aria-disabled and the activateItem guard.
+        cursor: default;
       }
 
       &:hover {
         background-color: var(--cc-teal-light-6);
       }
       &:active {
+        background-color: var(--cc-teal-light-4);
+      }
+      // Visible focus indicator for the roving-tabindex active item.
+      &:focus, &:focus-visible {
+        outline: none;
         background-color: var(--cc-teal-light-4);
       }
 

--- a/packages/blockly/src/components/header.scss
+++ b/packages/blockly/src/components/header.scss
@@ -1,15 +1,5 @@
 @import "./variables.scss";
 
-.backdrop {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 999;
-  background: transparent;
-}
-
 .header {
   position: relative;
   background: var(--cc-teal-light-5);

--- a/packages/blockly/src/components/header.scss
+++ b/packages/blockly/src/components/header.scss
@@ -105,6 +105,13 @@
         .fileMenuItemContent {
           opacity: 0.35;
         }
+
+        // A disabled item must not look interactive on mouse hover/press. The
+        // keyboard focus indicator below still applies (higher specificity is not
+        // needed since :focus is a different state).
+        &:hover, &:active {
+          background-color: transparent;
+        }
       }
 
       &:hover {

--- a/packages/blockly/src/components/header.scss
+++ b/packages/blockly/src/components/header.scss
@@ -89,11 +89,22 @@
       white-space: nowrap;
       cursor: pointer;
 
+      .fileMenuItemContent {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
       &.disabled {
-        opacity: 0.35;
-        // No pointer-events:none — the item must still receive roving focus.
-        // Activation is blocked by aria-disabled and the activateItem guard.
+        // Dim only the content, not the whole item, so the focus indicator stays
+        // visible when a keyboard user arrows onto this (still-focusable) disabled
+        // item. Activation is blocked by aria-disabled and the activateItem guard;
+        // no pointer-events:none, which would also block roving focus.
         cursor: default;
+
+        .fileMenuItemContent {
+          opacity: 0.35;
+        }
       }
 
       &:hover {
@@ -102,10 +113,14 @@
       &:active {
         background-color: var(--cc-teal-light-4);
       }
-      // Visible focus indicator for the roving-tabindex active item.
+      // Focus indicator for the roving-tabindex active item: a strong inset ring
+      // (distinct from the :active background alone) plus a background tint. The
+      // ring sits on the item box at full opacity, so focus stays perceptible even
+      // on the dimmed-content disabled item.
       &:focus, &:focus-visible {
         outline: none;
         background-color: var(--cc-teal-light-4);
+        box-shadow: inset 0 0 0 2px var(--cc-teal);
       }
 
       &:first-child {

--- a/packages/blockly/src/components/header.test.tsx
+++ b/packages/blockly/src/components/header.test.tsx
@@ -10,8 +10,8 @@ const defaultProps = {
   savedStates: [],
 };
 
-// The File menu button toggles the menu on mousedown (see header.tsx).
-const openMenu = () => fireEvent.mouseDown(screen.getByRole("button", { name: "File menu" }));
+// The File button toggles the menu on click.
+const openMenu = () => fireEvent.click(screen.getByRole("button", { name: "File menu" }));
 
 describe("Header", () => {
   it("returns focus to the File menu button when a menu item is activated", () => {
@@ -31,5 +31,35 @@ describe("Header", () => {
     openMenu();
     fireEvent.click(screen.getByRole("menuitem", { name: /New/ }));
     expect(onShowFileModal).toHaveBeenCalledWith("new");
+  });
+
+  it("opens the menu on button click and moves focus to the first item", () => {
+    render(<Header {...defaultProps} onShowFileModal={jest.fn()} />);
+    openMenu();
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(document.activeElement).toBe(screen.getByRole("menuitem", { name: /New/ }));
+  });
+
+  it("toggles the menu closed on a second button click", () => {
+    render(<Header {...defaultProps} onShowFileModal={jest.fn()} />);
+    openMenu();
+    openMenu();
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("closes the menu on an outside mousedown", () => {
+    render(<Header {...defaultProps} onShowFileModal={jest.fn()} />);
+    openMenu();
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("gives only the active item tabIndex 0 (roving tabindex)", () => {
+    render(<Header {...defaultProps} onShowFileModal={jest.fn()} />);
+    openMenu();
+    const items = screen.getAllByRole("menuitem");
+    expect(items[0]).toHaveAttribute("tabindex", "0");
+    items.slice(1).forEach(item => expect(item).toHaveAttribute("tabindex", "-1"));
   });
 });

--- a/packages/blockly/src/components/header.test.tsx
+++ b/packages/blockly/src/components/header.test.tsx
@@ -107,4 +107,32 @@ describe("Header", () => {
     fireEvent.keyDown(menu, { key: "Home" });
     expect(document.activeElement).toBe(menuItems[0]);
   });
+
+  it.each(["Enter", " "])(
+    "activates the focused enabled item on '%s', closes the menu, and refocuses the button",
+    (key) => {
+      const onShowFileModal = jest.fn();
+      render(<Header {...defaultProps} onShowFileModal={onShowFileModal} />);
+      const button = screen.getByRole("button", { name: "File menu" });
+      fireEvent.click(button); // opens, focus on New (index 0)
+      fireEvent.keyDown(screen.getByRole("menu"), { key });
+      expect(onShowFileModal).toHaveBeenCalledWith("new");
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+      expect(document.activeElement).toBe(button);
+    }
+  );
+
+  it("marks the disabled Open item aria-disabled and does not activate it", () => {
+    const onShowFileModal = jest.fn();
+    render(<Header {...defaultProps} onShowFileModal={onShowFileModal} />);
+    fireEvent.click(screen.getByRole("button", { name: "File menu" }));
+    const menu = screen.getByRole("menu");
+    const open = screen.getByRole("menuitem", { name: /Open/ });
+    expect(open).toHaveAttribute("aria-disabled", "true");
+    fireEvent.keyDown(menu, { key: "ArrowDown" }); // move to Open (index 1)
+    expect(document.activeElement).toBe(open);      // reachable by keyboard
+    fireEvent.keyDown(menu, { key: "Enter" });
+    expect(onShowFileModal).not.toHaveBeenCalled();  // no-op
+    expect(screen.getByRole("menu")).toBeInTheDocument(); // stays open
+  });
 });

--- a/packages/blockly/src/components/header.test.tsx
+++ b/packages/blockly/src/components/header.test.tsx
@@ -135,4 +135,25 @@ describe("Header", () => {
     expect(onShowFileModal).not.toHaveBeenCalled();  // no-op
     expect(screen.getByRole("menu")).toBeInTheDocument(); // stays open
   });
+
+  it.each(["Escape", "Tab"])(
+    "closes the menu and returns focus to the button on %s",
+    (key) => {
+      render(<Header {...defaultProps} onShowFileModal={jest.fn()} />);
+      const button = screen.getByRole("button", { name: "File menu" });
+      fireEvent.click(button);
+      fireEvent.keyDown(screen.getByRole("menu"), { key });
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+      expect(document.activeElement).toBe(button);
+    }
+  );
+
+  it("closes and returns focus to the button on Shift+Tab", () => {
+    render(<Header {...defaultProps} onShowFileModal={jest.fn()} />);
+    const button = screen.getByRole("button", { name: "File menu" });
+    fireEvent.click(button);
+    fireEvent.keyDown(screen.getByRole("menu"), { key: "Tab", shiftKey: true });
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(button);
+  });
 });

--- a/packages/blockly/src/components/header.test.tsx
+++ b/packages/blockly/src/components/header.test.tsx
@@ -62,4 +62,22 @@ describe("Header", () => {
     expect(items[0]).toHaveAttribute("tabindex", "0");
     items.slice(1).forEach(item => expect(item).toHaveAttribute("tabindex", "-1"));
   });
+
+  it("opens the menu and focuses the first item on ArrowDown from the button", () => {
+    render(<Header {...defaultProps} onShowFileModal={jest.fn()} />);
+    const button = screen.getByRole("button", { name: "File menu" });
+    button.focus();
+    fireEvent.keyDown(button, { key: "ArrowDown" });
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(document.activeElement).toBe(screen.getByRole("menuitem", { name: /New/ }));
+  });
+
+  it("opens the menu and focuses the last item on ArrowUp from the button", () => {
+    render(<Header {...defaultProps} onShowFileModal={jest.fn()} />);
+    const button = screen.getByRole("button", { name: "File menu" });
+    button.focus();
+    fireEvent.keyDown(button, { key: "ArrowUp" });
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(document.activeElement).toBe(screen.getByRole("menuitem", { name: /Delete/ }));
+  });
 });

--- a/packages/blockly/src/components/header.test.tsx
+++ b/packages/blockly/src/components/header.test.tsx
@@ -80,4 +80,31 @@ describe("Header", () => {
     expect(screen.getByRole("menu")).toBeInTheDocument();
     expect(document.activeElement).toBe(screen.getByRole("menuitem", { name: /Delete/ }));
   });
+
+  it("moves focus to the next/previous item with Arrow keys, wrapping at the ends", () => {
+    render(<Header {...defaultProps} onShowFileModal={jest.fn()} />);
+    openMenu();
+    const menuItems = screen.getAllByRole("menuitem"); // [New, Open, Make a copy, Rename, Delete]
+    const menu = screen.getByRole("menu");
+    expect(document.activeElement).toBe(menuItems[0]);
+    fireEvent.keyDown(menu, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(menuItems[1]);
+    fireEvent.keyDown(menu, { key: "ArrowUp" });
+    expect(document.activeElement).toBe(menuItems[0]);
+    fireEvent.keyDown(menu, { key: "ArrowUp" }); // wrap to last
+    expect(document.activeElement).toBe(menuItems[4]);
+    fireEvent.keyDown(menu, { key: "ArrowDown" }); // wrap to first
+    expect(document.activeElement).toBe(menuItems[0]);
+  });
+
+  it("jumps to the first/last item with Home/End", () => {
+    render(<Header {...defaultProps} onShowFileModal={jest.fn()} />);
+    openMenu();
+    const menuItems = screen.getAllByRole("menuitem");
+    const menu = screen.getByRole("menu");
+    fireEvent.keyDown(menu, { key: "End" });
+    expect(document.activeElement).toBe(menuItems[4]);
+    fireEvent.keyDown(menu, { key: "Home" });
+    expect(document.activeElement).toBe(menuItems[0]);
+  });
 });

--- a/packages/blockly/src/components/header.tsx
+++ b/packages/blockly/src/components/header.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import classNames from "classnames";
 
 import { ISavedBlocklyState } from "./types";
@@ -41,7 +41,14 @@ export const Header: React.FC<IProps> = (props) => {
   const menuRef = useRef<HTMLDivElement>(null);           // wrapper: button + menu
   const fileMenuButtonRef = useRef<HTMLButtonElement>(null);
   const itemRefs = useRef<Array<HTMLDivElement | null>>([]);
-  const menuId = useMemo(() => `blockly-file-menu-${++menuInstanceCount}`, []);
+  // A ref-backed constant (not useMemo, which React may discard) keeps the id
+  // stable for the component's lifetime — it links the button's aria-controls to
+  // the menu's id. Lazily initialized so the counter only increments once.
+  const menuIdRef = useRef<string>();
+  if (menuIdRef.current === undefined) {
+    menuIdRef.current = `blockly-file-menu-${++menuInstanceCount}`;
+  }
+  const menuId = menuIdRef.current;
   const hasSavedStates = savedStates.length > 1;
 
   const items: IMenuItem[] = [

--- a/packages/blockly/src/components/header.tsx
+++ b/packages/blockly/src/components/header.tsx
@@ -91,7 +91,7 @@ export const Header: React.FC<IProps> = (props) => {
   useEffect(() => {
     if (!showMenu) return;
     const handleDocMouseDown = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+      if (menuRef.current && e.target instanceof Node && !menuRef.current.contains(e.target)) {
         setShowMenu(false);
       }
     };

--- a/packages/blockly/src/components/header.tsx
+++ b/packages/blockly/src/components/header.tsx
@@ -95,6 +95,19 @@ export const Header: React.FC<IProps> = (props) => {
     }
   };
 
+  const handleButtonKeyDown = (e: React.KeyboardEvent) => {
+    // Enter/Space are intentionally NOT handled here: the native button already
+    // synthesizes a click for them, which handleButtonClick turns into an open.
+    // Handling them here too would open then immediately toggle closed.
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      openMenu(0);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      openMenu(items.length - 1);
+    }
+  };
+
   const renderMenu = () => (
     <div
       id={menuId}
@@ -128,6 +141,7 @@ export const Header: React.FC<IProps> = (props) => {
           type="button"
           className={classNames(css.fileMenuButton, { [css.active]: showMenu })}
           onClick={handleButtonClick}
+          onKeyDown={handleButtonKeyDown}
           aria-expanded={showMenu}
           aria-haspopup="menu"
           aria-controls={showMenu ? menuId : undefined}

--- a/packages/blockly/src/components/header.tsx
+++ b/packages/blockly/src/components/header.tsx
@@ -126,6 +126,11 @@ export const Header: React.FC<IProps> = (props) => {
         e.preventDefault();
         setActiveIndex(items.length - 1);
         break;
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        activateItem(activeIndex);
+        break;
     }
   };
 

--- a/packages/blockly/src/components/header.tsx
+++ b/packages/blockly/src/components/header.tsx
@@ -108,12 +108,34 @@ export const Header: React.FC<IProps> = (props) => {
     }
   };
 
+  const handleMenuKeyDown = (e: React.KeyboardEvent) => {
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setActiveIndex(i => (i + 1) % items.length);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setActiveIndex(i => (i - 1 + items.length) % items.length);
+        break;
+      case "Home":
+        e.preventDefault();
+        setActiveIndex(0);
+        break;
+      case "End":
+        e.preventDefault();
+        setActiveIndex(items.length - 1);
+        break;
+    }
+  };
+
   const renderMenu = () => (
     <div
       id={menuId}
       className={css.fileMenu}
       role="menu"
       aria-label="File menu"
+      onKeyDown={handleMenuKeyDown}
     >
       {items.map((item, index) => (
         <React.Fragment key={item.id}>

--- a/packages/blockly/src/components/header.tsx
+++ b/packages/blockly/src/components/header.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import classNames from "classnames";
 
 import { ISavedBlocklyState } from "./types";
@@ -22,70 +22,119 @@ interface IProps {
 export const fileModals = ["new", "open", "copy", "rename", "delete"] as const;
 export type FileModal = typeof fileModals[number] | undefined;
 
+interface IMenuItem {
+  id: Exclude<FileModal, undefined>;
+  label: string;
+  Icon: React.FC<React.SVGProps<SVGSVGElement>>;
+  disabled: boolean;
+}
+
+// Per-instance menu id without pulling in uuid (not a declared blockly dep).
+// React 17 has no useId; a module counter gives stable unique ids so multiple
+// Blockly instances on a page never collide.
+let menuInstanceCount = 0;
+
 export const Header: React.FC<IProps> = (props) => {
-  const {savedStates, onShowFileModal} = props;
+  const { savedStates, onShowFileModal } = props;
   const [showMenu, setShowMenu] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const menuRef = useRef<HTMLDivElement>(null);           // wrapper: button + menu
   const fileMenuButtonRef = useRef<HTMLButtonElement>(null);
+  const itemRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const menuId = useMemo(() => `blockly-file-menu-${++menuInstanceCount}`, []);
   const hasSavedStates = savedStates.length > 1;
 
-  const handleMouseDown = (e: React.MouseEvent) => {
-    e.preventDefault(); // Prevent the click event from firing
-    setShowMenu(prev => !prev);
+  const items: IMenuItem[] = [
+    { id: "new",    label: "New",         Icon: NewModelIcon,    disabled: false },
+    { id: "open",   label: "Open",        Icon: OpenModelIcon,   disabled: !hasSavedStates },
+    { id: "copy",   label: "Make a copy", Icon: CopyModelIcon,   disabled: false },
+    { id: "rename", label: "Rename",      Icon: RenameModelIcon, disabled: false },
+    { id: "delete", label: "Delete",      Icon: DeleteModelIcon, disabled: false },
+  ];
+
+  const openMenu = (index: number) => {
+    setActiveIndex(index);
+    setShowMenu(true);
   };
 
-  const handleCloseMenu = () => {
-    setShowMenu(false);
-  };
-
-  const handleShowFileModal = (fileModal: FileModal) => () => {
-    // Return focus to the persistent File menu button before the menu (and the
-    // activating menu item) unmount. The dialog the parent renders in response
-    // captures this element as the previously focused one and restores focus to
-    // it on close; without this, focus would fall to <body> when the item unmounts.
+  const activateItem = (index: number) => {
+    const item = items[index];
+    if (!item || item.disabled) return;
+    // Return focus to the File button before the menu (and this item) unmount,
+    // so the dialog opened in response captures it and restores focus there on
+    // close (QI-158).
     fileMenuButtonRef.current?.focus();
     setShowMenu(false);
-    onShowFileModal(fileModal);
+    onShowFileModal(item.id);
   };
 
-  const renderMenu = () => {
-    return (
-      <div className={css.fileMenu} role="menu" aria-label="File menu">
-        <div className={css.fileMenuItem} onClick={handleShowFileModal("new")} role="menuitem" tabIndex={0}>
-          <NewModelIcon /> New
-        </div>
-        <div className={classNames(css.fileMenuItem, {[css.disabled]: !hasSavedStates})} onClick={handleShowFileModal("open")} role="menuitem" tabIndex={hasSavedStates ? 0 : -1} aria-disabled={!hasSavedStates}>
-          <OpenModelIcon />
-          Open
-        </div>
-        <div className={css.fileMenuItem} onClick={handleShowFileModal("copy")} role="menuitem" tabIndex={0}>
-          <CopyModelIcon /> Make a copy
-        </div>
-        <div className={css.fileMenuSeparator} />
-        <div className={css.fileMenuItem} onClick={handleShowFileModal("rename")} role="menuitem" tabIndex={0}>
-          <RenameModelIcon /> Rename
-        </div>
-        <div className={css.fileMenuItem} onClick={handleShowFileModal("delete")} role="menuitem" tabIndex={0}>
-          <DeleteModelIcon /> Delete
-        </div>
-      </div>
-    );
+  // Roving tabindex: move DOM focus to the active item while the menu is open.
+  useEffect(() => {
+    if (showMenu) itemRefs.current[activeIndex]?.focus();
+  }, [showMenu, activeIndex]);
+
+  // Close on an outside mousedown (replaces the old transparent backdrop). The
+  // button lives inside menuRef, so its own onClick owns toggling; this listener
+  // only fires for clicks outside the wrapper.
+  useEffect(() => {
+    if (!showMenu) return;
+    const handleDocMouseDown = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setShowMenu(false);
+      }
+    };
+    document.addEventListener("mousedown", handleDocMouseDown);
+    return () => document.removeEventListener("mousedown", handleDocMouseDown);
+  }, [showMenu]);
+
+  const handleButtonClick = () => {
+    if (showMenu) {
+      setShowMenu(false);
+    } else {
+      openMenu(0);
+    }
   };
+
+  const renderMenu = () => (
+    <div
+      id={menuId}
+      className={css.fileMenu}
+      role="menu"
+      aria-label="File menu"
+    >
+      {items.map((item, index) => (
+        <React.Fragment key={item.id}>
+          {item.id === "rename" && <div className={css.fileMenuSeparator} />}
+          <div
+            ref={el => { itemRefs.current[index] = el; }}
+            className={classNames(css.fileMenuItem, { [css.disabled]: item.disabled })}
+            role="menuitem"
+            tabIndex={index === activeIndex ? 0 : -1}
+            aria-disabled={item.disabled || undefined}
+            onClick={() => activateItem(index)}
+          >
+            <item.Icon /> {item.label}
+          </div>
+        </React.Fragment>
+      ))}
+    </div>
+  );
 
   return (
     <div className={css.header}>
-      {showMenu && <div className={css.backdrop} onMouseDown={handleCloseMenu} />}
       <div className={css.fileMenuWrapper} ref={menuRef}>
         <button
           ref={fileMenuButtonRef}
-          className={classNames(css.fileMenuButton, {[css.active]: showMenu})}
-          onMouseDown={handleMouseDown}
+          type="button"
+          className={classNames(css.fileMenuButton, { [css.active]: showMenu })}
+          onClick={handleButtonClick}
           aria-expanded={showMenu}
           aria-haspopup="menu"
+          aria-controls={showMenu ? menuId : undefined}
           aria-label="File menu"
         >
           File
-          <ArrowIcon className={classNames(css.arrowIcon, {[css.rotated]: showMenu})} />
+          <ArrowIcon className={classNames(css.arrowIcon, { [css.rotated]: showMenu })} />
         </button>
         {showMenu && renderMenu()}
       </div>

--- a/packages/blockly/src/components/header.tsx
+++ b/packages/blockly/src/components/header.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import classNames from "classnames";
 
 import { ISavedBlocklyState } from "./types";
@@ -56,6 +56,11 @@ export const Header: React.FC<IProps> = (props) => {
     setActiveIndex(index);
     setShowMenu(true);
   };
+
+  const closeMenu = useCallback((focusButton: boolean) => {
+    setShowMenu(false);
+    if (focusButton) fileMenuButtonRef.current?.focus();
+  }, []);
 
   const activateItem = (index: number) => {
     const item = items[index];
@@ -130,6 +135,16 @@ export const Header: React.FC<IProps> = (props) => {
       case " ":
         e.preventDefault();
         activateItem(activeIndex);
+        break;
+      case "Escape":
+        e.preventDefault();
+        closeMenu(true);
+        break;
+      case "Tab":
+        // Close and return focus to the button rather than stranding focus on
+        // the unmounting item (see plan/spec).
+        e.preventDefault();
+        closeMenu(true);
         break;
     }
   };

--- a/packages/blockly/src/components/header.tsx
+++ b/packages/blockly/src/components/header.tsx
@@ -159,7 +159,7 @@ export const Header: React.FC<IProps> = (props) => {
     >
       {items.map((item, index) => (
         <React.Fragment key={item.id}>
-          {item.id === "rename" && <div className={css.fileMenuSeparator} />}
+          {item.id === "rename" && <div className={css.fileMenuSeparator} role="separator" />}
           <div
             ref={el => { itemRefs.current[index] = el; }}
             className={classNames(css.fileMenuItem, { [css.disabled]: item.disabled })}
@@ -168,7 +168,9 @@ export const Header: React.FC<IProps> = (props) => {
             aria-disabled={item.disabled || undefined}
             onClick={() => activateItem(index)}
           >
-            <item.Icon /> {item.label}
+            <span className={css.fileMenuItemContent}>
+              <item.Icon /> {item.label}
+            </span>
           </div>
         </React.Fragment>
       ))}


### PR DESCRIPTION
## What & why

[QI-157](https://concord-consortium.atlassian.net/browse/QI-157) — make the Blockly **File** menu fully keyboard-operable. Audit issue #94; **WCAG 2.1.1 Keyboard (A)** and **4.1.2 Name, Role, Value (A)**.

The menu already declared `role="menu"` / `role="menuitem"`, but the interaction those roles promise wasn't implemented: it couldn't be opened by keyboard (the button toggled on `mousedown` only), the items couldn't be activated by keyboard (`<div onClick>` with no key handling), and there was no in-menu navigation. This PR implements the canonical **ARIA APG menu-button** pattern so the declared roles are honored.

> **Stacked on [#517](https://github.com/concord-consortium/question-interactives/pull/517) (QI-158).** Base is `QI-158-modal-focus-trap`; GitHub will retarget to `master` once #517 merges. The keyboard focus-return added here composes with QI-158: activating a menu item returns focus to the File button so the dialog restores focus there on close.

## Changes (`packages/blockly/src/components/header.tsx` + `.scss`)

- **Data-driven items + roving tabindex.** The five items are a config array; only the active item is `tabIndex=0`, and a focus effect moves DOM focus as `activeIndex` changes.
- **Open by keyboard.** Button toggles on `onClick` (so native Enter/Space activation opens it); `↓`/`↑` open focused on the first/last item. Enter/Space are intentionally *not* in the button's `onKeyDown` — the native button already synthesizes a click for them, so handling them twice would open-then-close (documented inline).
- **In-menu navigation.** `↑`/`↓` move with wrap; `Home`/`End` jump to ends.
- **Activation.** `Enter`/`Space` activate the focused item and close the menu; mouse `click` still works.
- **Close.** `Esc` and `Tab`/`Shift+Tab` close and return focus to the File button.
- **Outside-click close.** The transparent backdrop is replaced by a document `mousedown` listener scoped to the menu wrapper (the backdrop would have raced with the new `onClick` toggle).
- **Focus visibility.** Menu items get a visible focus indicator.

## Design decisions (rationale that isn't obvious from the diff)

- **Full APG menu button**, not a minimal Enter/Space patch or a conversion to a disclosure + native buttons — the `role="menu"` semantics were already declared, so the right fix is to make them fully operable rather than restructure.
- **Disabled "Open" is focusable-but-inert:** it stays in the arrow-key sequence with `aria-disabled="true"` and Enter/Space are no-ops, so keyboard/AT users get parity with sighted users (who see it greyed-but-present). Previously it was hidden from the keyboard entirely.
- **Tab returns focus to the File button** (like Esc), rather than the APG "move to next element in page order" — the focused item unmounts as the menu closes, which makes "next element" racy and can strand focus. Predictable over strictly-spec.
- **Type-ahead (character search) is deliberately excluded** — YAGNI for a fixed five-item menu.
- **No new dependency:** the menu id uses a module counter, not `uuid` (not a declared blockly dep; `eslint-plugin-import` would reject it), and React 17 has no `useId`.

## Testing

- **Unit (`header.test.tsx`, TDD):** open via click and via `↓`/`↑`; arrow/Home/End navigation with wrap; Enter/Space activation + menu close + focus return; disabled-Open reachable, `aria-disabled`, and inert; Esc/Tab/Shift+Tab close + focus return; roving tabindex. 16/16 green. The two existing QI-158 header tests were updated to open via `click` (the button no longer toggles on `mousedown`).
- **Real browser (Playwright/Chromium), keyboard only — impossible before this PR:** Tab to the File button → Enter opens (focus on New) → Enter activates → New dialog opens with focus trapped (QI-158) → Esc returns focus to the File button → reopen → ArrowDown reaches the disabled Open (focusable, `aria-disabled`) then steps to Make a copy → Esc closes back to the button. 9/9 checks.

The pre-existing Blockly `fetch is not defined` jsdom suite failures (Blockly's audio loader under jsdom) are unrelated and untouched; validation gates on the targeted `header.test.tsx` run.

## Out of scope

- The shared `Modal` and its focus trap (QI-158 / #517).
- The broader Blockly canvas / Blockly-library keyboard access (QI-175 spike).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[QI-157]: https://concord-consortium.atlassian.net/browse/QI-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ