### PR TITLE
Switch S3 deployment to OIDC authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,10 @@ jobs:
       - build_test
       - cypress
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -86,6 +90,10 @@ jobs:
           # Skip installing Cypress since it isn't needed for just building
           # This decreases the deploy time quite a bit
           CYPRESS_INSTALL_BINARY: 0
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::612297603577:role/question-interactives
+          aws-region: us-east-1
       - name: Deploy files to Amazon S3
         uses: concord-consortium/s3-deploy-action@v1
         with:
@@ -95,8 +103,6 @@ jobs:
           build: npm run build -- --concurrency 3
           bucket: models-resources
           prefix: ${{ github.event.repository.name }} # 'question-interactives'
-          awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          awsSecretAccessKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           deployRunUrl: https://models-resources.concord.org/question-interactives/__deployPath__/
           # Add the default branch as a top branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Perform Release
+run-name: Release ${{ github.event.inputs.version }}
 
 on:
   workflow_dispatch:
@@ -20,14 +21,13 @@ env:
   PREFIX: ${{ github.event.repository.name }}
   SRC_FILE: index-top.html
   DEST_FILE: ${{ github.event.inputs.release-type }}
-  AWS_DEFAULT_REGION: us-east-1
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
 jobs:
   release:
     name: Copy [interactive]/index-top.html
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     strategy:
       matrix:
         include:
@@ -55,6 +55,10 @@ jobs:
           - INTERACTIVE_FOLDER: video-player
           - INTERACTIVE_FOLDER: wrapper
     steps:
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::612297603577:role/question-interactives
+          aws-region: us-east-1
       - name: Set S3 Paths
         run: |
           echo "S3_VERSIONED_INTERACTIVE_PATH=s3://${{ env.BUCKET }}/${{ env.PREFIX }}/version/${{ github.event.inputs.version }}/${{ matrix.INTERACTIVE_FOLDER }}" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Use the following steps to add a new interactive:
 
 ## Deployment
 
+S3 deployment uses OIDC for AWS authentication — see [deploy-setup.md in starter-projects](https://github.com/concord-consortium/starter-projects/blob/main/doc/deploy-setup.md) for how the AWS side is set up, and [doc/deploy.md](doc/deploy.md) for how deploys work in this repo.
+
 Production releases to S3 are based on the contents of the `/dist` folder and are built automatically by GitHub Actions
 for each branch pushed to GitHub and each merge into production.
 

--- a/doc/deploy.md
+++ b/doc/deploy.md
@@ -1,0 +1,19 @@
+# Deployment
+
+S3 deployment is handled by GitHub Actions. Pushes are deployed under
+`models-resources/question-interactives/` (e.g. `branch/<name>/...`) by the `s3-deploy` job in
+[`ci.yml`](../.github/workflows/ci.yml). Releases are promoted by
+[`release.yml`](../.github/workflows/release.yml) (via `workflow_dispatch`) by copying each interactive’s
+`version/<version>/<interactive>/index-top.html` to `<interactive>/index.html` (or `index-staging.html`).
+
+## AWS Access
+
+The GitHub Actions workflows in this project are allowed to update files in S3 using OIDC. An
+IAM role has been created in AWS with a trust policy that allows GitHub Actions in
+this specific repository to assume this IAM role. The IAM role has a `RepoName` tag
+and a managed policy that uses this tag to give the role permission to update files in
+`models-resources/[RepoName]`.
+
+See
+[deploy-setup.md in starter-projects](https://github.com/concord-consortium/starter-projects/blob/main/doc/deploy-setup.md)
+for how the AWS side is set up.


### PR DESCRIPTION
[DEV-163](https://concord-consortium.atlassian.net/browse/DEV-163)

Replace static AWS access-key secrets with OIDC role assumption in the S3 deploy workflows, per DEV-163. `ci.yml` s3-deploy plus the matrix `release.yml` (workflow-level AWS env replaced with a per-job credentials step, run-name added); `doc/deploy.md` + `README` reference added.

[DEV-163]: https://concord-consortium.atlassian.net/browse/DEV-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ