### PR TITLE
feat: make the carousel accessible [QI-146]

### DIFF
--- a/packages/carousel/src/components/iframe-authoring.scss
+++ b/packages/carousel/src/components/iframe-authoring.scss
@@ -15,12 +15,19 @@
     transition: max-height 500ms;
   }
 
-  .link {
-    cursor: pointer;
-  }
-
   h4 {
     margin-left: 10px;
+  }
+
+  // The collapsible-section toggle is a real <button> (keyboard-operable, exposes
+  // aria-expanded) styled to read as the heading text rather than a default button.
+  .headerToggle {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font: inherit;
+    padding: 0;
+    text-align: left;
   }
 
   .navButtonField {

--- a/packages/carousel/src/components/iframe-authoring.scss
+++ b/packages/carousel/src/components/iframe-authoring.scss
@@ -21,13 +21,17 @@
 
   // The collapsible-section toggle is a real <button> (keyboard-operable, exposes
   // aria-expanded) styled to read as the heading text rather than a default button.
+  // block + full width preserves the whole heading row as the click target (the old
+  // full-width <h4 onClick>), not just the width of the text.
   .headerToggle {
     background: none;
     border: none;
     cursor: pointer;
+    display: block;
     font: inherit;
     padding: 0;
     text-align: left;
+    width: 100%;
   }
 
   .navButtonField {

--- a/packages/carousel/src/components/iframe-authoring.test.tsx
+++ b/packages/carousel/src/components/iframe-authoring.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+
+import { IframeAuthoring } from "./iframe-authoring";
+
+jest.mock("iframe-phone", () => ({
+  ParentEndpoint: jest.fn(() => ({ disconnect: jest.fn(), post: jest.fn(), addListener: jest.fn() })),
+}));
+
+jest.mock("@concord-consortium/lara-interactive-api", () => ({
+  getFirebaseJwt: jest.fn(),
+}));
+
+jest.mock("@concord-consortium/question-interactives-helpers/src/widgets/image-upload/image-upload-widget", () => ({
+  ImageUploadComponent: () => <input data-testid="image-upload" />,
+}));
+
+const baseProps: any = {
+  onChange: jest.fn(),
+  formData: { libraryInteractiveId: "open-response", id: "1", authoredState: {} },
+  formContext: { tokenServiceClient: {} },
+};
+
+afterEach(cleanup);
+
+describe("IframeAuthoring collapsible header", () => {
+  it("renders the Subquestion Authoring toggle as a button, collapsed by default", () => {
+    const { getByRole } = render(<IframeAuthoring {...baseProps} />);
+    const toggle = getByRole("button", { name: /Subquestion Authoring/ });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("toggles aria-expanded when activated", () => {
+    const { getByRole } = render(<IframeAuthoring {...baseProps} />);
+    const toggle = getByRole("button", { name: /Subquestion Authoring/ });
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+});

--- a/packages/carousel/src/components/iframe-authoring.test.tsx
+++ b/packages/carousel/src/components/iframe-authoring.test.tsx
@@ -38,4 +38,14 @@ describe("IframeAuthoring collapsible header", () => {
     fireEvent.click(toggle);
     expect(toggle).toHaveAttribute("aria-expanded", "false");
   });
+
+  it("marks the collapsed panel inert so its inputs stay out of the tab order, and clears it when opened", () => {
+    const { getByRole, getAllByTestId } = render(<IframeAuthoring {...baseProps} />);
+    // The image-upload inputs live inside the collapsible panel.
+    const panelInput = getAllByTestId("image-upload")[0];
+    expect(panelInput.closest("[inert]")).not.toBeNull();
+
+    fireEvent.click(getByRole("button", { name: /Subquestion Authoring/ }));
+    expect(panelInput.closest("[inert]")).toBeNull();
+  });
 });

--- a/packages/carousel/src/components/iframe-authoring.tsx
+++ b/packages/carousel/src/components/iframe-authoring.tsx
@@ -118,7 +118,11 @@ export const IframeAuthoring: React.FC<FieldProps> = props => {
       {
         libraryInteractiveId &&
         <div className={interactiveWrapperClass}>
-          <h4 onClick={handleHeaderClick} className={css.link} data-cy="subquestion-authoring">{authoringOpened ? "▼" : "▶"} Subquestion Authoring</h4>
+          <h4>
+            <button type="button" className={css.headerToggle} aria-expanded={authoringOpened} onClick={handleHeaderClick} data-cy="subquestion-authoring">
+              {authoringOpened ? "▼" : "▶"} Subquestion Authoring
+            </button>
+          </h4>
           <div className={css.iframeContainer} style={{maxHeight: authoringOpened ? iframeHeight : 0 }}>
             <div className={css.navButtonField}>
               <label htmlFor="navImageUrl">Custom Navigation Button Image URL</label>

--- a/packages/carousel/src/components/iframe-authoring.tsx
+++ b/packages/carousel/src/components/iframe-authoring.tsx
@@ -123,7 +123,23 @@ export const IframeAuthoring: React.FC<FieldProps> = props => {
               {authoringOpened ? "▼" : "▶"} Subquestion Authoring
             </button>
           </h4>
-          <div className={css.iframeContainer} style={{maxHeight: authoringOpened ? iframeHeight : 0 }}>
+          <div
+            className={css.iframeContainer}
+            // When collapsed the panel is only visually clipped (maxHeight: 0), so its inputs and
+            // iframe would otherwise stay in the tab order — tabbing off the toggle would drop focus
+            // into the hidden panel. Mark it `inert` while closed to remove it from the tab order and
+            // from AT, matching aria-expanded. `inert` isn't a typed React 17 prop, so we toggle the
+            // attribute directly via a ref callback (same approach as the runtime's off-screen slides).
+            ref={el => {
+              if (!el) return;
+              if (authoringOpened) {
+                el.removeAttribute("inert");
+              } else {
+                el.setAttribute("inert", "");
+              }
+            }}
+            style={{maxHeight: authoringOpened ? iframeHeight : 0 }}
+          >
             <div className={css.navButtonField}>
               <label htmlFor="navImageUrl">Custom Navigation Button Image URL</label>
               <ImageUploadComponent className="form-control" id="navImageUrl" defaultValue={navImageUrl} onChange={handleNavImageUrlChange} tokenServiceClient={tokenServiceClient} />

--- a/packages/carousel/src/components/runtime.scss
+++ b/packages/carousel/src/components/runtime.scss
@@ -82,7 +82,7 @@ nav {
     // Nav buttons live outside .runtime, so they don't inherit the ap-button focus ring.
     // Give them their own visible focus indicator (WCAG 2.4.7). The outline follows the
     // border-radius, so it renders as a ring around the round dots and a box around the
-    // triangle buttons (whose 20×20 border-box encloses the arrow).
+    // triangle buttons (whose 24×24 border-box encloses the arrow).
     &:focus-visible {
       @include native-focus-ring(3px);
     }

--- a/packages/carousel/src/components/runtime.scss
+++ b/packages/carousel/src/components/runtime.scss
@@ -112,24 +112,27 @@ nav {
     &.prevButton {
       border-right: solid 24px var(--cc-carousel-nav);
 
-      &:hover:not(:disabled) {
+      &:hover:not([aria-disabled="true"]) {
         border-right-color: var(--cc-carousel-nav-hover);
       }
-      &:disabled {
+      &[aria-disabled="true"] {
         border-right-color: var(--cc-carousel-nav-disabled);
       }
     }
     &.nextButton {
       border-left: solid 24px var(--cc-carousel-nav);
 
-      &:hover:not(:disabled) {
+      &:hover:not([aria-disabled="true"]) {
         border-left-color: var(--cc-carousel-nav-hover);
       }
-      &:disabled {
+      &[aria-disabled="true"] {
         border-left-color: var(--cc-carousel-nav-disabled);
       }
     }
-    &:disabled {
+    // Prev/Next use aria-disabled (not the native `disabled` attribute) so the button keeps
+    // focus at the slide boundaries; the click handlers no-op there. Style the aria state to
+    // match the old disabled look.
+    &[aria-disabled="true"] {
       cursor: not-allowed;
       opacity: .8;
     }
@@ -146,10 +149,19 @@ nav {
       max-height: 100px;
       width: 150px;
 
-      &:hover, &.activeButton {
+      &:hover {
         background-color: transparent;
         border: solid 2px var(--cc-orange-dark-1);
         transform: scale(1.1);
+      }
+      // Active custom button: a stronger cue than hover — the same white-gap + orange ring the
+      // default active dot uses (see &.activeButton:not(.customButton) above) plus a larger
+      // bump — so the current slide stays distinguishable from a merely-hovered one (WCAG 1.4.1).
+      &.activeButton {
+        background-color: transparent;
+        border: solid 2px var(--cc-orange-dark-1);
+        box-shadow: 0 0 0 2px var(--white), 0 0 0 4px var(--cc-orange-dark-1);
+        transform: scale(1.15);
       }
     }
   }

--- a/packages/carousel/src/components/runtime.scss
+++ b/packages/carousel/src/components/runtime.scss
@@ -100,15 +100,17 @@ nav {
       transform: scale(1.25);
     }
     &.prevButton, &.nextButton {
+      // Border-drawn triangles: the 24px border box is the pointer target (WCAG 2.5.8),
+      // matching the round dots. 12px top/bottom + 24px on the pointing side = 24×24.
       background: transparent;
-      border-top: solid 10px transparent;
-      border-bottom: solid 10px transparent;
+      border-top: solid 12px transparent;
+      border-bottom: solid 12px transparent;
       border-radius: 0;
       height: 0;
       width: 0;
     }
     &.prevButton {
-      border-right: solid 20px var(--cc-carousel-nav);
+      border-right: solid 24px var(--cc-carousel-nav);
 
       &:hover:not(:disabled) {
         border-right-color: var(--cc-carousel-nav-hover);
@@ -118,7 +120,7 @@ nav {
       }
     }
     &.nextButton {
-      border-left: solid 20px var(--cc-carousel-nav);
+      border-left: solid 24px var(--cc-carousel-nav);
 
       &:hover:not(:disabled) {
         border-left-color: var(--cc-carousel-nav-hover);

--- a/packages/carousel/src/components/runtime.scss
+++ b/packages/carousel/src/components/runtime.scss
@@ -11,6 +11,20 @@
   --cc-carousel-nav-disabled: #767676; // disabled prev/next arrows — ≥3:1 on white (WCAG 1.4.11)
 }
 
+// Visually hidden but available to assistive technology (e.g. the slide-change live region).
+// Uses clip/absolute positioning rather than display:none so screen readers still announce it.
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .runtime {
   button {
     @include ap-button;
@@ -57,19 +71,33 @@ nav {
     border: none;
     border-radius: 50%;
     cursor: pointer;
-    height: 20px;
+    height: 24px; // WCAG 2.2 SC 2.5.8: ≥24px pointer target
     margin: 15px 0 10px 15px;
     overflow: hidden;
     padding: 0;
     text-indent: 200%;
     white-space: nowrap;
-    width: 20px;
+    width: 24px;
 
+    // Nav buttons live outside .runtime, so they don't inherit the ap-button focus ring.
+    // Give them their own visible focus indicator (WCAG 2.4.7). The outline follows the
+    // border-radius, so it renders as a ring around the round dots and a box around the
+    // triangle buttons (whose 20×20 border-box encloses the arrow).
+    &:focus-visible {
+      @include native-focus-ring(3px);
+    }
     &:hover {
       background: var(--cc-carousel-nav-hover);
     }
     &.activeButton {
       background: var(--cc-orange-dark-1);
+    }
+    // Non-color cue for the active dot so it's distinguishable without relying on hue
+    // (WCAG 1.4.1): a white gap + orange ring plus a size bump. Custom-image buttons have
+    // their own border/scale cue below, so this is scoped to the default dots.
+    &.activeButton:not(.customButton) {
+      box-shadow: 0 0 0 2px var(--white), 0 0 0 4px var(--cc-orange-dark-1);
+      transform: scale(1.25);
     }
     &.prevButton, &.nextButton {
       background: transparent;
@@ -82,24 +110,24 @@ nav {
     &.prevButton {
       border-right: solid 20px var(--cc-carousel-nav);
 
-      &:hover:not(.disabled) {
+      &:hover:not(:disabled) {
         border-right-color: var(--cc-carousel-nav-hover);
       }
-      &.disabled {
+      &:disabled {
         border-right-color: var(--cc-carousel-nav-disabled);
       }
     }
     &.nextButton {
       border-left: solid 20px var(--cc-carousel-nav);
 
-      &:hover:not(.disabled) {
+      &:hover:not(:disabled) {
         border-left-color: var(--cc-carousel-nav-hover);
       }
-      &.disabled {
+      &:disabled {
         border-left-color: var(--cc-carousel-nav-disabled);
       }
     }
-    &.disabled {
+    &:disabled {
       cursor: not-allowed;
       opacity: .8;
     }

--- a/packages/carousel/src/components/runtime.test.tsx
+++ b/packages/carousel/src/components/runtime.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, cleanup } from "@testing-library/react";
+import { render, cleanup, fireEvent } from "@testing-library/react";
 
 import { Runtime } from "./runtime";
 import { IAuthoredState } from "./types";
@@ -61,5 +61,24 @@ describe("Carousel Runtime child iframe titles", () => {
       <Runtime authoredState={unknownState} interactiveState={null} setInteractiveState={jest.fn()} />
     );
     expect(getByTestId("iframe-runtime")).toHaveAttribute("data-title", "Slide 1: Interactive content");
+  });
+});
+
+describe("Carousel Runtime active slide indication", () => {
+  it("marks only the active slide's nav button with aria-current=true", () => {
+    const { getByRole } = render(
+      <Runtime authoredState={authoredState} interactiveState={null} setInteractiveState={jest.fn()} />
+    );
+    expect(getByRole("button", { name: "Go to slide 1" })).toHaveAttribute("aria-current", "true");
+    expect(getByRole("button", { name: "Go to slide 2" })).not.toHaveAttribute("aria-current");
+  });
+
+  it("moves aria-current to the newly selected slide when a nav button is clicked", () => {
+    const { getByRole } = render(
+      <Runtime authoredState={authoredState} interactiveState={null} setInteractiveState={jest.fn()} />
+    );
+    fireEvent.click(getByRole("button", { name: "Go to slide 2" }));
+    expect(getByRole("button", { name: "Go to slide 1" })).not.toHaveAttribute("aria-current");
+    expect(getByRole("button", { name: "Go to slide 2" })).toHaveAttribute("aria-current", "true");
   });
 });

--- a/packages/carousel/src/components/runtime.test.tsx
+++ b/packages/carousel/src/components/runtime.test.tsx
@@ -84,24 +84,26 @@ describe("Carousel Runtime active slide indication", () => {
 });
 
 describe("Carousel Runtime Prev/Next availability", () => {
-  it("disables Prev on the first slide and enables Next", () => {
+  // Prev/Next use aria-disabled (not the native `disabled` attribute) so a keyboard user keeps
+  // focus on the button at the slide boundaries instead of having focus dropped to <body>.
+  it("marks Prev aria-disabled on the first slide and leaves Next enabled", () => {
     const { getByRole } = render(
       <Runtime authoredState={authoredState} interactiveState={null} setInteractiveState={jest.fn()} />
     );
-    expect(getByRole("button", { name: "Previous slide" })).toBeDisabled();
-    expect(getByRole("button", { name: "Next slide" })).toBeEnabled();
+    expect(getByRole("button", { name: "Previous slide" })).toHaveAttribute("aria-disabled", "true");
+    expect(getByRole("button", { name: "Next slide" })).toHaveAttribute("aria-disabled", "false");
   });
 
-  it("disables Next on the last slide and enables Prev", () => {
+  it("marks Next aria-disabled on the last slide and leaves Prev enabled", () => {
     const { getByRole } = render(
       <Runtime authoredState={authoredState} interactiveState={null} setInteractiveState={jest.fn()} />
     );
     fireEvent.click(getByRole("button", { name: "Go to slide 2" }));
-    expect(getByRole("button", { name: "Next slide" })).toBeDisabled();
-    expect(getByRole("button", { name: "Previous slide" })).toBeEnabled();
+    expect(getByRole("button", { name: "Next slide" })).toHaveAttribute("aria-disabled", "true");
+    expect(getByRole("button", { name: "Previous slide" })).toHaveAttribute("aria-disabled", "false");
   });
 
-  it("does not advance past the first slide when disabled Prev is clicked", () => {
+  it("does not advance past the first slide when aria-disabled Prev is clicked", () => {
     const { getByRole } = render(
       <Runtime authoredState={authoredState} interactiveState={null} setInteractiveState={jest.fn()} />
     );
@@ -132,13 +134,14 @@ describe("Carousel Runtime slide-change announcements", () => {
     window.history.replaceState(null, "", originalHref);
   });
 
-  it("exposes a polite status region naming the current slide and total", () => {
+  it("exposes a polite status region that stays silent on load (the first slide is already visible)", () => {
     const { getByRole } = render(
       <Runtime authoredState={authoredState} interactiveState={null} setInteractiveState={jest.fn()} />
     );
     const status = getByRole("status");
     expect(status).toHaveAttribute("aria-live", "polite");
-    expect(status).toHaveTextContent("Slide 1 of 2: Open response");
+    // No spurious announcement of the already-shown first slide on mount.
+    expect(status).toBeEmptyDOMElement();
   });
 
   it("updates the status region when the slide changes", () => {
@@ -147,6 +150,15 @@ describe("Carousel Runtime slide-change announcements", () => {
     );
     fireEvent.click(getByRole("button", { name: "Go to slide 2" }));
     expect(getByRole("status")).toHaveTextContent("Slide 2 of 2: Image");
+  });
+
+  it("announces the first slide when the user navigates back to it", () => {
+    const { getByRole } = render(
+      <Runtime authoredState={authoredState} interactiveState={null} setInteractiveState={jest.fn()} />
+    );
+    fireEvent.click(getByRole("button", { name: "Go to slide 2" }));
+    fireEvent.click(getByRole("button", { name: "Go to slide 1" }));
+    expect(getByRole("status")).toHaveTextContent("Slide 1 of 2: Open response");
   });
 });
 
@@ -189,6 +201,14 @@ describe("Carousel Runtime carousel structure", () => {
     );
     fireEvent.click(getByRole("button", { name: "Go to slide 2" }));
     expect(getByLabelText("Slide 1 of 2")).toHaveAttribute("inert");
+    expect(getByLabelText("Slide 2 of 2")).not.toHaveAttribute("inert");
+  });
+
+  it("does not mark slides inert in report mode, so every response stays readable", () => {
+    const { getByLabelText } = render(
+      <Runtime authoredState={authoredState} interactiveState={null} setInteractiveState={jest.fn()} report={true} />
+    );
+    expect(getByLabelText("Slide 1 of 2")).not.toHaveAttribute("inert");
     expect(getByLabelText("Slide 2 of 2")).not.toHaveAttribute("inert");
   });
 });

--- a/packages/carousel/src/components/runtime.test.tsx
+++ b/packages/carousel/src/components/runtime.test.tsx
@@ -82,3 +82,107 @@ describe("Carousel Runtime active slide indication", () => {
     expect(getByRole("button", { name: "Go to slide 2" })).toHaveAttribute("aria-current", "true");
   });
 });
+
+describe("Carousel Runtime Prev/Next availability", () => {
+  it("disables Prev on the first slide and enables Next", () => {
+    const { getByRole } = render(
+      <Runtime authoredState={authoredState} interactiveState={null} setInteractiveState={jest.fn()} />
+    );
+    expect(getByRole("button", { name: "Previous slide" })).toBeDisabled();
+    expect(getByRole("button", { name: "Next slide" })).toBeEnabled();
+  });
+
+  it("disables Next on the last slide and enables Prev", () => {
+    const { getByRole } = render(
+      <Runtime authoredState={authoredState} interactiveState={null} setInteractiveState={jest.fn()} />
+    );
+    fireEvent.click(getByRole("button", { name: "Go to slide 2" }));
+    expect(getByRole("button", { name: "Next slide" })).toBeDisabled();
+    expect(getByRole("button", { name: "Previous slide" })).toBeEnabled();
+  });
+
+  it("does not advance past the first slide when disabled Prev is clicked", () => {
+    const { getByRole } = render(
+      <Runtime authoredState={authoredState} interactiveState={null} setInteractiveState={jest.fn()} />
+    );
+    fireEvent.click(getByRole("button", { name: "Previous slide" }));
+    // aria-current must stay on slide 1 — currentSlide never goes negative
+    expect(getByRole("button", { name: "Go to slide 1" })).toHaveAttribute("aria-current", "true");
+  });
+
+  it("gives all nav buttons type=button so they never submit a surrounding form", () => {
+    const { getByRole } = render(
+      <Runtime authoredState={authoredState} interactiveState={null} setInteractiveState={jest.fn()} />
+    );
+    expect(getByRole("button", { name: "Previous slide" })).toHaveAttribute("type", "button");
+    expect(getByRole("button", { name: "Next slide" })).toHaveAttribute("type", "button");
+    expect(getByRole("button", { name: "Go to slide 1" })).toHaveAttribute("type", "button");
+  });
+});
+
+describe("Carousel Runtime slide-change announcements", () => {
+  beforeEach(() => {
+    // Resolve the child interactive type names so the announcement includes them.
+    window.history.replaceState(null, "", "/version/0.5.0/carousel");
+  });
+
+  it("exposes a polite status region naming the current slide and total", () => {
+    const { getByRole } = render(
+      <Runtime authoredState={authoredState} interactiveState={null} setInteractiveState={jest.fn()} />
+    );
+    const status = getByRole("status");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(status).toHaveTextContent("Slide 1 of 2: Open response");
+  });
+
+  it("updates the status region when the slide changes", () => {
+    const { getByRole } = render(
+      <Runtime authoredState={authoredState} interactiveState={null} setInteractiveState={jest.fn()} />
+    );
+    fireEvent.click(getByRole("button", { name: "Go to slide 2" }));
+    expect(getByRole("status")).toHaveTextContent("Slide 2 of 2: Image");
+  });
+});
+
+describe("Carousel Runtime carousel structure", () => {
+  it("exposes the carousel as a labeled region", () => {
+    const { getByRole } = render(
+      <Runtime authoredState={authoredState} interactiveState={null} setInteractiveState={jest.fn()} />
+    );
+    const region = getByRole("region", { name: "Carousel" });
+    expect(region).toHaveAttribute("aria-roledescription", "carousel");
+  });
+
+  it("labels each slide as a group with its position", () => {
+    const { getByRole } = render(
+      <Runtime authoredState={authoredState} interactiveState={null} setInteractiveState={jest.fn()} />
+    );
+    const slide1 = getByRole("group", { name: "Slide 1 of 2" });
+    expect(slide1).toHaveAttribute("aria-roledescription", "slide");
+    expect(getByRole("group", { name: "Slide 2 of 2" })).toHaveAttribute("aria-roledescription", "slide");
+  });
+
+  it("labels the nav landmark", () => {
+    const { getByRole } = render(
+      <Runtime authoredState={authoredState} interactiveState={null} setInteractiveState={jest.fn()} />
+    );
+    expect(getByRole("navigation", { name: "Carousel navigation" })).toBeInTheDocument();
+  });
+
+  it("keeps only the current slide reachable, marking off-screen slides inert", () => {
+    const { getByLabelText } = render(
+      <Runtime authoredState={authoredState} interactiveState={null} setInteractiveState={jest.fn()} />
+    );
+    expect(getByLabelText("Slide 1 of 2")).not.toHaveAttribute("inert");
+    expect(getByLabelText("Slide 2 of 2")).toHaveAttribute("inert");
+  });
+
+  it("moves inert to the previously-current slide when the slide changes", () => {
+    const { getByLabelText, getByRole } = render(
+      <Runtime authoredState={authoredState} interactiveState={null} setInteractiveState={jest.fn()} />
+    );
+    fireEvent.click(getByRole("button", { name: "Go to slide 2" }));
+    expect(getByLabelText("Slide 1 of 2")).toHaveAttribute("inert");
+    expect(getByLabelText("Slide 2 of 2")).not.toHaveAttribute("inert");
+  });
+});

--- a/packages/carousel/src/components/runtime.test.tsx
+++ b/packages/carousel/src/components/runtime.test.tsx
@@ -121,9 +121,15 @@ describe("Carousel Runtime Prev/Next availability", () => {
 });
 
 describe("Carousel Runtime slide-change announcements", () => {
+  const originalHref = window.location.href;
+
   beforeEach(() => {
     // Resolve the child interactive type names so the announcement includes them.
     window.history.replaceState(null, "", "/version/0.5.0/carousel");
+  });
+
+  afterEach(() => {
+    window.history.replaceState(null, "", originalHref);
   });
 
   it("exposes a polite status region naming the current slide and total", () => {

--- a/packages/carousel/src/components/runtime.tsx
+++ b/packages/carousel/src/components/runtime.tsx
@@ -146,7 +146,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
           }
           const buttonText = interactive.navImageAltText ? interactive.navImageAltText : `Go to slide ${index + 1}`;
           return (
-            <button key={index} className={buttonClass} style={buttonStyle} title={buttonText} aria-label={buttonText} onClick={(event) => updateCurrentSlide(index, event)}>{buttonText}</button>
+            <button key={index} className={buttonClass} style={buttonStyle} title={buttonText} aria-label={buttonText} aria-current={currentSlide === index ? "true" : undefined} onClick={(event) => updateCurrentSlide(index, event)}>{buttonText}</button>
           );
         })}
         <button className={currentSlide === subinteractives.length - 1 ? css.disabled + " " + css.nextButton : css.nextButton} onClick={nextSlide}>Next</button>

--- a/packages/carousel/src/components/runtime.tsx
+++ b/packages/carousel/src/components/runtime.tsx
@@ -17,14 +17,10 @@ interface IProps {
   setInteractiveState?: (updateFunc: (prevState: IInteractiveState | null) => IInteractiveState) => void;
 }
 
-type Subinteractive = NonNullable<IAuthoredState["subinteractives"]>[number];
-
-// Resolve the human-readable interactive type (e.g. "Open response", "Image") for a slide,
-// falling back to a generic name when the library interactive can't be resolved.
-const getInteractiveTypeName = (interactive: Subinteractive) => {
-  const url = libraryInteractiveIdToUrl(interactive.libraryInteractiveId, "carousel");
-  return getLibraryInteractive(url)?.name || "Interactive content";
-};
+// Resolve the human-readable interactive type (e.g. "Open response", "Image") from a slide's
+// already-resolved subinteractive URL, falling back to a generic name when it can't be resolved.
+const getInteractiveTypeName = (subinteractiveUrl: string) =>
+  getLibraryInteractive(subinteractiveUrl)?.name || "Interactive content";
 
 // react-responsive-carousel keeps every slide in the DOM (off-screen ones are only visually
 // offset), so their iframes stay focusable and in the accessibility tree. Marking non-current
@@ -106,7 +102,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
 
   const currentInteractive = subinteractives[currentSlide];
   const slideAnnouncement = currentInteractive
-    ? `Slide ${currentSlide + 1} of ${subinteractives.length}: ${getInteractiveTypeName(currentInteractive)}`
+    ? `Slide ${currentSlide + 1} of ${subinteractives.length}: ${getInteractiveTypeName(libraryInteractiveIdToUrl(currentInteractive.libraryInteractiveId, "carousel"))}`
     : "";
 
   return (
@@ -116,7 +112,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
         {subinteractives.map(function(interactive, index) {
           const subState = subStates && subStates[interactive.id];
           const subinteractiveUrl = libraryInteractiveIdToUrl(interactive.libraryInteractiveId, "carousel");
-          const interactiveTypeName = getInteractiveTypeName(interactive);
+          const interactiveTypeName = getInteractiveTypeName(subinteractiveUrl);
           const iframeTitle = `Slide ${index + 1}: ${interactiveTypeName}`;
           const logRequestData: Record<string, unknown> = { subinteractive_url: subinteractiveUrl,
                                                             subinteractive_type: interactive.authoredState.questionType,

--- a/packages/carousel/src/components/runtime.tsx
+++ b/packages/carousel/src/components/runtime.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent, useCallback, useEffect, useRef, useState } from "react";
+import React, { MouseEvent, useCallback, useRef, useState } from "react";
 import { IframeRuntime } from "@concord-consortium/question-interactives-helpers/src/components/iframe-runtime";
 import { IAuthoredState, IInteractiveState } from "./types";
 import { renderHTML } from "@concord-consortium/question-interactives-helpers/src/utilities/render-html";
@@ -16,6 +16,28 @@ interface IProps {
   interactiveState?: IInteractiveState | null;
   setInteractiveState?: (updateFunc: (prevState: IInteractiveState | null) => IInteractiveState) => void;
 }
+
+type Subinteractive = NonNullable<IAuthoredState["subinteractives"]>[number];
+
+// Resolve the human-readable interactive type (e.g. "Open response", "Image") for a slide,
+// falling back to a generic name when the library interactive can't be resolved.
+const getInteractiveTypeName = (interactive: Subinteractive) => {
+  const url = libraryInteractiveIdToUrl(interactive.libraryInteractiveId, "carousel");
+  return getLibraryInteractive(url)?.name || "Interactive content";
+};
+
+// react-responsive-carousel keeps every slide in the DOM (off-screen ones are only visually
+// offset), so their iframes stay focusable and in the accessibility tree. Marking non-current
+// slides `inert` removes them from the tab order and from AT. `inert` isn't a typed React 17
+// prop, so we toggle the attribute directly via a ref callback.
+const setSlideInert = (el: HTMLElement | null, inert: boolean) => {
+  if (!el) return;
+  if (inert) {
+    el.setAttribute("inert", "");
+  } else {
+    el.removeAttribute("inert");
+  }
+};
 
 export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState }) => {
   const readOnly = authoredState.required && interactiveState?.submitted;
@@ -36,26 +58,6 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
       setCurrentSlide(index);
     }
   }, []);
-
-  // This scroll handler triggers the carousel to set the current slide when
-  // a user uses their keyboard to tab directly through the slides (without
-  // using the carousel's navigation buttons).
-  const handleScroll = useCallback((scroller: any) => {
-    const scrollPosition = scroller.scrollLeft;
-    if (scrollPosition > 0) {
-      scroller.scrollLeft = 0;
-      updateCurrentSlide(currentSlideRef.current + 1);
-    }
-  }, [updateCurrentSlide]);
-
-  useEffect(() => {
-    const scroller = document.querySelector(".slider-wrapper");
-    if (scroller) {
-      (scroller as any).onscroll = () => {
-        handleScroll(scroller);
-      };
-    }
-  }, [handleScroll]);
 
   const subinteractives = authoredState.subinteractives || [];
   if (subinteractives.length === 0) {
@@ -80,12 +82,14 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
   };
 
   const nextSlide = (event: MouseEvent<HTMLButtonElement>) => {
+    if (currentSlide >= subinteractives.length - 1) return; // guard against overrunning the last slide
     const target = event.currentTarget as HTMLButtonElement;
     target.focus(); // required for consistent behavior in all browsers
     setCurrentSlide(currentSlide + 1);
   };
 
   const previousSlide = (event: MouseEvent<HTMLButtonElement>) => {
+    if (currentSlide <= 0) return; // guard against going before the first slide
     const target = event.currentTarget as HTMLButtonElement;
     target.focus(); // required for consistent behavior in all browsers
     setCurrentSlide(currentSlide - 1);
@@ -100,13 +104,19 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     });
   };
 
+  const currentInteractive = subinteractives[currentSlide];
+  const slideAnnouncement = currentInteractive
+    ? `Slide ${currentSlide + 1} of ${subinteractives.length}: ${getInteractiveTypeName(currentInteractive)}`
+    : "";
+
   return (
-    <div>
+    <div role="region" aria-roledescription="carousel" aria-label="Carousel">
+      <div role="status" aria-live="polite" className={css.visuallyHidden}>{slideAnnouncement}</div>
       <Carousel selectedItem={currentSlide} onChange={updateCurrentSlide} showArrows={false} showIndicators={false} showStatus={false} showThumbs={false} autoPlay={false} dynamicHeight={false} transitionTime={300}>
         {subinteractives.map(function(interactive, index) {
           const subState = subStates && subStates[interactive.id];
           const subinteractiveUrl = libraryInteractiveIdToUrl(interactive.libraryInteractiveId, "carousel");
-          const interactiveTypeName = getLibraryInteractive(subinteractiveUrl)?.name || "Interactive content";
+          const interactiveTypeName = getInteractiveTypeName(interactive);
           const iframeTitle = `Slide ${index + 1}: ${interactiveTypeName}`;
           const logRequestData: Record<string, unknown> = { subinteractive_url: subinteractiveUrl,
                                                             subinteractive_type: interactive.authoredState.questionType,
@@ -114,7 +124,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
                                                             subinteractive_id: interactive.id,
                                                           };
           return (
-            <div key={index} className={css.runtime}>
+            <div key={index} ref={(el) => setSlideInert(el, currentSlide !== index)} className={css.runtime} role="group" aria-roledescription="slide" aria-label={`Slide ${index + 1} of ${subinteractives.length}`}>
               { authoredState.prompt &&
                 <div><DynamicText>{renderHTML(authoredState.prompt)}</DynamicText></div> }
                 <IframeRuntime
@@ -135,8 +145,8 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
           );
         })}
       </Carousel>
-      <nav data-cy="carousel-nav">
-        <button className={currentSlide === 0 ? css.disabled + " " + css.prevButton : css.prevButton} onClick={previousSlide}>Prev</button>
+      <nav data-cy="carousel-nav" aria-label="Carousel navigation">
+        <button type="button" className={css.prevButton} disabled={currentSlide === 0} aria-label="Previous slide" onClick={previousSlide}>Prev</button>
         {subinteractives.map(function(interactive, index) {
           let buttonStyle = {};
           let buttonClass = currentSlide === index ? css.activeButton : "";
@@ -146,10 +156,10 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
           }
           const buttonText = interactive.navImageAltText ? interactive.navImageAltText : `Go to slide ${index + 1}`;
           return (
-            <button key={index} className={buttonClass} style={buttonStyle} title={buttonText} aria-label={buttonText} aria-current={currentSlide === index ? "true" : undefined} onClick={(event) => updateCurrentSlide(index, event)}>{buttonText}</button>
+            <button type="button" key={index} className={buttonClass} style={buttonStyle} title={buttonText} aria-label={buttonText} aria-current={currentSlide === index ? "true" : undefined} onClick={(event) => updateCurrentSlide(index, event)}>{buttonText}</button>
           );
         })}
-        <button className={currentSlide === subinteractives.length - 1 ? css.disabled + " " + css.nextButton : css.nextButton} onClick={nextSlide}>Next</button>
+        <button type="button" className={css.nextButton} disabled={currentSlide === subinteractives.length - 1} aria-label="Next slide" onClick={nextSlide}>Next</button>
       </nav>
     </div>
   );

--- a/packages/carousel/src/components/runtime.tsx
+++ b/packages/carousel/src/components/runtime.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent, useCallback, useRef, useState } from "react";
+import React, { MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { IframeRuntime } from "@concord-consortium/question-interactives-helpers/src/components/iframe-runtime";
 import { IAuthoredState, IInteractiveState } from "./types";
 import { renderHTML } from "@concord-consortium/question-interactives-helpers/src/utilities/render-html";
@@ -15,6 +15,7 @@ interface IProps {
   authoredState: IAuthoredState;
   interactiveState?: IInteractiveState | null;
   setInteractiveState?: (updateFunc: (prevState: IInteractiveState | null) => IInteractiveState) => void;
+  report?: boolean;
 }
 
 // Resolve the human-readable interactive type (e.g. "Open response", "Image") from a slide's
@@ -23,9 +24,21 @@ const getInteractiveTypeName = (subinteractiveUrl: string) =>
   getLibraryInteractive(subinteractiveUrl)?.name || "Interactive content";
 
 // react-responsive-carousel keeps every slide in the DOM (off-screen ones are only visually
-// offset), so their iframes stay focusable and in the accessibility tree. Marking non-current
-// slides `inert` removes them from the tab order and from AT. `inert` isn't a typed React 17
-// prop, so we toggle the attribute directly via a ref callback.
+// offset), so their iframes stay focusable and in the accessibility tree. In the runtime we
+// mark non-current slides `inert` to remove them from the tab order and from AT (matching the
+// one-slide-at-a-time carousel pattern). In report mode we skip inert so a reviewer can read
+// every response. `inert` isn't a typed React 17 prop, so we toggle the attribute directly via
+// a ref callback.
+//
+// We rely on native `inert` (Baseline "widely available" since 2023 — Chrome/Safari 2022,
+// Firefox 112) with no polyfill. On a browser predating that support, `inert` is ignored and
+// the off-screen slides fall back to react-responsive-carousel's raw behavior: still focusable
+// and in the DOM. A keyboard user tabbing past the current slide's last control would then step
+// into a visually off-screen slide's iframe. This is disorienting, not blocking — focus is not
+// trapped; continued tabbing walks through the hidden content and eventually reaches the nav
+// buttons, it just does so with no visual indication of where focus is. We accept that edge case
+// rather than pulling in wicg-inert. Add the polyfill here if an older-browser target ever
+// becomes a requirement.
 const setSlideInert = (el: HTMLElement | null, inert: boolean) => {
   if (!el) return;
   if (inert) {
@@ -35,14 +48,44 @@ const setSlideInert = (el: HTMLElement | null, inert: boolean) => {
   }
 };
 
-export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState }) => {
+export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, setInteractiveState, report }) => {
   const readOnly = authoredState.required && interactiveState?.submitted;
+  // Memoized so its reference is stable across renders (the `|| []` fallback would otherwise
+  // produce a new array each render, defeating the slideInfos memo below).
+  const subinteractives = useMemo(() => authoredState.subinteractives || [], [authoredState.subinteractives]);
 
   const [currentSlide, setCurrentSlide] = useState(0);
   const currentSlideRef = useRef(currentSlide);
   currentSlideRef.current = currentSlide;
 
   const accessibility = useAccessibility();
+
+  // Resolve each slide's subinteractive URL + human-readable type once, reused by both the
+  // slide render and the slide-change announcement (avoids resolving the current slide twice
+  // per render).
+  const slideInfos = useMemo(
+    () => subinteractives.map((interactive) => {
+      const url = libraryInteractiveIdToUrl(interactive.libraryInteractiveId, "carousel");
+      return { url, typeName: getInteractiveTypeName(url) };
+    }),
+    [subinteractives]
+  );
+
+  // Announce slide changes to screen readers via the polite live region, but stay silent on the
+  // initial mount: slide 1 is already visible on load, so re-announcing it would be redundant.
+  // Only subsequent changes are announced (including navigating back to the first slide).
+  const [slideAnnouncement, setSlideAnnouncement] = useState("");
+  const didMountRef = useRef(false);
+  useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
+    const info = slideInfos[currentSlide];
+    if (info) {
+      setSlideAnnouncement(`Slide ${currentSlide + 1} of ${slideInfos.length}: ${info.typeName}`);
+    }
+  }, [currentSlide, slideInfos]);
 
   const updateCurrentSlide = useCallback((index: number, event?: MouseEvent<HTMLButtonElement>) => {
     if (event) {
@@ -55,7 +98,6 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     }
   }, []);
 
-  const subinteractives = authoredState.subinteractives || [];
   if (subinteractives.length === 0) {
     return <div>No sub items available. Please add them using the authoring interface.</div>;
   }
@@ -100,19 +142,13 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     });
   };
 
-  const currentInteractive = subinteractives[currentSlide];
-  const slideAnnouncement = currentInteractive
-    ? `Slide ${currentSlide + 1} of ${subinteractives.length}: ${getInteractiveTypeName(libraryInteractiveIdToUrl(currentInteractive.libraryInteractiveId, "carousel"))}`
-    : "";
-
   return (
     <div role="region" aria-roledescription="carousel" aria-label="Carousel">
       <div role="status" aria-live="polite" className={css.visuallyHidden}>{slideAnnouncement}</div>
       <Carousel selectedItem={currentSlide} onChange={updateCurrentSlide} showArrows={false} showIndicators={false} showStatus={false} showThumbs={false} autoPlay={false} dynamicHeight={false} transitionTime={300}>
         {subinteractives.map(function(interactive, index) {
           const subState = subStates && subStates[interactive.id];
-          const subinteractiveUrl = libraryInteractiveIdToUrl(interactive.libraryInteractiveId, "carousel");
-          const interactiveTypeName = getInteractiveTypeName(subinteractiveUrl);
+          const { url: subinteractiveUrl, typeName: interactiveTypeName } = slideInfos[index];
           const iframeTitle = `Slide ${index + 1}: ${interactiveTypeName}`;
           const logRequestData: Record<string, unknown> = { subinteractive_url: subinteractiveUrl,
                                                             subinteractive_type: interactive.authoredState.questionType,
@@ -120,7 +156,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
                                                             subinteractive_id: interactive.id,
                                                           };
           return (
-            <div key={index} ref={(el) => setSlideInert(el, currentSlide !== index)} className={css.runtime} role="group" aria-roledescription="slide" aria-label={`Slide ${index + 1} of ${subinteractives.length}`}>
+            <div key={index} ref={(el) => setSlideInert(el, !report && currentSlide !== index)} className={css.runtime} role="group" aria-roledescription="slide" aria-label={`Slide ${index + 1} of ${subinteractives.length}`}>
               { authoredState.prompt &&
                 <div><DynamicText>{renderHTML(authoredState.prompt)}</DynamicText></div> }
                 <IframeRuntime
@@ -142,7 +178,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
         })}
       </Carousel>
       <nav data-cy="carousel-nav" aria-label="Carousel navigation">
-        <button type="button" className={css.prevButton} disabled={currentSlide === 0} aria-label="Previous slide" onClick={previousSlide}>Prev</button>
+        <button type="button" className={css.prevButton} aria-disabled={currentSlide === 0} aria-label="Previous slide" onClick={previousSlide}>Prev</button>
         {subinteractives.map(function(interactive, index) {
           let buttonStyle = {};
           let buttonClass = currentSlide === index ? css.activeButton : "";
@@ -155,7 +191,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
             <button type="button" key={index} className={buttonClass} style={buttonStyle} title={buttonText} aria-label={buttonText} aria-current={currentSlide === index ? "true" : undefined} onClick={(event) => updateCurrentSlide(index, event)}>{buttonText}</button>
           );
         })}
-        <button type="button" className={css.nextButton} disabled={currentSlide === subinteractives.length - 1} aria-label="Next slide" onClick={nextSlide}>Next</button>
+        <button type="button" className={css.nextButton} aria-disabled={currentSlide === subinteractives.length - 1} aria-label="Next slide" onClick={nextSlide}>Next</button>
       </nav>
     </div>
   );


### PR DESCRIPTION
## Summary

Makes the Carousel interactive accessible. QI-146 started as a 1-point "expose the active slide with `aria-current`" story; an accesslint audit of the whole carousel surfaced several more gaps, so the scope was widened to "make the carousel accessible."

Jira: [QI-146](https://concord-consortium.atlassian.net/browse/QI-146)

## Findings addressed

| # | WCAG | Fix |
|---|------|-----|
| aria-current | 4.1.2 | Active slide nav button gets `aria-current="true"` (moves with the slide). |
| **H1** | 4.1.2 / 2.1.1 / 2.4.3 | Prev/Next convey their end-of-range state with `aria-disabled` and the handlers guard against under/overrunning. Previously the disabled look was a CSS class only, so **Prev on slide 0 drove `currentSlide` to `-1`** (out of range) and the visual state desynced. `aria-disabled` (rather than the native `disabled` attribute) is deliberate: it keeps the button focusable so a keyboard user isn't dropped to `<body>` when reaching a boundary (WCAG 2.4.3). SCSS keys the disabled visuals off `[aria-disabled="true"]`. |
| **H2** | 4.1.3 | Visually-hidden `aria-live="polite"` status region announces `Slide N of M: <type>` on each slide change. It stays silent on initial mount (the first slide is already visible) and announces again when navigating back to slide 1. |
| **H3** | 1.4.1 | The active default dot gets a non-color cue (white gap + orange ring and a size bump); the active vs inactive dots were only ~1.16:1 apart in grayscale. |
| **M1** | 2.4.7 | Nav buttons (which sit outside `.runtime` and inherited no focus style) get their own visible focus ring. |
| **M2 / L1** | 1.3.1 | Carousel exposed as a labeled `region` with `aria-roledescription="carousel"`; each slide is a labeled `group`; nav landmark labeled. |
| **M3** | 2.4.3 | Off-screen slides are marked `inert` so their iframes leave the tab order and the a11y tree; removed the now-redundant scroll workaround. In **report** mode `inert` is skipped so a reviewer can read every response. |
| **L2 / L3** | 4.1.2 / 2.5.8 | `type="button"` on nav buttons; default dot target bumped to 24px. |
| Authoring | 2.1.1 / 2.4.3 | The "Subquestion Authoring" collapsible header was a clickable `<h4>`; now a real `<button>` with `aria-expanded`, keyboard-operable. The collapsed panel was hidden only visually (`maxHeight: 0`), so its inputs and iframe stayed focusable — tabbing off the toggle dropped focus into the "hidden" panel, contradicting `aria-expanded`. The panel is now marked `inert` while collapsed (same approach as the off-screen slides), so it leaves the tab order and the a11y tree. |

## Testing

- **Jest:** 22 tests pass, covering the `aria-disabled` Prev/Next + the `currentSlide → -1` guard, the live-region behavior (silent on mount, announces on change and on navigating back), region/slide/nav roles, `inert` toggling, `type=button`, the authoring header toggle, and the collapsed authoring panel being `inert`.
- **Lint** clean; `npm run build` compiles the SCSS.
- **Real-browser (Playwright, Chromium):** drove the carousel through the `wrapper.html` + iframe-phone harness. All checks passed, including the ones that only exist in a real browser: keyboard **focus is retained on Next at the last-slide boundary** (not dropped to `<body>`), the live region is silent on load then announces on change/back, off-screen slides are `inert` (observed focus order never enters them), and the triangle targets measure 24×24. The active-dot cue and keyboard focus ring were screenshot-confirmed.

Existing Cypress `carousel.test.js` stays valid: it only clicks Prev/Next mid-carousel (never a boundary button), and the `data-cy="subquestion-authoring"` hook moved onto the new authoring button so `.click()` still works.

## Notes for review

- `inert` is toggled via a ref callback rather than a JSX prop because this repo is on React 17 (no typed `inert` prop).
- Removing the `handleScroll` hack is the one behavior change worth a careful look; it existed to advance the slide when a user tabbed into an off-screen slide, which `inert` now prevents outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[QI-146]: https://concord-consortium.atlassian.net/browse/QI-146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
