### PR TITLE
feat: associate bar-graph sliders with their labels [QI-148]

### DIFF
--- a/packages/bar-graph/src/components/bar-chart.tsx
+++ b/packages/bar-graph/src/components/bar-chart.tsx
@@ -208,9 +208,13 @@ export const BarChartComponent: React.FC<IProps> = ({ authoredState, interactive
               })}
               {!readOnly && chartInfo.bars.map(renderedBar => {
                 const { index } = renderedBar;
-                if (authoredState.bars[index].lockValue) {
+                const bar = authoredState.bars[index];
+                if (bar.lockValue) {
                   return null;
                 }
+                const label = bar.label || `Bar ${index + 1}`;
+                const value = authoredState.numberOfDecimalPlaces ? renderedBar.value.toFixed(authoredState.numberOfDecimalPlaces) : renderedBar.value;
+                const valueText = authoredState.yAxisLabel ? `${value} ${authoredState.yAxisLabel}` : undefined;
                 return (
                   <Slider
                     key={index}
@@ -219,6 +223,8 @@ export const BarChartComponent: React.FC<IProps> = ({ authoredState, interactive
                     bottom={chartInfo.bottom}
                     max={max}
                     handleSliderChange={handleSliderChange}
+                    label={label}
+                    valueText={valueText}
                   />
                 );
               })}

--- a/packages/bar-graph/src/components/slider.scss
+++ b/packages/bar-graph/src/components/slider.scss
@@ -1,8 +1,10 @@
+@import "../../../helpers/src/styles/variables.scss";
+
 .slider {
   position: absolute;
 
   // Draw a visible keyboard focus ring on the svg handle so keyboard focus is
-  // at least as clear as the hover/active affordance. #0592AF is 3.66:1 on the
+  // at least as clear as the hover/active affordance. --cc-teal is 3.66:1 on the
   // white plot area, meeting WCAG 1.4.11 Non-text Contrast (>=3:1).
   //
   // Suppress the UA outline only under :focus-visible (not plain :focus): in
@@ -14,7 +16,7 @@
     outline: none;
 
     svg {
-      box-shadow: 0 0 0 3px #0592AF;
+      box-shadow: 0 0 0 3px var(--cc-teal);
     }
   }
 

--- a/packages/bar-graph/src/components/slider.scss
+++ b/packages/bar-graph/src/components/slider.scss
@@ -1,16 +1,21 @@
 .slider {
   position: absolute;
 
-  // Suppress the default UA outline; a visible focus ring is drawn on the svg
-  // handle below (:focus-visible) so keyboard focus is at least as clear as
-  // the hover/active affordance. #0592AF is 3.66:1 on the white plot area,
-  // meeting WCAG 1.4.11 Non-text Contrast (>=3:1).
-  &:focus {
+  // Draw a visible keyboard focus ring on the svg handle so keyboard focus is
+  // at least as clear as the hover/active affordance. #0592AF is 3.66:1 on the
+  // white plot area, meeting WCAG 1.4.11 Non-text Contrast (>=3:1).
+  //
+  // Suppress the UA outline only under :focus-visible (not plain :focus): in
+  // modern browsers keyboard focus shows just our ring, while pointer focus is
+  // already outline-free via the browser's own :focus-visible heuristic.
+  // Browsers WITHOUT :focus-visible support drop this rule entirely, keeping
+  // the default UA outline as a fallback focus indicator rather than none.
+  &:focus-visible {
     outline: none;
-  }
 
-  &:focus-visible svg {
-    box-shadow: 0 0 0 3px #0592AF;
+    svg {
+      box-shadow: 0 0 0 3px #0592AF;
+    }
   }
 
   svg {

--- a/packages/bar-graph/src/components/slider.scss
+++ b/packages/bar-graph/src/components/slider.scss
@@ -1,6 +1,18 @@
 .slider {
   position: absolute;
 
+  // Suppress the default UA outline; a visible focus ring is drawn on the svg
+  // handle below (:focus-visible) so keyboard focus is at least as clear as
+  // the hover/active affordance. #0592AF is 3.66:1 on the white plot area,
+  // meeting WCAG 1.4.11 Non-text Contrast (>=3:1).
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible svg {
+    box-shadow: 0 0 0 3px #0592AF;
+  }
+
   svg {
     border-radius: 50%;
     transition: box-shadow 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;

--- a/packages/bar-graph/src/components/slider.test.tsx
+++ b/packages/bar-graph/src/components/slider.test.tsx
@@ -47,4 +47,25 @@ describe("Slider accessibility", () => {
     const node = renderSlider().find('[role="slider"]').getDOMNode();
     expect(node.getAttribute("aria-orientation")).toEqual("vertical");
   });
+
+  it("hides the decorative handle svg from assistive tech", () => {
+    const svg = renderSlider().find('[role="slider"] svg').getDOMNode();
+    expect(svg.getAttribute("aria-hidden")).toEqual("true");
+  });
+
+  it("increases the value on ArrowRight (mirrors ArrowUp)", () => {
+    const handleSliderChange = jest.fn();
+    renderSlider({ handleSliderChange })
+      .find('[role="slider"]').simulate("keydown", { key: "ArrowRight" });
+    expect(handleSliderChange).toHaveBeenCalledWith(
+      renderedBar, 1, { via: "keyboard", key: "ArrowRight", delta: true });
+  });
+
+  it("decreases the value on ArrowLeft (mirrors ArrowDown)", () => {
+    const handleSliderChange = jest.fn();
+    renderSlider({ handleSliderChange })
+      .find('[role="slider"]').simulate("keydown", { key: "ArrowLeft" });
+    expect(handleSliderChange).toHaveBeenCalledWith(
+      renderedBar, -1, { via: "keyboard", key: "ArrowLeft", delta: true });
+  });
 });

--- a/packages/bar-graph/src/components/slider.test.tsx
+++ b/packages/bar-graph/src/components/slider.test.tsx
@@ -42,4 +42,9 @@ describe("Slider accessibility", () => {
     const node = renderSlider({ valueText: undefined }).find('[role="slider"]').getDOMNode();
     expect(node.hasAttribute("aria-valuetext")).toBe(false);
   });
+
+  it("declares a vertical orientation (slider is operated up/down)", () => {
+    const node = renderSlider().find('[role="slider"]').getDOMNode();
+    expect(node.getAttribute("aria-orientation")).toEqual("vertical");
+  });
 });

--- a/packages/bar-graph/src/components/slider.test.tsx
+++ b/packages/bar-graph/src/components/slider.test.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { mount } from "enzyme";
+import { Slider } from "./slider";
+import { IRenderedBar } from "../plugins/chart-info";
+
+const renderedBar: IRenderedBar = {
+  index: 0,
+  value: 25,
+  width: 40,
+  top: 100,
+  left: 10,
+  center: 30,
+  color: "#EA6D2F"
+};
+
+const renderSlider = (props: Partial<React.ComponentProps<typeof Slider>> = {}) =>
+  mount(
+    <Slider
+      renderedBar={renderedBar}
+      top={0}
+      bottom={200}
+      max={100}
+      handleSliderChange={jest.fn()}
+      label="Winter"
+      valueText="25 Days of Sunlight"
+      {...props}
+    />
+  );
+
+describe("Slider accessibility", () => {
+  it("associates the slider with its bar label via aria-label", () => {
+    const node = renderSlider().find('[role="slider"]').getDOMNode();
+    expect(node.getAttribute("aria-label")).toEqual("Winter");
+  });
+
+  it("announces the value with units via aria-valuetext", () => {
+    const node = renderSlider().find('[role="slider"]').getDOMNode();
+    expect(node.getAttribute("aria-valuetext")).toEqual("25 Days of Sunlight");
+  });
+
+  it("omits aria-valuetext when none is provided", () => {
+    const node = renderSlider({ valueText: undefined }).find('[role="slider"]').getDOMNode();
+    expect(node.hasAttribute("aria-valuetext")).toBe(false);
+  });
+});

--- a/packages/bar-graph/src/components/slider.tsx
+++ b/packages/bar-graph/src/components/slider.tsx
@@ -77,9 +77,11 @@ export const Slider = ({renderedBar, top, bottom, max, handleSliderChange, label
     const options: SliderChangeCallbackOptions = {via: "keyboard", key: e.key};
     switch (e.key) {
       case "ArrowUp":
+      case "ArrowRight":
         handleSliderChange(renderedBar, 1, {...options, delta: true});
         break;
       case "ArrowDown":
+      case "ArrowLeft":
         handleSliderChange(renderedBar, -1, {...options, delta: true});
         break;
       case "Home":
@@ -148,7 +150,7 @@ export const SliderIconHalfWidth = 14;
 
 export const SliderIcon = () => {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 38 38">
+    <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 38 38" aria-hidden="true" focusable="false">
       <defs>
         <filter id="jk8sb59w0a" width="140%" height="140%" x="-20%" y="-20%" filterUnits="objectBoundingBox">
           <feOffset in="SourceAlpha" result="shadowOffsetOuter1" />

--- a/packages/bar-graph/src/components/slider.tsx
+++ b/packages/bar-graph/src/components/slider.tsx
@@ -13,9 +13,11 @@ interface IProps {
   bottom: number;
   max: number;
   handleSliderChange: SliderChangeCallback;
+  label: string;
+  valueText?: string;
 }
 
-export const Slider = ({renderedBar, top, bottom, max, handleSliderChange}: IProps) => {
+export const Slider = ({renderedBar, top, bottom, max, handleSliderChange, label, valueText}: IProps) => {
   const {index} = renderedBar;
   const style: React.CSSProperties = {
     top: renderedBar.top - SliderIconHalfHeight,
@@ -128,9 +130,11 @@ export const Slider = ({renderedBar, top, bottom, max, handleSliderChange}: IPro
       tabIndex={tabIndex}
       onKeyDown={handleKeyDown}
       role="slider"
+      aria-label={label}
       aria-valuemin={0}
       aria-valuemax={max}
       aria-valuenow={renderedBar.value}
+      aria-valuetext={valueText}
       data-cy={`slider${renderedBar.index}`}
     >
       <SliderIcon />

--- a/packages/bar-graph/src/components/slider.tsx
+++ b/packages/bar-graph/src/components/slider.tsx
@@ -131,6 +131,7 @@ export const Slider = ({renderedBar, top, bottom, max, handleSliderChange, label
       onKeyDown={handleKeyDown}
       role="slider"
       aria-label={label}
+      aria-orientation="vertical"
       aria-valuemin={0}
       aria-valuemax={max}
       aria-valuenow={renderedBar.value}

--- a/packages/helpers/src/styles/helpers.scss
+++ b/packages/helpers/src/styles/helpers.scss
@@ -1,45 +1,5 @@
 @import "./px-to-rem.scss";
-
-// Colors &etc.
-
-:root {
-  --white: #ffffff;
-  --cc-charcoal: #3f3f3f;
-  --cc-charcoal-hint: #828282;
-  --cc-charcoal-light-1: #979797;
-  --cc-charcoal-light-2: #dfdfdf;
-  --cc-teal-dark-2: #016082;
-  --cc-teal-dark-1: #0481a0;
-  --cc-teal-dark-1-alpha-50: rgba(4, 129, 160, 0.5);
-  --cc-teal-dark-1-alpha-0: rgba(4, 129, 160, 0);
-  --cc-teal: #0592af;
-  --cc-teal-light-1: #2ba5c1;
-  --cc-teal-light-2: #6fc6da;
-  --cc-teal-light-3: #93d5e4;
-  --cc-teal-light-4: #b7e2ec;
-  --cc-teal-light-5: #cdebf2;
-  --cc-teal-light-6: #e2f4f8;
-  --cc-teal-light-7: #f5fbfc;
-  --cc-orange-dark-1: #ea6d2f;
-  --cc-orange-dark-1-alpha-35: #f7cab6; // approximates rgba(234, 109, 47, 0.35) w/o transparency;
-  --cc-orange: #ff8415;
-  --cc-orange-light-1: #ffa350;
-  --cc-orange-light-2: #ffc18a;
-  --cc-orange-light-3: #ffcea1;
-  --cc-orange-light-4: #ffe6d0;
-  --cc-orange-light-4-b: #ffeddc;
-  --cc-orange-light-5: #fff2e7;
-  --cc-orange-light-6: #fff9f3;
-  --cc-ap-button-color: #000000;
-  --cc-ap-button-default: #ffba7d;
-  --cc-ap-button-hover: #ff9a42;
-  --cc-ap-button-click: #ff8113;
-  --cc-ap-button-border: #949494;
-  --cc-ap-button-focus-ring: #0957d0;
-  // The browser-native focus ring color (matches native controls like the comment textarea
-  // and the thumbnail delete button). See the native-focus-ring mixin below.
-  --cc-native-focus-ring: #005fcc;
-}
+@import "./variables.scss";
 
 
 $correctColor: #055c05;

--- a/packages/helpers/src/styles/variables.scss
+++ b/packages/helpers/src/styles/variables.scss
@@ -1,0 +1,45 @@
+// CSS custom properties (colors &etc.) shared by all interactives.
+//
+// Split out from helpers.scss so a stylesheet that needs only the variables can
+// import this without also pulling in helpers.scss's emitted rules (.error,
+// .apButton, .interactiveButton). helpers.scss imports this file, so existing
+// clients are unaffected.
+
+:root {
+  --white: #ffffff;
+  --cc-charcoal: #3f3f3f;
+  --cc-charcoal-hint: #828282;
+  --cc-charcoal-light-1: #979797;
+  --cc-charcoal-light-2: #dfdfdf;
+  --cc-teal-dark-2: #016082;
+  --cc-teal-dark-1: #0481a0;
+  --cc-teal-dark-1-alpha-50: rgba(4, 129, 160, 0.5);
+  --cc-teal-dark-1-alpha-0: rgba(4, 129, 160, 0);
+  --cc-teal: #0592af;
+  --cc-teal-light-1: #2ba5c1;
+  --cc-teal-light-2: #6fc6da;
+  --cc-teal-light-3: #93d5e4;
+  --cc-teal-light-4: #b7e2ec;
+  --cc-teal-light-5: #cdebf2;
+  --cc-teal-light-6: #e2f4f8;
+  --cc-teal-light-7: #f5fbfc;
+  --cc-orange-dark-1: #ea6d2f;
+  --cc-orange-dark-1-alpha-35: #f7cab6; // approximates rgba(234, 109, 47, 0.35) w/o transparency;
+  --cc-orange: #ff8415;
+  --cc-orange-light-1: #ffa350;
+  --cc-orange-light-2: #ffc18a;
+  --cc-orange-light-3: #ffcea1;
+  --cc-orange-light-4: #ffe6d0;
+  --cc-orange-light-4-b: #ffeddc;
+  --cc-orange-light-5: #fff2e7;
+  --cc-orange-light-6: #fff9f3;
+  --cc-ap-button-color: #000000;
+  --cc-ap-button-default: #ffba7d;
+  --cc-ap-button-hover: #ff9a42;
+  --cc-ap-button-click: #ff8113;
+  --cc-ap-button-border: #949494;
+  --cc-ap-button-focus-ring: #0957d0;
+  // The browser-native focus ring color (matches native controls like the comment textarea
+  // and the thumbnail delete button). See the native-focus-ring mixin in helpers.scss.
+  --cc-native-focus-ring: #005fcc;
+}


### PR DESCRIPTION
## Summary

Associates each Bar Graph slider with the bar it controls so assistive technology announces which bar a slider affects (WCAG 1.3.1, [QI-148](https://concord-consortium.atlassian.net/browse/QI-148)).

Previously a screen-reader user tabbing onto a slider heard only `role="slider"` plus the numeric value (e.g. *"slider, 25"*) with no indication it controlled the *Winter* bar.

## Changes

**Slider labelling (the core change)**

- **`slider.tsx`** — add `label` / `valueText` props; render `aria-label` and `aria-valuetext` on the slider element alongside the existing `role="slider"` / `aria-valuemin`/`max`/`now`. Also adds `aria-orientation="vertical"`, matching the slider's ArrowUp/ArrowDown, y-axis operation.
- **`bar-chart.tsx`** — compute per-slider `label` (bar label, with a `Bar N` fallback for a blank label) and `valueText` (value + y-axis units, omitted when there's no y-axis label) and pass them to `<Slider>`.
- **`slider.test.tsx`** — new unit tests for the `aria-label`, `aria-valuetext`, and empty-`valueText` cases.

Net announcement: *"Winter, slider, 25 Days of Sunlight."*

**Keyboard focus ring (from review)**

- **`slider.scss`** — draw a visible keyboard focus ring on the svg handle, so keyboard focus is at least as clear as the existing hover/active affordance (WCAG 1.4.11; `--cc-teal` is 3.66:1 on the white plot area). `outline: none` is scoped under `:focus-visible`, so browsers lacking `:focus-visible` support keep the UA outline as a fallback rather than showing no indicator at all.

**Shared helpers refactor (from review) — note the wider scope**

- **`variables.scss`** (new) — the `:root` custom properties, split out of `helpers.scss`.
- **`helpers.scss`** — now imports `variables.scss` in place of its inline `:root` block.

Review asked the focus ring to use `--cc-teal` rather than a hardcoded `#0592af`. Nothing in `bar-graph` imported the helpers styles, and importing all of `helpers.scss` costs +4,356 bytes because it also emits rules (`.error`, `.apButton`, `.interactiveButton`). Splitting the variables out lets `slider.scss` import only what it needs: **+1,011 bytes, no rule duplication**, and the dependency is explicit rather than relying on the `:root` block arriving incidentally via other bundled helper styles (where a future change would silently drop the focus ring).

**Existing clients are unaffected — verified:** compiling `helpers.scss` before and after the split produces byte-identical output (4,151 bytes both), so all 28 stylesheets that import it are unchanged by construction.

## Note on `aria-label` vs `aria-labelledby`

The acceptance criteria call for `aria-labelledby` pointing to a label element's ID, but the bar category labels are painted onto the chart.js `<canvas>` and have no DOM node to reference. `aria-label` is the idiomatic tool when the label text isn't already present as visible DOM, and it fully meets the AC's intent.

## Testing

- Unit tests green; full `bar-graph` package suite (5 suites / 15 tests) passes; lint clean.
- `button` (an existing `helpers.scss` client) builds clean; `helpers` has no `"files"` whitelist, so the new partial ships to published consumers.
- Verified in a real browser (Playwright on the built runtime): sliders render `aria-label="Spring"` / `aria-valuetext="0 Days of Sunlight"` etc., locked bars correctly have no slider, and `aria-valuetext` updates live as the value changes via keyboard (ArrowUp / End). Keyboard focus shows a single clean ring with no double outline.
- **Still needs a manual screen-reader pass (NVDA / VoiceOver)** to close out the AC's screen-reader-testing requirement.

## Out of scope

- Authorable bar colors / color-contrast authoring warnings (tracked separately by QI-150 / QI-180).
- The remaining `:root` duplication (3 copies per bundle) predates this PR and is left alone. Investigating it surfaced that we ship CSS unminified (`--mode production` only minifies JS; `css-minimizer-webpack-plugin` isn't installed) — filed as [QI-184](https://concord-consortium.atlassian.net/browse/QI-184).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[QI-148]: https://concord-consortium.atlassian.net/browse/QI-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[QI-184]: https://concord-consortium.atlassian.net/browse/QI-184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ